### PR TITLE
Nexus-HA: add support for semaphore-based resource locks

### DIFF
--- a/nexus/nexus-api/pom.xml
+++ b/nexus/nexus-api/pom.xml
@@ -76,6 +76,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-locks</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>rome</groupId>
       <artifactId>rome</artifactId>
     </dependency>

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SisuLockResource.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SisuLockResource.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.item;
+
+import org.sonatype.sisu.locks.ResourceLock;
+
+/**
+ * Drop-in replacement for {@link SimpleLockResource} that uses Sisu's semaphore-based {@link ResourceLock}.
+ */
+final class SisuLockResource
+    implements LockResource
+{
+    private final ResourceLock lock;
+
+    // ==
+
+    SisuLockResource( final ResourceLock lock )
+    {
+        this.lock = lock;
+    }
+
+    @Override
+    public void lockShared()
+    {
+        lock.lockShared( Thread.currentThread() );
+    }
+
+    @Override
+    public void lockExclusively()
+    {
+        lock.lockExclusive( Thread.currentThread() );
+    }
+
+    @Override
+    public void unlock()
+    {
+        /*
+         * Maintains any exclusive access until the last unlock, as Nexus expects
+         */
+        final Thread self = Thread.currentThread();
+        if ( lock.getSharedCount( self ) > 0 )
+        {
+            lock.unlockShared( self );
+        }
+        else if ( lock.getExclusiveCount( self ) > 0 )
+        {
+            lock.unlockExclusive( self );
+        }
+        else
+        {
+            throw new IllegalStateException( self + " does not own this lock" );
+        }
+    }
+
+    @Override
+    public boolean hasLocksHeld()
+    {
+        final Thread self = Thread.currentThread();
+        for ( final Thread t : lock.getOwners() )
+        {
+            if ( self == t )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        int sharedCount = 0, exclusiveCount = 0;
+        for ( final Thread t : lock.getOwners() )
+        {
+            sharedCount += lock.getSharedCount( t );
+            exclusiveCount += lock.getExclusiveCount( t );
+        }
+        return "[Write locks = " + exclusiveCount + ", Read locks = " + sharedCount + "]";
+    }
+}

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -505,6 +505,13 @@
         <version>1.0-SNAPSHOT</version>
       </dependency>
 
+      <!-- locks -->
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-locks</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+      </dependency>
+
       <!-- shiro -->
       <dependency>
         <groupId>org.sonatype.security</groupId>


### PR DESCRIPTION
This patch adds the ability to switch Nexus resource locking from the current reader-writer lock approach to a semaphore-based approach. Semaphores have some advantages over reader-writer locks in that they can be easily distributed. One thread can also lock/unlock the resource on behalf of another thread, which can help when recovering from deadlocks. The key disadvantage of semaphores is the extra book-keeping required to provide ownership semantics on top of what is essentially an ownerless primitive.

The current configuration leaves the existing lock approach in place. To enable local semaphore resource locking add "sisu-resource-locks = local" to conf/nexus.properties. To enable distributed hazelcast resource locking copy http://search.maven.org/#artifactdetails%7Ccom.hazelcast%7Chazelcast%7C1.9.4.4%7Cjar to nexus/WEB-INF/lib and add "sisu-resource-locks = hazelcast" to conf/nexus.properties

See https://github.com/sonatype/sisu-locks for the local and distributed (hazelcast) lock implementations as well as their associated stress-tests. JMX controls are provided to monitor and manage resource locks; start "jconsole" and attach it to the Nexus process. The controls can be found under the "org.sonatype.sisu" entry.
