### PR TITLE
Do not run long running tests as part of default pre push profile

### DIFF
--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUidLRTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUidLRTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.repository.Repository;
 
-public class DefaultRepositoryItemUidTest
+// This is an IT just because it runs longer then 15 seconds
+public class DefaultRepositoryItemUidLRTest
 {
     private DummyRepositoryItemUidFactory factory;
 

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SimpleLockResourceLRTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SimpleLockResourceLRTest.java
@@ -22,7 +22,7 @@ import java.util.Random;
 
 import org.junit.Test;
 
-public class SimpleLockResourceTest
+public class SimpleLockResourceLRTest
 {
     private static Random rnd = new Random( System.currentTimeMillis() );
 

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/error/reporting/DefaultErrorReportingManagerLRTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/error/reporting/DefaultErrorReportingManagerLRTest.java
@@ -44,7 +44,8 @@ import org.sonatype.nexus.scheduling.NexusTask;
 import org.sonatype.nexus.util.StringDigester;
 import org.sonatype.scheduling.SchedulerTask;
 
-public class DefaultErrorReportingManagerTest
+// This is an IT just because it runs longer then 15 seconds
+public class DefaultErrorReportingManagerLRTest
     extends AbstractNexusTestCase
 {
     private DefaultErrorReportingManager manager;

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemoverLRTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemoverLRTest.java
@@ -40,7 +40,8 @@ import java.util.Map;
 /**
  * @author juven
  */
-public class DefaultSnapshotRemoverTest
+// This is an IT just because it runs longer then 15 seconds
+public class DefaultSnapshotRemoverLRTest
     extends AbstractMavenRepoContentTests
 {
     protected void validateResults( MavenRepository repository, Map<String, Boolean> results )

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/ReindexLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/ReindexLRTest.java
@@ -42,7 +42,8 @@ import org.sonatype.nexus.index.DefaultIndexerManager;
 import org.sonatype.nexus.index.IndexerManager;
 import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
 
-public class ReindexTest
+// This is an IT just because it runs longer then 15 seconds
+public class ReindexLRTest
     extends AbstractMavenRepoContentTests
 {
     public static final long A_DAY_MILLIS = 24 * 60 * 60 * 1000;

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DefaultIndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DefaultIndexerManagerLRTest.java
@@ -28,7 +28,8 @@ import org.sonatype.nexus.Nexus;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.templates.repository.maven.Maven2ProxyRepositoryTemplate;
 
-public class DefaultIndexerManagerTest
+// This is an IT just because it runs longer then 15 seconds
+public class DefaultIndexerManagerLRTest
     extends AbstractIndexerManagerTest
 {
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DisableIndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DisableIndexerManagerLRTest.java
@@ -20,8 +20,8 @@ package org.sonatype.nexus.index;
 
 import org.junit.Test;
 
-
-public class DisableIndexerManagerTest
+// This is an IT just because it runs longer then 15 seconds
+public class DisableIndexerManagerLRTest
     extends AbstractIndexerManagerTest
 {
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
@@ -45,7 +45,8 @@ import org.mortbay.jetty.handler.HandlerList;
 import org.mortbay.jetty.handler.ResourceHandler;
 import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
 
-public class DownloadRemoteIndexerManagerTest
+// This is an IT just because it runs longer then 15 seconds
+public class DownloadRemoteIndexerManagerLRTest
     extends AbstractIndexerManagerTest
 {
     private Server server;

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus3578IndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus3578IndexerManagerLRTest.java
@@ -39,7 +39,8 @@ import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.storage.local.fs.FileContentLocator;
 
-public class Nexus3578IndexerManagerTest
+// This is an IT just because it runs longer then 15 seconds
+public class Nexus3578IndexerManagerLRTest
     extends AbstractIndexerManagerTest
 {
     protected static File pomFile =

--- a/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/src/test/java/org/sonatype/nexus/plugins/mavenbridge/ResolvingLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/src/test/java/org/sonatype/nexus/plugins/mavenbridge/ResolvingLRTest.java
@@ -34,7 +34,8 @@ import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
 import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 
-public class ResolvingTest
+// This is an IT just because it runs longer then 15 seconds
+public class ResolvingLRTest
     extends AbstractMavenRepoContentTests
 {
     protected NexusAether nexusAether;

--- a/nexus/nexus-mock/src/test/java/org/sonatype/nexus/mock/SimpleLRTest.java
+++ b/nexus/nexus-mock/src/test/java/org/sonatype/nexus/mock/SimpleLRTest.java
@@ -46,7 +46,8 @@ import com.thoughtworks.xstream.XStream;
  * @author cstamas
  *
  */
-public class SimpleTest
+// This is an IT just because it runs longer then 15 seconds
+public class SimpleLRTest
 {
     protected MockNexusEnvironment mockNexusEnvironment;
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/maven2/NexusMetadataMergeLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/maven2/NexusMetadataMergeLRTest.java
@@ -38,7 +38,8 @@ import org.sonatype.nexus.proxy.maven.metadata.operations.MetadataOperand;
 import org.sonatype.nexus.proxy.maven.metadata.operations.MetadataOperation;
 import org.sonatype.nexus.proxy.maven.metadata.operations.NexusMergeOperation;
 
-public class NexusMetadataMergeTest
+// This is an IT just because it runs longer then 15 seconds
+public class NexusMetadataMergeLRTest
 {
     private static final boolean DUMP = false;
 

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/component/ComponentPlexusResourceLRTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/component/ComponentPlexusResourceLRTest.java
@@ -30,7 +30,8 @@ import org.sonatype.nexus.rest.model.PlexusComponentListResource;
 import org.sonatype.nexus.rest.model.PlexusComponentListResourceResponse;
 import org.sonatype.plexus.rest.resource.PlexusResource;
 
-public class ComponentPlexusResourceTest
+// This is an IT just because it runs longer then 15 seconds
+public class ComponentPlexusResourceLRTest
     extends AbstractNexusTestCase
 {
     private AbstractComponentListPlexusResource getComponentPlexusResource()

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -1769,6 +1769,21 @@
         <enunciate.skip>true</enunciate.skip> -->
         <test-env.skip>true</test-env.skip>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <excludes>
+                  <exclude>**/*LRTest.java</exclude>
+                </excludes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+
     </profile>
 
     <!-- dummy profile for activating integration tests -->


### PR DESCRIPTION
Renamed all tests (its) that are running for longer then 15 seconds(ish) to LRTest (as in Long Running Test) and excluded them from default profile (prepush).
The tests are still run on another profiles as in "it" profile.

On my machine 2.3 i7/quad it reduced the default build from 16 minutes to about 7.

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
