### PR TITLE
Nexus-4611 CloseStageRepositoryMojoTest.mavenProxySupportWithoutAuth failing on grid

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractStagingMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractStagingMojo.java
@@ -79,7 +79,7 @@ public abstract class AbstractStagingMojo
             }
             catch ( RESTLightClientException e )
             {
-                throw new MojoExecutionException( "Failed to connect to Nexus at: " + getNexusUrl() );
+                throw new MojoExecutionException( "Failed to connect to Nexus at: " + getNexusUrl(), e );
             }
         }
 

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojoTest.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojoTest.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.StartingException;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.allOf;
@@ -266,6 +267,9 @@ public class CloseStageRepositoryMojoTest
         mojo.setUsername( getExpectedUser() );
         mojo.setPassword( getExpectedPassword() );
         mojo.setDescription( "this is a description" );
+
+        // just make sure the URL my mojo is trying to access is the same server is started
+        assertThat( mojo.getNexusUrl(), containsString( String.valueOf( fixture.getPort() ) ) );
 
         runMojo( mojo );
 


### PR DESCRIPTION
I was not able to reproduce the problem locally.

From what I could assert from logs looks like server started in one port and client tried to connect on a different one:
13:46:28.512 [main] INFO org.mortbay.log - Started SocketConnector@0.0.0.0:36253
13:46:28.512 [main] DEBUG org.mortbay.log - started SocketConnector@0.0.0.0:36253
13:46:28.512 [main] DEBUG org.mortbay.log - started Server@66c5c0e5
[info] Proxying the Nexus client connection because an applicable active Maven proxy is configured.
[info] Logging into Nexus: http://127.0.0.1:49049

So, I assertThat now and the exception is no longer swallowed
