### PR TITLE
NEXUS-4588: proper cleanup of "cancel" signal, since it affects all Walke

### DIFF
--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
@@ -45,22 +45,24 @@ public class Nexus4588CancellationTest
     public void setUpProgressListener()
         throws Exception
     {
-        Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );
-
-        setCurrentMethod.setAccessible( true );
-
-        setCurrentMethod.invoke( null, new CancellableProgressListenerWrapper( null ) );
+        new TaskUtil()
+        {
+            {
+                setCurrent( new CancellableProgressListenerWrapper( null ) );
+            }
+        };
     }
 
     @After
     public void removeProgressListener()
         throws Exception
     {
-        Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );
-
-        setCurrentMethod.setAccessible( true );
-
-        setCurrentMethod.invoke( null, (ProgressListener) null );
+        new TaskUtil()
+        {
+            {
+                setCurrent( null );
+            }
+        };
     }
 
     @Test( expected = TaskInterruptedException.class )

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
@@ -20,11 +20,11 @@ package org.sonatype.nexus.maven.tasks;
 
 import java.lang.reflect.Method;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.sonatype.nexus.AbstractMavenRepoContentTests;
 import org.sonatype.nexus.proxy.events.EventInspector;
-import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
-import org.sonatype.plexus.appevents.Event;
 import org.sonatype.scheduling.CancellableProgressListenerWrapper;
 import org.sonatype.scheduling.ProgressListener;
 import org.sonatype.scheduling.TaskInterruptedException;
@@ -41,13 +41,33 @@ public class Nexus4588CancellationTest
     extends AbstractMavenRepoContentTests
 {
 
+    @Before
+    public void setUpProgressListener()
+        throws Exception
+    {
+        Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );
+
+        setCurrentMethod.setAccessible( true );
+
+        setCurrentMethod.invoke( null, new CancellableProgressListenerWrapper( null ) );
+    }
+
+    @After
+    public void removeUpProgressListener()
+        throws Exception
+    {
+        Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );
+
+        setCurrentMethod.setAccessible( true );
+
+        setCurrentMethod.invoke( null, (ProgressListener) null );
+    }
+
     @Test( expected = TaskInterruptedException.class )
     public void testNexus4588()
         throws Exception
     {
         fillInRepo();
-
-        setUpProgressListener();
 
         SnapshotRemovalRequest snapshotRemovalRequest =
             new SnapshotRemovalRequest( snapshots.getId(), 1, 10, true );
@@ -63,8 +83,6 @@ public class Nexus4588CancellationTest
     {
         fillInRepo();
 
-        setUpProgressListener();
-
         SnapshotRemovalRequest snapshotRemovalRequest =
             new SnapshotRemovalRequest( snapshots.getId(), 1, 10, true );
 
@@ -77,13 +95,4 @@ public class Nexus4588CancellationTest
         SnapshotRemovalResult result = defaultNexus.removeSnapshots( snapshotRemovalRequest );
     }
 
-    public static void setUpProgressListener()
-        throws Exception
-    {
-        Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );
-
-        setCurrentMethod.setAccessible( true );
-
-        setCurrentMethod.invoke( null, new CancellableProgressListenerWrapper( null ) );
-    }
 }

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.java
@@ -53,7 +53,7 @@ public class Nexus4588CancellationTest
     }
 
     @After
-    public void removeUpProgressListener()
+    public void removeProgressListener()
         throws Exception
     {
         Method setCurrentMethod = TaskUtil.class.getDeclaredMethod( "setCurrent", ProgressListener.class );


### PR DESCRIPTION
NEXUS-4588: proper cleanup of "cancel" signal, since it affects all Walker using tests within classloader boundaries

This pullreq fixed the mistake made in #8 that, while does correct tests, it breaks all other Walker dependent tests.
