### PR TITLE
NEXUS-4521: more fixes for leak spotted during test debug.

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractPlexusLoggingComponent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractPlexusLoggingComponent.java
@@ -18,25 +18,23 @@
  */
 package org.sonatype.nexus.logging;
 
-import javax.inject.Inject;
-
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.slf4j.Logger;
+import org.codehaus.plexus.logging.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Similar to Plexus' AbstractLogEnabled, but using Slf4j and straight-forward stuff! Consider using
- * {@code LoggerFactory.getLogger(getClass() )} directly instead, since unsure about the "value" of this class.
+ * Plexus' AbstractLogEnabled in compatibility way.
  *
- * @author cstamas
+ * @author: cstamas
+ * @deprecated To be used by components still relying on Plexus Logger, but in general, avoid this! Use SLF4J API instead!
  */
-public abstract class AbstractLoggingComponent
+public class AbstractPlexusLoggingComponent
 {
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private final Logger plexusLogger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     protected Logger getLogger()
     {
-        return logger;
+        return plexusLogger;
     }
+
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/Slf4jPlexusLogger.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/Slf4jPlexusLogger.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.logging;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper that wraps SLF4J logger into a Plexus Logger interface to be used with Legacy Plexus components.
+ *
+ * @author: cstamas
+ */
+public class Slf4jPlexusLogger
+    implements org.codehaus.plexus.logging.Logger
+{
+
+    private final Logger logger;
+
+    public Slf4jPlexusLogger( final Logger logger )
+    {
+        this.logger = checkNotNull( logger );
+    }
+
+    public Logger getSlf4jLogger()
+    {
+        return logger;
+    }
+
+    // ==
+
+    @Override
+    public void debug( final String message )
+    {
+        logger.debug( message );
+    }
+
+    @Override
+    public void debug( final String message, final Throwable throwable )
+    {
+        logger.debug( message, throwable );
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void info( final String message )
+    {
+        logger.info( message );
+    }
+
+    @Override
+    public void info( final String message, final Throwable throwable )
+    {
+        logger.info( message, throwable );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void warn( final String message )
+    {
+        logger.warn( message );
+    }
+
+    @Override
+    public void warn( final String message, final Throwable throwable )
+    {
+        logger.warn( message, throwable );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return isWarnEnabled();
+    }
+
+    @Override
+    public void error( final String message )
+    {
+        logger.error( message );
+    }
+
+    @Override
+    public void error( final String message, final Throwable throwable )
+    {
+        logger.error( message, throwable );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void fatalError( final String message )
+    {
+        error( message );
+    }
+
+    @Override
+    public void fatalError( final String message, final Throwable throwable )
+    {
+        error( message, throwable );
+    }
+
+    @Override
+    public boolean isFatalErrorEnabled()
+    {
+        return isErrorEnabled();
+    }
+
+    // ==
+
+    @Override
+    public int getThreshold()
+    {
+        // lie is "debug" to have all legacy code that are nested in the if/else checking for DEBUG level
+        // actually execute, and the real Slf4j backed will decide what to do with it.
+        return LEVEL_DEBUG;
+    }
+
+    @Override
+    public void setThreshold( final int threshold )
+    {
+        // noop, it is a matter of Slf4j backend.
+    }
+
+    @Override
+    public org.codehaus.plexus.logging.Logger getChildLogger( final String name )
+    {
+        // this is a noop implementation actually, since in Core there is only one component using this
+        // feature that itself is disabled (parked).
+        return this;
+    }
+
+    @Override
+    public String getName()
+    {
+        return logger.getName();
+    }
+
+    // ==
+
+    /**
+     * Factory method for Plexus Logger instances, that uses the good old {@code LoggerFactory.getLogger(owner)} way
+     * to obtain Slf4l Logger to have it wrapped into Slf4jPlexusLogger instance.
+     *
+     * @param owner
+     * @return
+     */
+    public static org.codehaus.plexus.logging.Logger getPlexusLogger( final Class<?> owner )
+    {
+        return new Slf4jPlexusLogger( LoggerFactory.getLogger( owner ) );
+    }
+}

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CGlobalRemoteConnectionSettingsCoreConfiguration.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CGlobalRemoteConnectionSettingsCoreConfiguration.java
@@ -37,7 +37,7 @@ public class CGlobalRemoteConnectionSettingsCoreConfiguration
             // create default
             CRemoteConnectionSettings newConn = new CRemoteConnectionSettings();
 
-            newConn.setConnectionTimeout( 1000 );
+            newConn.setConnectionTimeout( 20000 );
 
             newConn.setRetrievalRetryCount( 3 );
 

--- a/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
+++ b/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
@@ -61,7 +61,7 @@ public class SimpleApplicationConfiguration
 
         this.configuration = new Configuration();
 
-        configuration.setGlobalConnectionSettings( new CRemoteConnectionSettings() );
+        // configuration.setGlobalConnectionSettings( new CRemoteConnectionSettings() );
         // configuration.setGlobalHttpProxySettings( new CRemoteHttpProxySettings() );
         configuration.setRouting( new CRouting() );
         configuration.setRepositoryGrouping( new CRepositoryGrouping() );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -33,6 +33,7 @@ import org.sonatype.nexus.configuration.Configurator;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.CRepositoryExternalConfigurationHolderFactory;
 import org.sonatype.nexus.feeds.FeedRecorder;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.mime.MimeUtil;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
@@ -103,8 +104,7 @@ public abstract class AbstractRepository
     extends ConfigurableRepository
     implements Repository
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/AbstractLocalRepositoryStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/AbstractLocalRepositoryStorage.java
@@ -54,7 +54,7 @@ import javax.inject.Inject;
 public abstract class AbstractLocalRepositoryStorage
     implements LocalRepositoryStorage
 {
-    private Logger logger = LoggerFactory.getLogger( AbstractLocalRepositoryStorage.class );
+    private Logger logger = LoggerFactory.getLogger( getClass() );
 
     /**
      * The wastebasket.

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/AbstractRemoteRepositoryStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/AbstractRemoteRepositoryStorage.java
@@ -27,6 +27,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.sonatype.nexus.ApplicationStatusSource;
 import org.sonatype.nexus.SystemStatus;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.mime.MimeUtil;
 import org.sonatype.nexus.proxy.RemoteAccessException;
 import org.sonatype.nexus.proxy.RemoteAuthenticationNeededException;
@@ -44,8 +45,7 @@ import org.sonatype.nexus.proxy.utils.UserAgentBuilder;
 public abstract class AbstractRemoteRepositoryStorage
     implements RemoteRepositoryStorage
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private MimeUtil mimeUtil;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientInputStream.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientInputStream.java
@@ -30,20 +30,88 @@ import org.sonatype.nexus.util.WrappingInputStream;
 public class HttpClientInputStream
     extends WrappingInputStream
 {
-    /** The method. */
+
+    /**
+     * The method.
+     */
     private final HttpMethod method;
 
     /**
      * Instantiates a new http client input stream.
-     * 
+     *
      * @param method the method
-     * @param is the is
+     * @param is     the is
      */
-    public HttpClientInputStream( HttpMethod method, InputStream is )
+    public HttpClientInputStream( final HttpMethod method, final InputStream is )
     {
         super( is );
-
         this.method = method;
+    }
+
+    @Override
+    public int read()
+        throws IOException
+    {
+        try
+        {
+            final int result = super.read();
+
+            if ( result == -1 )
+            {
+                release();
+            }
+
+            return result;
+        }
+        catch ( IOException e )
+        {
+            release();
+            throw e;
+        }
+    }
+
+    @Override
+    public int read( byte b[] )
+        throws IOException
+    {
+        try
+        {
+            final int result = super.read( b );
+
+            if ( result == -1 )
+            {
+                release();
+            }
+
+            return result;
+        }
+        catch ( IOException e )
+        {
+            release();
+            throw e;
+        }
+    }
+
+    @Override
+    public int read( byte b[], int off, int len )
+        throws IOException
+    {
+        try
+        {
+            final int result = super.read( b, off, len );
+
+            if ( result == -1 )
+            {
+                release();
+            }
+
+            return result;
+        }
+        catch ( IOException e )
+        {
+            release();
+            throw e;
+        }
     }
 
     @Override
@@ -56,8 +124,13 @@ public class HttpClientInputStream
         }
         finally
         {
-            method.releaseConnection();
+            release();
         }
+    }
+
+    protected void release()
+    {
+        method.releaseConnection();
     }
 
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
@@ -67,7 +67,7 @@ public class HttpClientProxyUtil
 
         httpClient.getHttpConnectionManager().getParams().setConnectionTimeout( timeout );
         httpClient.getHttpConnectionManager().getParams().setSoTimeout( timeout );
-        httpClient.getHttpConnectionManager().getParams().setTcpNoDelay( true );
+        //httpClient.getHttpConnectionManager().getParams().setTcpNoDelay( true );
         httpClient.getHttpConnectionManager().getParams().setMaxTotalConnections( connectionPoolSize );
         // NOTE: connPool is _per_ repo, hence all of those will connect to same host (unless mirrors are used)
         // so, we are violating intentionally the RFC and we let the whole pool size to chase same host

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/configuration/SimpleProxyApplicationConfiguration.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/configuration/SimpleProxyApplicationConfiguration.java
@@ -52,9 +52,10 @@ public class SimpleProxyApplicationConfiguration
     {
         Configuration configuration = getConfigurationModel();
 
-        configuration.setGlobalConnectionSettings( new CRemoteConnectionSettings() );
-        configuration.getGlobalConnectionSettings().setConnectionTimeout( 1000 );
-        configuration.getGlobalConnectionSettings().setRetrievalRetryCount( 3 );
+        // NEXUS-4521: littering "defaults" all over the place is unhealthy
+        //configuration.setGlobalConnectionSettings( new CRemoteConnectionSettings() );
+        //configuration.getGlobalConnectionSettings().setConnectionTimeout( 1000 );
+        //configuration.getGlobalConnectionSettings().setRetrievalRetryCount( 3 );
         // configuration.setGlobalHttpProxySettings( new CRemoteHttpProxySettings() );
         configuration.setRouting( new CRouting() );
         configuration.setRepositoryGrouping( new CRepositoryGrouping() );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimpleRemoteLeakTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimpleRemoteLeakTest.java
@@ -79,6 +79,7 @@ public class SimpleRemoteLeakTest
         repo1.setRemoteUrl(
             getRepositoryRegistry().getRepositoryWithFacet( "repo1", ProxyRepository.class ).getRemoteUrl().replace(
                 "localhost", "127.0.0.1" ) );
+        repo1.commitChanges();
 
         ResourceStoreRequest req1 =
             new ResourceStoreRequest( "/repositories/repo1/activemq/activemq-core/1.2/activemq-core-1.2.jar", false );


### PR DESCRIPTION
If IO error occurs in the middle of body transfer, the connection
would be left dangling until HttpClient CM timeouts on it. On heavily
loaded systems this might lead to connection pool depletion. Now
the method.releaseConnection() will be invoked as quick as possible.

Also, in the UT the config change was not applied explicitly.

This are still not the solutions, see comments on NEXUS-4521 issue
about setSoTimeout() method.
