### PR TITLE
NEXUS-3996 Make date validation of 'once' scheduled tasks more lenient

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/schedules/AbstractScheduledServicePlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/schedules/AbstractScheduledServicePlexusResource.java
@@ -324,12 +324,15 @@ public abstract class AbstractScheduledServicePlexusResource
         cal.setTime( new Date( Long.parseLong( date ) ) );
 
         Calendar nowCal = Calendar.getInstance();
-        nowCal.setTime( new Date() );
+        nowCal.add( Calendar.DAY_OF_YEAR, -1 );
+        nowCal.set( Calendar.HOUR, 0 );
+        nowCal.set( Calendar.MINUTE, 0 );
+        nowCal.set( Calendar.SECOND, 0 );
+        nowCal.set( Calendar.MILLISECOND, 0 );
 
         // This is checking just the year/month/day, time isn't of concern right now
-        if ( cal.before( nowCal )
-            && ( cal.get( Calendar.YEAR ) != nowCal.get( Calendar.YEAR )
-                || cal.get( Calendar.MONTH ) != nowCal.get( Calendar.MONTH ) || cal.get( Calendar.DAY_OF_YEAR ) != nowCal.get( Calendar.DAY_OF_YEAR ) ) )
+        // basic check that the day timestamp is roughly in the correct range
+        if ( cal.before( nowCal ) )
         {
             ValidationResponse vr = new ApplicationValidationResponse();
             ValidationMessage vm = new ValidationMessage( "startDate", "Date cannot be in the past." );
@@ -365,10 +368,6 @@ public abstract class AbstractScheduledServicePlexusResource
                 parseDate( ( (ScheduledServiceMonthlyResource) model ).getStartDate(),
                     ( (ScheduledServiceMonthlyResource) model ).getRecurringTime() );
 
-            // validateStartDate( ( (ScheduledServiceMonthlyResource) model ).getStartDate() );
-
-            // validateTime( "recurringTime", date );
-
             schedule =
                 new MonthlySchedule( date, null,
                     formatRecurringDayOfMonth( ( (ScheduledServiceMonthlyResource) model ).getRecurringDay() ) );
@@ -378,10 +377,6 @@ public abstract class AbstractScheduledServicePlexusResource
             Date date =
                 parseDate( ( (ScheduledServiceWeeklyResource) model ).getStartDate(),
                     ( (ScheduledServiceWeeklyResource) model ).getRecurringTime() );
-
-            // validateStartDate( ( (ScheduledServiceWeeklyResource) model ).getStartDate() );
-
-            // validateTime( "recurringTime", date );
 
             schedule =
                 new WeeklySchedule( date, null,
@@ -393,10 +388,6 @@ public abstract class AbstractScheduledServicePlexusResource
                 parseDate( ( (ScheduledServiceDailyResource) model ).getStartDate(),
                     ( (ScheduledServiceDailyResource) model ).getRecurringTime() );
 
-            // validateStartDate( ( (ScheduledServiceDailyResource) model ).getStartDate() );
-
-            // validateTime( "recurringTime", date );
-
             schedule = new DailySchedule( date, null );
         }
         else if ( ScheduledServiceHourlyResource.class.isAssignableFrom( model.getClass() ) )
@@ -404,10 +395,6 @@ public abstract class AbstractScheduledServicePlexusResource
             Date date =
                 parseDate( ( (ScheduledServiceHourlyResource) model ).getStartDate(),
                     ( (ScheduledServiceHourlyResource) model ).getStartTime() );
-
-            // validateStartDate( ( (ScheduledServiceHourlyResource) model ).getStartDate() );
-
-            // validateTime( "startTime", date );
 
             schedule = new HourlySchedule( date, null );
         }
@@ -418,7 +405,6 @@ public abstract class AbstractScheduledServicePlexusResource
                     ( (ScheduledServiceOnceResource) model ).getStartTime() );
 
             validateStartDate( ( (ScheduledServiceOnceResource) model ).getStartDate() );
