### PR TITLE
NXCM-3493: fixes for running plugin on Maven2

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -138,7 +138,7 @@
       <version>${mavenVersion}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.sonatype.plexus</groupId>
+          <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-container-default</artifactId>
         </exclusion>
       </exclusions>

--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -126,6 +126,7 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-inject-plexus</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
@@ -152,7 +152,7 @@ public abstract class AbstractNexusMojo
 
             if ( logger != null )
             {
-                LoggerManager loggerManager = container.lookup( LoggerManager.class );
+                LoggerManager loggerManager = (LoggerManager) container.lookup( LoggerManager.class.getName() );
 
                 final int threshold = loggerManager.getThreshold();
 
@@ -166,7 +166,7 @@ public abstract class AbstractNexusMojo
                 }
             }
 
-            discoverer = container.lookup( NexusInstanceDiscoverer.class );
+            discoverer = (NexusInstanceDiscoverer) container.lookup( NexusInstanceDiscoverer.class.getName() );
         }
         catch ( ComponentLookupException e )
         {


### PR DESCRIPTION
See https://issues.sonatype.org/browse/NXCM-3493 which occurs when running the plugin with Maven 2.2.1

Fixes:
- put back missing provided scope on plexus container to avoid class cast issue in Maven2
- use string-based lookup, since type-based lookup is not available in Maven2 Plexus API

Qs:
- should this project build and test against the old Plexus API?
- or should we add a plugin IT to explicitly test it with Maven2?
