### PR TITLE
**EXPERIMENTAL PATCH** support lock downgrading

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SimpleLockResource.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SimpleLockResource.java
@@ -21,7 +21,7 @@ package org.sonatype.nexus.proxy.item;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Before you continue using this class, stop and read carefully it's description. This "smart" lock is NOT an improved
+ * Before you continue using this class, stop and read carefully its description. This "smart" lock is NOT an improved
  * implementation of Java's ReentrantReadWriteLock in any way. It does NOT implement the unsupported atomic
  * lock-upgrade. All this class allows is following pattern:
  * 
@@ -42,11 +42,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *   }
  * </pre>
  * 
- * So, it is all about being able of "boxing" the locks.
+ * So, it is all about being able to "box" the locks.
  * <p>
- * Caveat No 1: Once you "upgrade" from shared to exclusive lock, you will possess exclusive lock as long as your last
- * {@link #unlock()} is invoked! While this is not totally correct or natural with "expectations", it does fit it's
- * purpose for use in Nexus.
+ * Caveat No 1: When a lock is "upgraded" from shared to exclusive, it remains exclusive until the matching unlock.
+ * <p>
+ * Previous behaviour: <s>Once you "upgrade" from shared to exclusive lock, you will possess exclusive lock as long as
+ * your last {@link #unlock()} is invoked! While this is not totally correct or natural with "expectations", it does fit
+ * it's purpose for use in Nexus.</s>
  * <p>
  * Caveat No 2: The "upgrade" is not atomic, and it is actually not even meant to be atomic. If you take a peek at
  * implementation, by acquiring an exclusive lock, you actually give away all your shared locks, and just then tries to
@@ -56,7 +58,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * 
  * @author cstamas
  */
-class SimpleLockResource
+final class SimpleLockResource
     implements LockResource
 {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -64,9 +66,9 @@ class SimpleLockResource
     @Override
     public void lockShared()
     {
-        if ( lock.getWriteHoldCount() > 0 )
+        if ( lock.isWriteLockedByCurrentThread() )
         {
-            lockExclusively();
+            lock.writeLock().lock();
         }
         else
         {
@@ -77,21 +79,29 @@ class SimpleLockResource
     @Override
     public void lockExclusively()
     {
-        final int readLockCount = lock.getReadHoldCount();
+        // if we already have exclusive lock then we don't need to upgrade...
+        final int readHoldCount = lock.isWriteLockedByCurrentThread() ? 0 : lock.getReadHoldCount();
 
-        for ( int i = 0; i < readLockCount; i++ )
+        if ( readHoldCount > 0 )
         {
-            lock.readLock().unlock();
+            // upgrading: must release all read locks
+            for ( int i = 0; i < readHoldCount; i++ )
+            {
+                lock.readLock().unlock();
+            }
+
+            Thread.yield(); // fairness
         }
 
-        if ( readLockCount > 0 )
-        {
-            Thread.yield();
-        }
+        lock.writeLock().lock();
 
-        for ( int i = 0; i < readLockCount + 1; i++ )
+        if ( readHoldCount > 0 )
         {
-            lock.writeLock().lock();
+            // re-acquire so downgrade works later on
+            for ( int i = 0; i < readHoldCount; i++ )
+            {
+                lock.readLock().lock();
+            }
         }
     }
 
@@ -111,11 +121,7 @@ class SimpleLockResource
     @Override
     public boolean hasLocksHeld()
     {
-        final int reads = lock.getReadHoldCount();
-
-        final int writes = lock.getWriteHoldCount();
-
-        return ( reads + writes ) != 0;
+        return lock.isWriteLockedByCurrentThread() || lock.getReadHoldCount() > 0;
     }
 
     // ==
@@ -123,6 +129,7 @@ class SimpleLockResource
     /**
      * Mainly for debug purposes, see DefaultRepositoryItemUidTest UT how is this used to verify conditions.
      */
+    @Override
     public String toString()
     {
         return lock.toString();


### PR DESCRIPTION
At the moment once a resource lock is upgraded from shared to exclusive mode in Nexus, it will remain locked in exclusive mode until the very last unlock call. It would be more intuitive (and could help performance) if the resource lock was instead downgraded from exclusive to shared mode by the unlock call that corresponds to the original call that upgraded the lock:

```
   try
   {
      resource.lockShared();
      //
      //   ...etc...
      //
      try
      {
         resource.lockExclusive();   // upgrade
         //
         //   ...etc...
         //
      }
      finally
      {
         resource.unlock();          // downgrade
      }
   }
   finally
   {
      resource.unlock();
   }
```

This patch updates both the SimpleLockResource and SisuLockResource implementations to use the new semantics. 

This patch requires careful code review and rigorous testing. Some pieces of code will now be running under a (downgraded) shared lock, and they might have been written expecting that the exclusive lock would be maintained until the very last unlock.
