### PR TITLE
NXCM-3463 - wait for all async events and tasks to finish before trying t

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
@@ -1080,6 +1080,15 @@ public abstract class AbstractNexusIntegrationTest
     public File downloadFile( URL url, String targetFile )
         throws IOException
     {
+        try
+        {
+            TaskScheduleUtil.waitForAllTasksToStop();
+            getEventInspectorsUtil().waitForCalmPeriod();
+        }
+        catch ( Exception e )
+        {
+            throw new IOException( e );
+        }
 
         return RequestFacade.downloadFile( url, targetFile );
     }


### PR DESCRIPTION
Both NXCM-3463 and NXCM-3462 seem to be related to file downloading.

I think we should wait all events to run before we try to download anything.  Anyone disagrees?
