### PR TITLE
Remove some duplicate copyright headers

### DIFF
--- a/nexus/nexus-configuration-model/src/main/mdo/nexus-old.xml
+++ b/nexus/nexus-configuration-model/src/main/mdo/nexus-old.xml
@@ -18,15 +18,6 @@
     All other trademarks are the property of their respective owners.
 
 -->
-  <!--
-
-    Nexus: Maven Repository Manager Copyright (C) 2008 Sonatype, Inc. This file is part of Nexus. This program is free software; you can
-    redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation;
-    either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
-    General Public License for more details. You should have received a copy of the GNU Lesser General Public License along with this
-    program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-  -->
 
 <model xmlns="http://modello.codehaus.org/MODELLO/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://modello.codehaus.org/MODELLO/1.0.0 http://modello.codehaus.org/xsd/modello-1.0.0.xsd">

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/mdo/vos.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/mdo/vos.xml
@@ -18,13 +18,6 @@
     All other trademarks are the property of their respective owners.
 
 -->
-<!-- Nexus: Maven Repository Manager Copyright (C) 2008 Sonatype, Inc. This file is part of Nexus. This program is free software; 
-  you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free 
-  Software Foundation; either version 3 of the License, or (at your option) any later version. This program is distributed 
-  in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. You should have received a copy of 
-  the GNU Lesser General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin 
-  Street, Fifth Floor, Boston, MA 02110-1301, USA. -->
 
 <model>
 

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipher.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipher.java
@@ -18,22 +18,6 @@
  */
 package org.sonatype.security.ldap.upgrade.cipher;
 
-/*
- * Copyright (C) 2008 Sonatype Inc.
- * Sonatype Inc, licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import java.io.ByteArrayOutputStream;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/PlexusCipher.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/PlexusCipher.java
@@ -18,22 +18,6 @@
  */
 package org.sonatype.security.ldap.upgrade.cipher;
 
-/*
- * Copyright (C) 2008 Sonatype Inc.
- * Sonatype Inc, licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 /**
  * 
  * @author Oleg Gusakov

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/PlexusCipherException.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/PlexusCipherException.java
@@ -18,22 +18,6 @@
  */
 package org.sonatype.security.ldap.upgrade.cipher;
 
-/*
- * Copyright (C) 2008 Sonatype Inc.
- * Sonatype Inc, licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 public class PlexusCipherException
     extends Exception
 {

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipherTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipherTest.java
@@ -18,22 +18,6 @@
  */
 package org.sonatype.security.ldap.upgrade.cipher;
 
-/*
- * Copyright (C) 2008 Sonatype Inc.
- * Sonatype Inc, licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.codehaus.plexus.util.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
I used the following script to find files with more than one occurrence of "Copyright (c)"

   find nexus -type f -print0 | xargs -0 grep -ci "Copyright (c)" | awk -F: '/:[^01]$/ {print $1}'

Though I wasn't sure what to do about the following files:

   nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.ux.form.LovCombo.js
   nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.ux.ThemeCombo.js

which contain both the Ext header and the overall/aggregate Nexus header
