### PR TITLE
[NEXUS-4361] Set UTF-8 as default character set for post/ajax requests

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/Sonatype.config.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/Sonatype.config.js
@@ -27,7 +27,7 @@
 
   // Set default HTTP headers //@todo: move this to some other common init
   // section
-  Ext.lib.Ajax.defaultPostHeader = 'application/json';
+  Ext.lib.Ajax.defaultPostHeader = 'application/json; charset=utf-8';
 
   // set Sonatype defaults for Ext widgets
   Ext.form.Field.prototype.msgTarget = 'under';

--- a/nexus/nexus-webapp/src/main/webapp/js/extensions/ext-override.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/extensions/ext-override.js
@@ -195,6 +195,20 @@ Ext.override(Ext.data.Connection, {
             }
           }
 
+          if(o.xmlData)
+          {
+              if (!hs || !hs['Content-Type']){
+                  hs['Content-Type'] = 'text/xml; charset=utf-8';
+              }
+          }
+          else if(o.jsonData)
+          {
+              if (!hs || !hs['Content-Type']){
+                  hs['Content-Type'] = 'application/json; charset=utf-8';
+              }
+          }
+
+
           if (Sonatype.utils.authToken)
           {
             // Add auth header to each request


### PR DESCRIPTION
[NEXUS-4361] Set UTF-8 as default character set for post/ajax requests to server

Looks like from the 3 browsers I tested with (Safari,Chrome,FF) only FF will automatically add UTF-8 as character set. To make the UTF-8 encoding work also in the other browsers, the fix will set the charset on Content-Type request header to UTF-8.

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
