### PR TITLE
NEXUS-4574 - Give Nexus179* test time to run async events

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus179/Nexus179RemoteRepoDownIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus179/Nexus179RemoteRepoDownIT.java
@@ -100,6 +100,9 @@ public class Nexus179RemoteRepoDownIT
         // unblock the proxy
         this.setBlockProxy( this.getBaseNexusUrl(), REPO_RELEASE_PROXY_REPO1, false );
 
+        // run async events
+        getEventInspectorsUtil().waitForCalmPeriod();
+
         File artifact = this.downloadArtifact( gav, "target/downloads" );
 
         Assert.assertTrue( FileTestingUtils.compareFileSHA1s( artifact, localFile ) );


### PR DESCRIPTION
I ran it here several times and was not able cause problem here.

CI is also running fine for 20 times now (other failures but not this one)

Debugging I noticed async events fire, so I gave time to run.