-
             validateTime( "startTime", date );
 
             schedule =

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3996/Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3996/Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT.java
@@ -46,6 +46,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * every midnight that is earlier than local time and not on the same day of the year.
  * <p/>
  * This test simulates a client whose timezone offset is two hours more than the local timezone.
+ * <p/>
+ * Related issues with timezone problems in the scheduled tasks:
+ * <ul>
+ * <li> https://issues.sonatype.org/browse/NEXUS-4617 </li>
+ * <li> https://issues.sonatype.org/browse/NEXUS-4616 </li>
+ * </ul>
  *
  * @since 1.10.0
  */
@@ -67,6 +73,8 @@ public class Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT
         task.setProperties( Lists.newArrayList( property ) );
 
         Calendar cal = Calendar.getInstance();
+
+        // simulating client timezone here: calculate offset from current timezone
 
         // client is tz+2 -> 3 hours ahead for local tz is one hour ahead for client tz
         cal.add( Calendar.HOUR_OF_DAY, 3 );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3996/Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3996/Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.integrationtests.nexus3996;
+
+import com.google.common.collect.Lists;
+import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
+import org.sonatype.nexus.rest.model.ScheduledServiceBaseResource;
+import org.sonatype.nexus.rest.model.ScheduledServiceOnceResource;
+import org.sonatype.nexus.rest.model.ScheduledServicePropertyResource;
+import org.sonatype.nexus.tasks.descriptors.EmptyTrashTaskDescriptor;
+import org.sonatype.nexus.test.utils.NexusRequestMatchers;
+import org.sonatype.nexus.test.utils.ResponseMatchers;
+import org.sonatype.nexus.test.utils.TaskScheduleUtil;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Nexus would not create tasks for the same day if the client is in a timezone with a larger offset from UTC than
+ * the server's timezone.
+ * <p/>
+ * The date is sent separate from the time as a timestamp for midnight of the selected day. The midnight is calculated
+ * on the client based on the local timezone.
+ * <p/>
+ * The server does not know which timezone the client is in and validates the date based on his timezone, rejecting
+ * every midnight that is earlier than local time and not on the same day of the year.
+ * <p/>
+ * This test simulates a client whose timezone offset is two hours more than the local timezone.
+ *
+ * @since 1.10.0
+ */
+public class Nexus3996ScheduledTasksTimezoneDifferentDayValidationIT
+    extends AbstractNexusIntegrationTest
+{
+
+    @Test
+    public void createTask()
+        throws IOException
+    {
+
+        final ScheduledServiceOnceResource task = new ScheduledServiceOnceResource();
+        task.setName( "name" );
+        task.setSchedule( "once" );
+        task.setTypeId( EmptyTrashTaskDescriptor.ID );
+        ScheduledServicePropertyResource property = new ScheduledServicePropertyResource();
+        property.setKey( EmptyTrashTaskDescriptor.OLDER_THAN_FIELD_ID );
+        task.setProperties( Lists.newArrayList( property ) );
+
+        Calendar cal = Calendar.getInstance();
+
+        // client is tz+2 -> 3 hours ahead for local tz is one hour ahead for client tz
+        cal.add( Calendar.HOUR_OF_DAY, 3 );
+        task.setStartTime( new SimpleDateFormat( "HH:mm" ).format( cal.getTime() ) );
+
+        cal.set( Calendar.HOUR_OF_DAY, 0 );
+        cal.set( Calendar.MINUTE, 0 );
+        cal.set( Calendar.SECOND, 0 );
+        cal.set( Calendar.MILLISECOND, 0 );
+
+        // client is tz+2 -> midnight for client happens 2 hours before servers midnight
+        cal.add( Calendar.HOUR_OF_DAY, -2 );
+        task.setStartDate( String.valueOf( cal.getTimeInMillis() ) );
+
+        assertThat( TaskScheduleUtil.create( task ), NexusRequestMatchers.hasStatusCode( 201 ) );
+    }
+
+}


### PR DESCRIPTION
Nexus tried to validate the date of a task that is run once without any information about the clients timezone, which failed when the timezone offset from GMT on the client is bigger than on the server.
(Client's midnight in server's timezone was on a different day)
