### PR TITLE
Nxcm 3230 test log levels

### DIFF
--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/resources/logback.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/resources/logback.xml
@@ -6,7 +6,7 @@
       <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
+  <root level="${test.log.level:-INFO}">
     <appender-ref ref="console" />
   </root>
 </configuration>

--- a/nexus/nexus-launcher/src/test/resources/logback-test.xml
+++ b/nexus/nexus-launcher/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
   <logger name="com.sonatype.overlord" level="TRACE"/>
   <logger name="org.apache.commons.httpclient.HttpMethodDirector" level="ERROR"/>
 
-  <root level="INFO">
+  <root level="${test.log.level:-INFO}">
     <appender-ref ref="CONSOLE"/>
   </root>
 

--- a/nexus/nexus-test/nexus-test-common/src/main/resources/logback.xml
+++ b/nexus/nexus-test/nexus-test-common/src/main/resources/logback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2008-2011 Sonatype, Inc.
@@ -25,7 +25,7 @@
 			<Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
 		</encoder>
 	</appender>
-	<root level="${test.loglevel:-info}">
+	<root level="${test.log.level:-INFO}">
 		<appender-ref ref="STDOUT"/>
 	</root>
 </configuration>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -149,6 +149,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <nexus.version>${project.version}</nexus.version>
 
+    <!-- logging configuration used in logback config files to control test logging -->
+    <test.log.level>INFO</test.log.level>
+    <it.test.log.level>INFO</it.test.log.level>
+    <it.nexus.log.level>INFO</it.nexus.log.level>
+
     <!-- version properties -->
     <aether.version>1.8.1</aether.version>
     <applifecycle.version>1.4</applifecycle.version>
@@ -1501,8 +1506,11 @@
               <jub.customkey>${os.name}</jub.customkey>
               <jub.charts.dir>${project.build.directory}/junit-benchmarks</jub.charts.dir>
               <!-- end junit benchmarks config -->
+              <!-- logging configuration properties, see logback*.xml files -->
+              <test.log.level>${test.log.level}</test.log.level>
+              <it.test.log.level>${it.test.log.level}</it.test.log.level>
+              <it.nexus.log.level>${it.nexus.log.level}</it.nexus.log.level>
             </systemPropertyVariables>
-
           </configuration>
         </plugin>
         <plugin>
@@ -1536,6 +1544,12 @@
                 <value>org.sonatype.nexus.integrationtests.report.ProgressListener</value>
               </property>
             </properties>
+            <systemPropertyVariables>
+              <!-- logging configuration properties, see logback*.xml files -->
+              <test.log.level>${test.log.level}</test.log.level>
+              <it.test.log.level>${it.test.log.level}</it.test.log.level>
+              <it.nexus.log.level>${it.nexus.log.level}</it.nexus.log.level>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
       </plugins>
@@ -1975,7 +1989,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.8.1</version>
             <configuration>
               <classesDirectory>${project.build.directory}/generated-classes/emma/classes</classesDirectory>
               <systemPropertyVariables>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -1614,6 +1614,23 @@
   </modules>
 
   <profiles>
+      
+    <profile>
+      <id>debug</id>
+      <activation>
+        <property>
+            <name>debug</name>
+            <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- configure test logging properties to debug levels -->
+        <test.log.level>DEBUG</test.log.level>
+        <it.test.log.level>DEBUG</it.test.log.level>
+        <it.nexus.log.level>DEBUG</it.nexus.log.level>
+      </properties>
+    </profile>
+
     <profile>
       <id>skipBenchmarks</id>
       <build>


### PR DESCRIPTION
Modules which use nexus-test-common artifact in test scope will now expose logging level of the ITs, UTs and nexus under test to a system property evaluated via logback.

```
mvn clean test -Dit.test=MyNoisyTest -Pdebug
```

or

```
mvn clean verify -Dit.test=MyNoisyIT -Dit.test.log.level=WARN -Dit.nexus.log.level=WARN -Dit=true
```

for example
