### PR TITLE
[NEXUS-4624] Log skipped reindexing as re-indexing is already in place

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -880,6 +880,7 @@ public class DefaultIndexerManager
 
         if ( isAlreadyBeingIndexed( repository.getId() ) )
         {
+            logAlreadyBeingIndexed( repository.getId(), "re-indexing" );
             return;
         }
 
@@ -1003,6 +1004,7 @@ public class DefaultIndexerManager
 
         if ( isAlreadyBeingIndexed( repository.getId() ) )
         {
+            logAlreadyBeingIndexed( repository.getId(), "downloading index" );
             return false;
         }
 
@@ -1256,6 +1258,7 @@ public class DefaultIndexerManager
 
         if ( isAlreadyBeingIndexed( repository.getId() ) )
         {
+            logAlreadyBeingIndexed( repository.getId(), "publishing index" );
             return;
         }
 
@@ -2328,4 +2331,13 @@ public class DefaultIndexerManager
         // if I can't get a read lock means someone else has the write lock (index tasks do write lock)
         return !locked;
     }
+
+    private void logAlreadyBeingIndexed( final String repositoryId, final String processName )
+    {
+        getLogger().info( String.format(
+            "Repository '%s' is already in the process of being re-indexed. Skipping %s'.",
+            repositoryId, processName
+        ) );
+    }
+
 }


### PR DESCRIPTION
We should be able to easier spot the cases when re-indexed is expected to happen but is skipped because indexing is already taking place (mainly happens in tests)

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
