### PR TITLE
Enable Sisu index for Nexus core (plugins still use full scanning)

### DIFF
--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
@@ -87,7 +87,7 @@ public class PlexusContainerContextListener
                 ContainerConfiguration plexusConfiguration =
                     new DefaultContainerConfiguration().setName( context.getServletContextName() ).setContainerConfigurationURL(
                         plexusXmlFile.toURI().toURL() ).setContext( (Map) plexusContext ).setAutoWiring( true ).setClassPathScanning(
-                        PlexusConstants.SCANNING_ON ).setComponentVisibility( PlexusConstants.GLOBAL_VISIBILITY );
+                        PlexusConstants.SCANNING_INDEX ).setComponentVisibility( PlexusConstants.GLOBAL_VISIBILITY );
 
                 final Module[] customModules = (Module[]) context.getAttribute( CUSTOM_MODULES );
 

--- a/nexus/nexus-webapp/pom.xml
+++ b/nexus/nexus-webapp/pom.xml
@@ -396,6 +396,20 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <id>index-war</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <version>2.1-alpha-2</version>
         <configuration>


### PR DESCRIPTION
This patch adds an aggregate index to the Nexus WAR that lists all @ Named (JSR330) components found under WEB-INF/classes and WEB-INF/lib. It then configures the container to use this index when discovering components in Nexus core instead of doing a full scan of every JAR (PlexusConstants.SCANNING_INDEX).

Full scanning is still enabled for Nexus plugins, because it's needed for @ Extension / @ Managed support as well as discovery of custom repository types that don't use @ Named. Most plugins only contain a few JARs, so doing a full scan is less of an issue.

Note that Plexus components will still be found via META-INF/plexus/components.xml - this just enables a similar index for @ Named components. The reason for an aggregate index is because some dependencies might contain JSR330 components, but not contain a generated index - this can happen if they're built with JDK5, or when sisu-inject-bean is not a compile scope dependency [1].

Since the index replaces full scanning, it is important to remember that components in libraries added to the Nexus WAR after its been built won't be picked up unless their library also contains a sisu index (or plexus components.xml). See for example https://github.com/sonatype/nexus-enterprise/pull/3 which would need merging in if/when indexing was enabled in the core.

[1] sisu-inject-bean contains a simple annotation processor for javac/apt that incrementally builds an index under META-INF/sisu/javax.inject.Named when you compile using JDK6+. In this patch we use another tool called the sisu-maven-plugin http://sonatype.github.com/sisu-maven-plugin/index.html to build the aggregate index, but you can also use it to create index files for individual projects (just like with the plexus-component-metadata plugin).
