### PR TITLE
NEXUS-4625: Consolidating core logging.

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/AbstractApplicationStatusSource.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/AbstractApplicationStatusSource.java
@@ -28,13 +28,12 @@ import javax.inject.Inject;
 
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 
 public abstract class AbstractApplicationStatusSource
     implements ApplicationStatusSource
 {
-    @Requirement
-    @Inject
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /**
      * System status.

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractLoggingComponent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractLoggingComponent.java
@@ -18,9 +18,8 @@
  */
 package org.sonatype.nexus.logging;
 
-import javax.inject.Inject;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +32,32 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractLoggingComponent
 {
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private final Logger logger;
 
+    /**
+     * Default constructor that creates logger for component upon instantiation.
+     */
+    protected AbstractLoggingComponent()
+    {
+        this.logger = checkNotNull( createLogger() );
+    }
+
+    /**
+     * Creates logger instance to be used with component instance. It might be overridden by subclasses to implement
+     * alternative logger naming strategy. By default, this method does the "usual" fluff: {@code LoggerFactory.getLogger(getClass())}.
+     *
+     * @return The Logger instance to be used by component for logging.
+     */
+    protected Logger createLogger()
+    {
+        return LoggerFactory.getLogger( getClass() );
+    }
+
+    /**
+     * Returns the Logger instance of this component. Never returns {@code null}.
+     *
+     * @return
+     */
     protected Logger getLogger()
     {
         return logger;

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractPlexusLoggingComponent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/AbstractPlexusLoggingComponent.java
@@ -18,20 +18,43 @@
  */
 package org.sonatype.nexus.logging;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.codehaus.plexus.logging.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Plexus' AbstractLogEnabled in compatibility way.
  *
  * @author: cstamas
- * @deprecated To be used by components still relying on Plexus Logger, but in general, avoid this! Use SLF4J API instead!
+ * @deprecated To be used by components still relying on Plexus Logger only, but in general, avoid this! Use
+ *             AbstractLoggingComponent or directly SLF4J API instead!
  */
 public class AbstractPlexusLoggingComponent
 {
 
-    private final Logger plexusLogger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
+    private final Logger plexusLogger;
 
+    protected AbstractPlexusLoggingComponent()
+    {
+        this.plexusLogger = checkNotNull( createLogger() );
+    }
+
+    /**
+     * Creates logger instance to be used with component instance. It might be overridden by subclasses to implement
+     * alternative logger naming strategy. By default, this method does the "usual" fluff: {@code Slf4jPlexusLogger.getPlexusLogger(getClass() )}.
+     *
+     * @return The Logger instance to be used by component for logging.
+     */
+    protected Logger createLogger()
+    {
+        return Slf4jPlexusLogger.getPlexusLogger( getClass() );
+    }
+
+    /**
+     * Returns the Logger instance of this component. Never returns {@code null}.
+     *
+     * @return
+     */
     protected Logger getLogger()
     {
         return plexusLogger;

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/Slf4jPlexusLogger.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/logging/Slf4jPlexusLogger.java
@@ -141,8 +141,7 @@ public class Slf4jPlexusLogger
     @Override
     public int getThreshold()
     {
-        // lie is "debug" to have all legacy code that are nested in the if/else checking for DEBUG level
-        // actually execute, and the real Slf4j backed will decide what to do with it.
+        // unused
         return LEVEL_DEBUG;
     }
 
@@ -177,6 +176,18 @@ public class Slf4jPlexusLogger
      */
     public static org.codehaus.plexus.logging.Logger getPlexusLogger( final Class<?> owner )
     {
-        return new Slf4jPlexusLogger( LoggerFactory.getLogger( owner ) );
+        return getPlexusLogger( LoggerFactory.getLogger( owner ) );
     }
+
+    /**
+     * Factory method for Plexus Logger instances, that wraps existing Slf4j Logger instances.
+     *
+     * @param logger
+     * @return
+     */
+    public static org.codehaus.plexus.logging.Logger getPlexusLogger( final Logger logger )
+    {
+        return new Slf4jPlexusLogger( logger );
+    }
+
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/plugins/rest/AbstractDocumentationNexusResourceBundle.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/plugins/rest/AbstractDocumentationNexusResourceBundle.java
@@ -30,13 +30,13 @@ import java.util.zip.ZipFile;
 
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.mime.MimeUtil;
 
 public abstract class AbstractDocumentationNexusResourceBundle
     implements NexusDocumentationBundle
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private MimeUtil mimeUtil;

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/AbstractEventInspector.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/AbstractEventInspector.java
@@ -20,12 +20,12 @@ package org.sonatype.nexus.proxy.events;
 
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 
 public abstract class AbstractEventInspector
     implements EventInspector
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     protected Logger getLogger()
     {

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultRepositoryFolderRemover.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultRepositoryFolderRemover.java
@@ -24,14 +24,14 @@ import java.util.Map;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 @Component( role = RepositoryFolderRemover.class )
 public class DefaultRepositoryFolderRemover
     implements RepositoryFolderRemover
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement( role = RepositoryFolderCleaner.class )
     private Map<String, RepositoryFolderCleaner> cleaners;

--- a/nexus/nexus-app/pom.xml
+++ b/nexus/nexus-app/pom.xml
@@ -145,21 +145,6 @@
       <artifactId>com.noelios.restlet</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <!-- TEMPORARY: remove once AbstractPluginTestCase is fixed -->
     <dependency>

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
@@ -54,6 +54,7 @@ import org.sonatype.nexus.configuration.model.Configuration;
 import org.sonatype.nexus.configuration.source.ApplicationConfigurationSource;
 import org.sonatype.nexus.configuration.validator.ApplicationConfigurationValidator;
 import org.sonatype.nexus.configuration.validator.ApplicationValidationContext;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.plugins.RepositoryType;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.events.VetoFormatter;
@@ -84,8 +85,7 @@ import org.sonatype.security.SecuritySystem;
 public class DefaultNexusConfiguration
     implements NexusConfiguration
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationEventMulticaster applicationEventMulticaster;

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/runtime/DefaultApplicationRuntimeConfigurationBuilder.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/runtime/DefaultApplicationRuntimeConfigurationBuilder.java
@@ -22,11 +22,11 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.configuration.validation.InvalidConfigurationException;
 import org.sonatype.nexus.configuration.model.CRepository;
 import org.sonatype.nexus.configuration.model.Configuration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
@@ -37,7 +37,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  */
 @Component( role = ApplicationRuntimeConfigurationBuilder.class )
 public class DefaultApplicationRuntimeConfigurationBuilder
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ApplicationRuntimeConfigurationBuilder
 {
     @Requirement

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/email/DefaultSmtpSettingsValidator.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/email/DefaultSmtpSettingsValidator.java
@@ -23,7 +23,6 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.sonatype.micromailer.Address;
 import org.sonatype.micromailer.EMailer;
@@ -32,13 +31,14 @@ import org.sonatype.micromailer.MailRequest;
 import org.sonatype.micromailer.MailRequestStatus;
 import org.sonatype.micromailer.imp.DefaultMailType;
 import org.sonatype.nexus.configuration.model.CSmtpConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * @author velo
  */
 @Component( role = SmtpSettingsValidator.class )
 public class DefaultSmtpSettingsValidator
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SmtpSettingsValidator, Contextualizable
 {
 

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/error/reporting/DefaultErrorReportingManager.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/error/reporting/DefaultErrorReportingManager.java
@@ -65,6 +65,7 @@ import org.sonatype.nexus.configuration.model.ConfigurationHelper;
 import org.sonatype.nexus.error.report.ErrorReportBundleContentContributor;
 import org.sonatype.nexus.error.report.ErrorReportBundleEntry;
 import org.sonatype.nexus.error.report.ErrorReportComponent;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.util.StringDigester;
 import org.sonatype.plexus.encryptor.PlexusEncryptor;
 import org.sonatype.security.configuration.source.SecurityConfigurationSource;
@@ -75,8 +76,7 @@ public class DefaultErrorReportingManager
     extends AbstractConfigurable
     implements ErrorReportingManager
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private NexusConfiguration nexusConfig;

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/feeds/DefaultFeedArtifactEventFilter.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/feeds/DefaultFeedArtifactEventFilter.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
@@ -33,7 +33,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
 
 @Component( role = FeedArtifactEventFilter.class )
 public class DefaultFeedArtifactEventFilter
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements FeedArtifactEventFilter
 {
     @Requirement

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/feeds/DefaultFeedRecorder.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/feeds/DefaultFeedRecorder.java
@@ -34,6 +34,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.ExceptionUtils;
 import org.sonatype.nexus.artifact.NexusItemInfo;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.timeline.NexusTimeline;
 import org.sonatype.timeline.TimelineFilter;
 import org.sonatype.timeline.TimelineRecord;
@@ -113,8 +114,7 @@ public class DefaultFeedRecorder
      */
     private static final String EVENT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSZ";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /**
      * The timeline for persistent events and feeds.

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/DefaultNotificationManager.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/DefaultNotificationManager.java
@@ -33,14 +33,14 @@ import org.sonatype.nexus.configuration.application.NexusConfiguration;
 import org.sonatype.nexus.configuration.model.CNotification;
 import org.sonatype.nexus.configuration.model.CNotificationConfiguration;
 import org.sonatype.nexus.configuration.model.CNotificationTarget;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 
 @Component( role = NotificationManager.class )
 public class DefaultNotificationManager
     extends AbstractConfigurable
     implements NotificationManager
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private NexusConfiguration nexusConfig;

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/EmailCarrier.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/EmailCarrier.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.micromailer.Address;
 import org.sonatype.micromailer.MailRequest;
 import org.sonatype.nexus.email.NexusEmailer;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.security.SecuritySystem;
 import org.sonatype.security.usermanagement.User;
 import org.sonatype.security.usermanagement.UserNotFoundException;
@@ -40,8 +41,7 @@ public class EmailCarrier
 {
     public static final String KEY = "email";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private NexusEmailer nexusEmailer;

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/repositories/metadata/DefaultNexusRepositoryMetadataHandler.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/repositories/metadata/DefaultNexusRepositoryMetadataHandler.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -33,7 +33,7 @@ import org.sonatype.nexus.repository.metadata.restlet.RestletRawTransport;
 
 @Component( role = NexusRepositoryMetadataHandler.class )
 public class DefaultNexusRepositoryMetadataHandler
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements NexusRepositoryMetadataHandler
 {
     @Requirement

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/DefaultNexusScheduler.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/DefaultNexusScheduler.java
@@ -25,7 +25,7 @@ import java.util.concurrent.RejectedExecutionException;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.scheduling.NoSuchTaskException;
 import org.sonatype.scheduling.ScheduledTask;
 import org.sonatype.scheduling.Scheduler;
@@ -38,7 +38,7 @@ import org.sonatype.scheduling.schedules.Schedule;
  */
 @Component( role = NexusScheduler.class )
 public class DefaultNexusScheduler
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements NexusScheduler
 {
     @Requirement

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/timeline/DefaultNexusTimeline.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/timeline/DefaultNexusTimeline.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationExce
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.StartingException;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.timeline.Timeline;
 import org.sonatype.timeline.TimelineConfiguration;
 import org.sonatype.timeline.TimelineException;
@@ -45,8 +46,7 @@ public class DefaultNexusTimeline
 {
     private static final String TIMELINE_BASEDIR = "timeline";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private Timeline timeline;

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/DefaultApplicationConfigurationUpgrader.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/DefaultApplicationConfigurationUpgrader.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -35,6 +34,7 @@ import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UnsupportedConfigurationVersionException;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.Configuration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Default configuration updater, using versioned Modello models. It tried to detect version signature from existing
@@ -44,7 +44,7 @@ import org.sonatype.nexus.configuration.model.Configuration;
  */
 @Component( role = ApplicationConfigurationUpgrader.class )
 public class DefaultApplicationConfigurationUpgrader
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ApplicationConfigurationUpgrader
 {
     @Requirement( role = SingleVersionUpgrader.class )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade103to104.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade103to104.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
@@ -63,7 +62,7 @@ import org.sonatype.nexus.configuration.model.v1_0_4.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.v1_0_4.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_0_4.CSecurity;
 import org.sonatype.nexus.configuration.model.v1_0_4.CSmtpConfiguration;
-
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
@@ -75,7 +74,7 @@ import com.thoughtworks.xstream.io.xml.DomDriver;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.3" )
 public class Upgrade103to104
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     private File tasksFile;

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade104to105.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade104to105.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -54,6 +53,7 @@ import org.sonatype.nexus.configuration.model.v1_0_5.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.v1_0_5.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_0_5.CSecurity;
 import org.sonatype.nexus.configuration.model.v1_0_5.CSmtpConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.0.4 to 1.0.5.
@@ -62,7 +62,7 @@ import org.sonatype.nexus.configuration.model.v1_0_5.CSmtpConfiguration;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.4" )
 public class Upgrade104to105
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     public Object loadConfiguration( File file )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade105to106.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade105to106.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -54,6 +53,7 @@ import org.sonatype.nexus.configuration.model.v1_0_6.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.v1_0_6.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_0_6.CSecurity;
 import org.sonatype.nexus.configuration.model.v1_0_6.CSmtpConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.0.5 to 1.0.6.
@@ -62,7 +62,7 @@ import org.sonatype.nexus.configuration.model.v1_0_6.CSmtpConfiguration;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.5" )
 public class Upgrade105to106
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     public Object loadConfiguration( File file )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade106to107.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade106to107.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -54,6 +53,7 @@ import org.sonatype.nexus.configuration.model.v1_0_7.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.v1_0_7.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_0_7.CSecurity;
 import org.sonatype.nexus.configuration.model.v1_0_7.CSmtpConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.0.6 to 1.0.7.
@@ -62,7 +62,7 @@ import org.sonatype.nexus.configuration.model.v1_0_7.CSmtpConfiguration;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.6" )
 public class Upgrade106to107
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     public Object loadConfiguration( File file )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade107to108.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade107to108.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -37,10 +36,11 @@ import org.sonatype.nexus.configuration.model.v1_0_8.CRepositoryShadow;
 import org.sonatype.nexus.configuration.model.v1_0_8.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_0_8.CSecurity;
 import org.sonatype.nexus.configuration.model.v1_0_8.upgrade.BasicVersionUpgrade;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.7" )
 public class Upgrade107to108
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     private BasicVersionUpgrade converter = new BasicVersionUpgrade()

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade108to140.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade108to140.java
@@ -28,12 +28,13 @@ import java.util.Map;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
+import org.sonatype.nexus.configuration.model.v1_0_8.Configuration;
+import org.sonatype.nexus.configuration.model.v1_0_8.io.xpp3.NexusConfigurationXpp3Reader;
 import org.sonatype.nexus.configuration.model.v1_4_0.CErrorReporting;
 import org.sonatype.nexus.configuration.model.v1_4_0.CHttpProxySettings;
 import org.sonatype.nexus.configuration.model.v1_4_0.CLocalStorage;
@@ -52,8 +53,7 @@ import org.sonatype.nexus.configuration.model.v1_4_0.CRouting;
 import org.sonatype.nexus.configuration.model.v1_4_0.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.v1_4_0.CScheduledTask;
 import org.sonatype.nexus.configuration.model.v1_4_0.CSmtpConfiguration;
-import org.sonatype.nexus.configuration.model.v1_0_8.Configuration;
-import org.sonatype.nexus.configuration.model.v1_0_8.io.xpp3.NexusConfigurationXpp3Reader;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
 import org.sonatype.nexus.proxy.repository.LocalStatus;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -74,7 +74,7 @@ import org.sonatype.security.realms.XmlAuthorizingRealm;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.0.8" )
 public class Upgrade108to140
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     @Requirement( hint = "file" )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade140to141.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade140to141.java
@@ -23,14 +23,13 @@ import java.io.FileReader;
 import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.v1_4_1.CNotification;
 import org.sonatype.nexus.configuration.model.v1_4_1.upgrade.BasicVersionConverter;
-
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.0 to 1.4.1.
@@ -39,7 +38,7 @@ import org.sonatype.nexus.configuration.model.v1_4_1.upgrade.BasicVersionConvert
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.0" )
 public class Upgrade140to141
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade141to142.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade141to142.java
@@ -23,12 +23,12 @@ import java.io.FileReader;
 import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.v1_4_2.upgrade.BasicVersionConverter;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.1 to 1.4.2.
@@ -37,7 +37,7 @@ import org.sonatype.nexus.configuration.model.v1_4_2.upgrade.BasicVersionConvert
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.1" )
 public class Upgrade141to142
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade142to143.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade142to143.java
@@ -23,13 +23,13 @@ import java.io.FileReader;
 import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.v1_4_3.CRestApiSettings;
 import org.sonatype.nexus.configuration.model.v1_4_3.upgrade.BasicVersionConverter;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.2 to 1.4.3.
@@ -38,7 +38,7 @@ import org.sonatype.nexus.configuration.model.v1_4_3.upgrade.BasicVersionConvert
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.2" )
 public class Upgrade142to143
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade143to144.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade143to144.java
@@ -26,7 +26,6 @@ import java.net.URL;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
@@ -34,6 +33,7 @@ import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.v1_4_4.upgrade.BasicVersionConverter;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.3 to 1.4.4.
@@ -42,7 +42,7 @@ import org.sonatype.nexus.configuration.model.v1_4_4.upgrade.BasicVersionConvert
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.3" )
 public class Upgrade143to144
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
     @Requirement

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade144to145.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade144to145.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -32,6 +31,7 @@ import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.v1_4_5.CProps;
 import org.sonatype.nexus.configuration.model.v1_4_5.CRemoteStorage;
 import org.sonatype.nexus.configuration.model.v1_4_5.upgrade.BasicVersionConverter;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.4 to 1.4.5.<BR>
@@ -43,7 +43,7 @@ import org.sonatype.nexus.configuration.model.v1_4_5.upgrade.BasicVersionConvert
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.4" )
 public class Upgrade144to145
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade145to146.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade145to146.java
@@ -23,7 +23,6 @@ import java.io.FileReader;
 import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
@@ -31,6 +30,7 @@ import org.sonatype.configuration.upgrade.UpgradeMessage;
 import org.sonatype.nexus.configuration.model.CNotificationTarget;
 import org.sonatype.nexus.configuration.model.v1_4_6.upgrade.BasicVersionUpgrade;
 import org.sonatype.nexus.configuration.security.upgrade.SecurityData204Upgrade;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Upgrades configuration model from version 1.4.5 to 1.4.6.<BR>
@@ -39,7 +39,7 @@ import org.sonatype.nexus.configuration.security.upgrade.SecurityData204Upgrade;
  */
 @Component( role = SingleVersionUpgrader.class, hint = "1.4.5" )
 public class Upgrade145to146
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SingleVersionUpgrader
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/DefaultConfigurationHelper.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/DefaultConfigurationHelper.java
@@ -22,16 +22,15 @@ import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.nexus.configuration.PasswordHelper;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.plexus.components.cipher.PlexusCipherException;
-
 import com.thoughtworks.xstream.XStream;
 
 @Component( role = ConfigurationHelper.class )
 public class DefaultConfigurationHelper
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ConfigurationHelper
 {
     @Requirement

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityData201Upgrade.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityData201Upgrade.java
@@ -34,6 +34,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.security.model.v2_0_2.CPrivilege;
 import org.sonatype.security.model.v2_0_2.CProperty;
 import org.sonatype.security.model.v2_0_2.CRole;
@@ -48,8 +49,7 @@ public class SecurityData201Upgrade
     implements SecurityDataUpgrader
 {
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Override
     public void doUpgrade( Configuration configuration )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/AbstractConfigurationSource.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/AbstractConfigurationSource.java
@@ -18,10 +18,10 @@
  */
 package org.sonatype.nexus.configuration.source;
 
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.configuration.source.ConfigurationSource;
 import org.sonatype.configuration.validation.ValidationResponse;
 import org.sonatype.nexus.configuration.model.Configuration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * Abstract class that encapsulates Modello model loading and saving with interpolation.
@@ -29,7 +29,7 @@ import org.sonatype.nexus.configuration.model.Configuration;
  * @author cstamas
  */
 public abstract class AbstractConfigurationSource
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ConfigurationSource<Configuration>
 {
     /** Flag to mark update. */

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/FileConfigurationSource.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/FileConfigurationSource.java
@@ -305,7 +305,7 @@ public class FileConfigurationSource
                         + "* Nexus cannot start properly until the process has read+write permissions to this folder *\r\n"
                         + "******************************************************************************";
 
-                getLogger().fatalError( message );
+                getLogger().error( message );
             }
 
             // copy the current nexus config file as file.bak

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
@@ -28,7 +28,6 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.configuration.validation.ValidationMessage;
@@ -51,6 +50,7 @@ import org.sonatype.nexus.configuration.model.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.CScheduledTask;
 import org.sonatype.nexus.configuration.model.CSmtpConfiguration;
 import org.sonatype.nexus.configuration.model.Configuration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.repository.LocalStatus;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
@@ -63,7 +63,7 @@ import org.sonatype.nexus.proxy.repository.ShadowRepository;
  */
 @Component( role = ApplicationConfigurationValidator.class )
 public class DefaultApplicationConfigurationValidator
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ApplicationConfigurationValidator, Contextualizable
 {
     private Random rand = new Random( System.currentTimeMillis() );

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/util/configurationreader/DefaultConfigurationHelper.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/util/configurationreader/DefaultConfigurationHelper.java
@@ -31,7 +31,6 @@ import java.io.Writer;
 import java.util.concurrent.locks.Lock;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
@@ -42,11 +41,12 @@ import org.sonatype.configuration.upgrade.UnsupportedConfigurationVersionExcepti
 import org.sonatype.configuration.validation.ValidationRequest;
 import org.sonatype.configuration.validation.ValidationResponse;
 import org.sonatype.nexus.configuration.validator.ConfigurationValidator;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 @SuppressWarnings( "deprecation" )
 @Component( role = ConfigurationHelper.class )
 public class DefaultConfigurationHelper
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ConfigurationHelper
 {
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
@@ -43,6 +43,7 @@ import org.sonatype.nexus.configuration.model.CProps;
 import org.sonatype.nexus.configuration.model.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.CScheduledTask;
 import org.sonatype.nexus.configuration.model.CScheduledTaskCoreConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.scheduling.NexusTask;
 import org.sonatype.nexus.scheduling.TaskUtils;
 import org.sonatype.scheduling.schedules.CronSchedule;
@@ -65,8 +66,7 @@ public class DefaultTaskConfigManager
     implements TaskConfigManager
 {
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /**
      * The app config holding tasks.

--- a/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultGroovyScriptManager.java
+++ b/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultGroovyScriptManager.java
@@ -18,10 +18,6 @@
  */
 package com.sonatype.nexus.plugin.groovyconsole;
 
-import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
-import groovy.util.AntBuilder;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,14 +28,16 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.plexus.appevents.Event;
-
 import com.sonatype.nexus.plugin.groovyconsole.rest.dto.GroovyScriptDTO;
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import groovy.util.AntBuilder;
 
 @Component( role = GroovyScriptManager.class, instantiationStrategy = "singleton" )
 public class DefaultGroovyScriptManager
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements GroovyScriptManager
 {
     @Requirement

--- a/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultScriptStorage.java
+++ b/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultScriptStorage.java
@@ -38,17 +38,17 @@ import org.apache.commons.vfs.VFS;
 import org.apache.commons.vfs.impl.DefaultFileMonitor;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.plexus.appevents.Event;
 
 @Component( role = ScriptStorage.class )
 public class DefaultScriptStorage
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ScriptStorage, Initializable, Disposable, FileListener
 {
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexArtifactFilter.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexArtifactFilter.java
@@ -26,7 +26,7 @@ import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.artifact.Gav;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
@@ -42,7 +42,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  */
 @Component( role = IndexArtifactFilter.class )
 public class DefaultIndexArtifactFilter
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements IndexArtifactFilter
 {
     @Requirement

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -90,6 +90,7 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.nexus.configuration.application.NexusConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.maven.tasks.SnapshotRemover;
 import org.sonatype.nexus.mime.MimeUtil;
 import org.sonatype.nexus.proxy.IllegalOperationException;
@@ -154,8 +155,7 @@ public class DefaultIndexerManager
 
     private static final Map<String, ReadWriteLock> locks = new HashMap<String, ReadWriteLock>();
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private NexusIndexer nexusIndexer;

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/DefaultLdapGroupDAO.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/DefaultLdapGroupDAO.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.naming.InvalidNameException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -35,7 +34,6 @@ import javax.naming.ldap.LdapName;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,14 +43,18 @@ import org.slf4j.LoggerFactory;
  */
 @Component( role = LdapGroupDAO.class )
 public class DefaultLdapGroupDAO
-    extends AbstractLogEnabled
     implements LdapGroupDAO
 {
     @Requirement
     private LdapUserDAO ldapUserManager;
 
     private Logger logger = LoggerFactory.getLogger( getClass() );
-    
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
+
     private static boolean isGroupsEnabled( LdapAuthConfiguration configuration )
     {
         return configuration.isLdapGroupsAsRoles();

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/DefaultLdapUserDAO.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/DefaultLdapUserDAO.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.naming.InvalidNameException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -30,15 +29,14 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
-import javax.naming.ldap.Control;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
-import javax.naming.ldap.SortControl;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.security.ldap.dao.password.PasswordEncoderManager;
 
 
@@ -47,12 +45,17 @@ import org.sonatype.security.ldap.dao.password.PasswordEncoderManager;
  */
 @Component( role = LdapUserDAO.class )
 public class DefaultLdapUserDAO
-    extends AbstractLogEnabled
     implements LdapUserDAO
 {
+    private Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Requirement
     private PasswordEncoderManager passwordEncoderManager;
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
 
     public PasswordEncoderManager getPasswordEncoderManager()
     {

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/password/DefaultPasswordEncoderManager.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/dao/password/DefaultPasswordEncoderManager.java
@@ -27,18 +27,20 @@ import java.util.regex.Pattern;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Configuration;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author cstamas
  */
 @Component( role = PasswordEncoderManager.class )
 public class DefaultPasswordEncoderManager
-    extends AbstractLogEnabled
     implements PasswordEncoderManager
 {
 
     private static final Pattern ENCODING_SPEC_PATTERN = Pattern.compile( "\\{([a-zA-Z0-9]+)\\}(.+)" );
+
+    private Logger logger = LoggerFactory.getLogger( getClass() );
 
     /**
      */
@@ -52,6 +54,11 @@ public class DefaultPasswordEncoderManager
 
     @Requirement( role = PasswordEncoder.class )
     private Map<String, PasswordEncoder> encodersMap;
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
 
     public String encodePassword( String password, Object salt )
     {

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/realms/persist/DefaultLdapConfiguration.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/realms/persist/DefaultLdapConfiguration.java
@@ -32,9 +32,10 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 import org.sonatype.security.ldap.dao.LdapAuthConfiguration;
 import org.sonatype.security.ldap.dao.password.PasswordEncoderManager;
@@ -47,9 +48,10 @@ import org.sonatype.security.ldap.upgrade.cipher.PlexusCipherException;
 
 @Component( role = LdapConfiguration.class, hint = "default", instantiationStrategy = "singleton" )
 public class DefaultLdapConfiguration
-    extends AbstractLogEnabled
     implements LdapConfiguration
 {
+    private Logger logger = LoggerFactory.getLogger( getClass() );
+    
     @org.codehaus.plexus.component.annotations.Configuration( value = "${application-conf}/ldap.xml" )
     private File configurationFile;
 
@@ -68,6 +70,11 @@ public class DefaultLdapConfiguration
     private ApplicationEventMulticaster applicationEventMulticaster;
 
     private ReentrantLock lock = new ReentrantLock();
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
 
     public CConnectionInfo readConnectionInfo()
     {

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipher.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/upgrade/cipher/DefaultPlexusCipher.java
@@ -23,7 +23,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.security.spec.KeySpec;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -34,20 +33,22 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Base64Encoder;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Configuration;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author <a href="oleg@codehaus.org">Oleg Gusakov</a>
  */
 @Component( role = PlexusCipher.class )
 public class DefaultPlexusCipher
-    extends AbstractLogEnabled
     implements PlexusCipher
 {
     private static final int SALT_SIZE = 8;
 
     private static final String STRING_ENCODING = "UTF8";
+
+    private Logger logger = LoggerFactory.getLogger( getClass() );
 
     /**
      * Encryption algorithm to use by this instance. Needs protected scope for tests
@@ -64,6 +65,11 @@ public class DefaultPlexusCipher
     protected int iterationCount = 23;
 
     private final BouncyCastleProvider bouncyCastleProvider;
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
 
     public DefaultPlexusCipher()
     {

--- a/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/DefaultLvoPlugin.java
+++ b/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/DefaultLvoPlugin.java
@@ -24,15 +24,15 @@ import java.util.Map;
 import org.apache.maven.index.ArtifactInfo;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.lvo.config.LvoPluginConfiguration;
 import org.sonatype.nexus.plugins.lvo.config.model.CLvoKey;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 
 @Component( role = LvoPlugin.class )
 public class DefaultLvoPlugin
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements LvoPlugin
 {
     @Requirement

--- a/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfiguration.java
+++ b/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/config/DefaultLvoPluginConfiguration.java
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.lvo.NoSuchKeyException;
 import org.sonatype.nexus.plugins.lvo.config.model.CLvoKey;
 import org.sonatype.nexus.plugins.lvo.config.model.Configuration;
@@ -44,7 +44,7 @@ import org.sonatype.nexus.plugins.lvo.config.model.io.xpp3.NexusLvoPluginConfigu
 
 @Component( role = LvoPluginConfiguration.class )
 public class DefaultLvoPluginConfiguration
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements LvoPluginConfiguration
 {
     @org.codehaus.plexus.component.annotations.Configuration( value = "${nexus-work}/conf/lvo-plugin.xml" )

--- a/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/strategy/AbstractDiscoveryStrategy.java
+++ b/nexus/nexus-core-plugins/nexus-lvo-plugin/src/main/java/org/sonatype/nexus/plugins/lvo/strategy/AbstractDiscoveryStrategy.java
@@ -19,8 +19,8 @@
 package org.sonatype.nexus.plugins.lvo.strategy;
 
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.nexus.Nexus;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.lvo.DiscoveryStrategy;
 
 /**
@@ -29,7 +29,7 @@ import org.sonatype.nexus.plugins.lvo.DiscoveryStrategy;
  * @author cstamas
  */
 public abstract class AbstractDiscoveryStrategy
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements DiscoveryStrategy
 {
     @Requirement

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>sisu-inject-plexus</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/src/main/webapp/WEB-INF/plexus.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/src/main/webapp/WEB-INF/plexus.xml
@@ -15,7 +15,7 @@
 <plexus>
 
 	<components>
-
+<!--
 		<component>
 			<role>org.codehaus.plexus.logging.LoggerManager</role>
 			<implementation>org.codehaus.plexus.logging.slf4j.Slf4jLoggerManager</implementation>
@@ -23,6 +23,6 @@
 				<threshold>DEBUG</threshold>
 			</configuration>
 		</component>
-
+-->
 	</components>
 </plexus>

--- a/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/DefaultPluginConsoleManager.java
+++ b/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/DefaultPluginConsoleManager.java
@@ -28,9 +28,9 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.NexusPluginManager;
 import org.sonatype.nexus.plugins.PluginResponse;
 import org.sonatype.nexus.plugins.plugin.console.model.DocumentationLink;
@@ -40,7 +40,6 @@ import org.sonatype.nexus.plugins.rest.NexusDocumentationBundle;
 import org.sonatype.nexus.plugins.rest.NexusResourceBundle;
 import org.sonatype.plexus.rest.resource.PlexusResource;
 import org.sonatype.plugin.metadata.GAVCoordinate;
-
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
@@ -49,7 +48,7 @@ import com.google.common.collect.Multimap;
  */
 @Component( role = PluginConsoleManager.class )
 public class DefaultPluginConsoleManager
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements PluginConsoleManager, Initializable
 {
     @Requirement

--- a/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/error/reporting/PluginListErrorReportBundleContentContributor.java
+++ b/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/error/reporting/PluginListErrorReportBundleContentContributor.java
@@ -24,17 +24,16 @@ import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.nexus.error.report.ErrorReportBundleContentContributor;
 import org.sonatype.nexus.error.report.ErrorReportBundleEntry;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.plugin.console.PluginConsoleManager;
 import org.sonatype.nexus.plugins.plugin.console.model.PluginInfo;
-
 import com.thoughtworks.xstream.XStream;
 
 @Component( role = ErrorReportBundleContentContributor.class, hint = "pluginList" )
 public class PluginListErrorReportBundleContentContributor
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements ErrorReportBundleContentContributor
 {
 

--- a/nexus/nexus-logging-extras/pom.xml
+++ b/nexus/nexus-logging-extras/pom.xml
@@ -78,11 +78,6 @@
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-test-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/access/DefaultNexusItemAuthorizer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/access/DefaultNexusItemAuthorizer.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.shiro.subject.Subject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
@@ -39,7 +39,7 @@ import org.sonatype.security.SecuritySystem;
  */
 @Component( role = NexusItemAuthorizer.class )
 public class DefaultNexusItemAuthorizer
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements NexusItemAuthorizer
 {
     @Requirement

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/AbstractStorageFileItemInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/AbstractStorageFileItemInspector.java
@@ -18,7 +18,7 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 
 /**
  * The Class AbstractStorageFileItemInspector is a convenience class for implementing inspectors.
@@ -26,7 +26,7 @@ import org.codehaus.plexus.logging.AbstractLogEnabled;
  * @author cstamas
  */
 public abstract class AbstractStorageFileItemInspector
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements StorageFileItemInspector
 {
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/AbstractStorageItemInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/AbstractStorageItemInspector.java
@@ -20,7 +20,7 @@ package org.sonatype.nexus.proxy.attributes;
 
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 
 /**
  * The Class AbstractStorageFileItemInspector is a convenience class for implementing inspectors.
@@ -30,8 +30,7 @@ import org.codehaus.plexus.logging.Logger;
 public abstract class AbstractStorageItemInspector
     implements StorageItemInspector
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
     
     protected Logger getLogger()
     {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -53,8 +54,7 @@ import org.sonatype.nexus.proxy.storage.local.fs.FileContentLocator;
 public class DefaultAttributesHandler
     implements AttributesHandler
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /**
      * The application configuration.

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageCollectionItem;
@@ -60,8 +61,7 @@ import com.thoughtworks.xstream.XStreamException;
 public class DefaultFSAttributeStorage
     implements AttributeStorage, EventListener, Initializable, Disposable
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationEventMulticaster applicationEventMulticaster;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -26,6 +26,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.IOUtil;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
@@ -59,8 +60,7 @@ public class DefaultLSAttributeStorage
 {
     private static final String ATTRIBUTE_PATH_PREFIX = "/.nexus/attributes";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /** The XStream. */
     private XStream xstream;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
@@ -20,7 +20,7 @@ package org.sonatype.nexus.proxy.cache;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.plexus.components.ehcache.PlexusEhCacheWrapper;
 
 /**
@@ -30,7 +30,7 @@ import org.sonatype.plexus.components.ehcache.PlexusEhCacheWrapper;
  */
 @Component( role = CacheManager.class )
 public class EhCacheCacheManager
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements CacheManager
 {
     @Requirement

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/DefaultHttpProxyService.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/DefaultHttpProxyService.java
@@ -37,6 +37,7 @@ import org.sonatype.nexus.configuration.CoreConfiguration;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.CHttpProxyCoreConfiguration;
 import org.sonatype.nexus.configuration.model.CHttpProxySettings;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.threads.NexusThreadFactory;
 
 /**
@@ -51,8 +52,7 @@ public class DefaultHttpProxyService
 {
     public static final int DEFAULT_TIMEOUT = 20 * 1000;
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/DefaultNexusURLResolver.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/DefaultNexusURLResolver.java
@@ -26,8 +26,8 @@ import org.codehaus.plexus.component.annotations.Configuration;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -41,7 +41,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  */
 @Component(role=NexusURLResolver.class)
 public class DefaultNexusURLResolver
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements NexusURLResolver, Contextualizable
 {
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/HttpProxyHandler.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/http/HttpProxyHandler.java
@@ -25,7 +25,6 @@ import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.URL;
 
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.logging.Logger;
 
 /**
@@ -36,7 +35,6 @@ import org.codehaus.plexus.logging.Logger;
  * @author cstamas
  */
 public class HttpProxyHandler
-    extends AbstractLogEnabled
     implements Runnable
 {
     private HttpProxyService service;
@@ -45,17 +43,24 @@ public class HttpProxyHandler
 
     private final HttpProxyPolicy policy;
 
+    private Logger logger;
+
     public HttpProxyHandler( Logger logger, HttpProxyService service, HttpProxyPolicy policy, Socket socket )
     {
         super();
 
-        enableLogging( logger );
+        this.logger = logger;
 
         this.service = service;
 
         this.policy = policy;
 
         this.socket = socket;
+    }
+
+    protected Logger getLogger()
+    {
+        return logger;
     }
 
     public void run()

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/mapping/DefaultRequestRepositoryMapper.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/mapping/DefaultRequestRepositoryMapper.java
@@ -42,6 +42,7 @@ import org.sonatype.nexus.configuration.model.CPathMappingItem;
 import org.sonatype.nexus.configuration.model.CRepositoryGrouping;
 import org.sonatype.nexus.configuration.model.CRepositoryGroupingCoreConfiguration;
 import org.sonatype.nexus.configuration.validator.ApplicationConfigurationValidator;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventRemove;
@@ -73,8 +74,7 @@ public class DefaultRequestRepositoryMapper
     extends AbstractConfigurable
     implements RequestRepositoryMapper
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
@@ -21,16 +21,16 @@ package org.sonatype.nexus.proxy.maven;
 import java.util.Date;
 import java.util.List;
 
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.nexus.artifact.NexusItemInfo;
 import org.sonatype.nexus.feeds.NexusArtifactEvent;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.StorageException;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 
 public abstract class AbstractChecksumContentValidator
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
 {
 
     public AbstractChecksumContentValidator()

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataManager.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
-
 import java.util.Locale;
 import java.util.TimeZone;
+
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Snapshot;
 import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
@@ -33,8 +33,8 @@ import org.apache.maven.index.artifact.Gav;
 import org.apache.maven.index.artifact.VersionUtils;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.maven.metadata.operations.ModelVersionUtility;
 
 /**
@@ -45,7 +45,7 @@ import org.sonatype.nexus.proxy.maven.metadata.operations.ModelVersionUtility;
  */
 @Component( role = MetadataManager.class )
 public class DefaultMetadataManager
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements MetadataManager
 {
     static final String LATEST_VERSION = "LATEST";

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataUpdater.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataUpdater.java
@@ -29,8 +29,8 @@ import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.apache.maven.index.artifact.Gav;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.item.StorageCollectionItem;
 import org.sonatype.nexus.proxy.maven.metadata.operations.AddPluginOperation;
@@ -47,7 +47,7 @@ import org.sonatype.nexus.proxy.maven.metadata.operations.TimeUtil;
 
 @Component( role = MetadataUpdater.class )
 public class DefaultMetadataUpdater
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements MetadataUpdater
 {
     @Requirement

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MavenFileTypeValidator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MavenFileTypeValidator.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.IOUtil;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.mime.MimeUtil;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.repository.validator.FileTypeValidator;
@@ -47,8 +48,7 @@ import org.sonatype.nexus.proxy.repository.validator.FileTypeValidator;
 public class MavenFileTypeValidator
     implements FileTypeValidator
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private MimeUtil mimeUtil;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryTypeRegistry.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryTypeRegistry.java
@@ -30,6 +30,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.plugins.RepositoryType;
 import org.sonatype.nexus.proxy.maven.maven1.M1GroupRepository;
 import org.sonatype.nexus.proxy.maven.maven1.M1LayoutedM2ShadowRepository;
@@ -48,8 +49,7 @@ import com.google.common.collect.Multimap;
 public class DefaultRepositoryTypeRegistry
     implements RepositoryTypeRegistry
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private PlexusContainer container;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/router/DefaultRepositoryRouter.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/router/DefaultRepositoryRouter.java
@@ -36,6 +36,7 @@ import org.sonatype.nexus.configuration.CoreConfiguration;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.CRouting;
 import org.sonatype.nexus.configuration.model.CRoutingCoreConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.IllegalRequestException;
@@ -71,8 +72,7 @@ public class DefaultRepositoryRouter
     extends AbstractConfigurable
     implements RepositoryRouter
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -50,8 +51,7 @@ public class DefaultFSPeer
 {
     private static final String HIDDEN_TARGET_SUFFIX = ".nx-upload";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     protected Logger getLogger()
     {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistry.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistry.java
@@ -40,6 +40,7 @@ import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.CRepositoryTarget;
 import org.sonatype.nexus.configuration.model.CRepositoryTargetCoreConfiguration;
 import org.sonatype.nexus.configuration.validator.ApplicationConfigurationValidator;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.events.TargetRegistryEventAdd;
 import org.sonatype.nexus.proxy.events.TargetRegistryEventRemove;
 import org.sonatype.nexus.proxy.registry.ContentClass;
@@ -56,8 +57,7 @@ public class DefaultTargetRegistry
     extends AbstractConfigurable
     implements TargetRegistry
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -21,7 +21,7 @@ package org.sonatype.nexus.proxy.walker;
 import java.util.Collection;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
@@ -40,7 +40,7 @@ import org.sonatype.scheduling.TaskInterruptedException;
  */
 @Component( role = Walker.class )
 public class DefaultWalker
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements Walker
 {
     public static final String WALKER_WALKED_COLLECTION_COUNT = Walker.class.getSimpleName() + ".collCount";

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/AbstractRepositoryFolderCleaner.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/AbstractRepositoryFolderCleaner.java
@@ -25,6 +25,7 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.scheduling.TaskUtil;
 
 public abstract class AbstractRepositoryFolderCleaner
@@ -32,8 +33,7 @@ public abstract class AbstractRepositoryFolderCleaner
 {
     public static final String GLOBAL_TRASH_KEY = "trash";
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
@@ -25,6 +25,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -45,8 +46,7 @@ public class DefaultWastebasket
 
     private static final long ALL = -1L;
 
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     protected Logger getLogger()
     {

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractProxyTestEnvironment.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractProxyTestEnvironment.java
@@ -31,10 +31,10 @@ import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.LoggerManager;
 import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.attributes.AttributesHandler;
 import org.sonatype.nexus.proxy.attributes.DefaultFSAttributeStorage;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
@@ -61,7 +61,7 @@ public abstract class AbstractProxyTestEnvironment
 {
 
     /** The logger. */
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     /** The config */
     private ApplicationConfiguration applicationConfiguration;
@@ -211,10 +211,6 @@ public abstract class AbstractProxyTestEnvironment
         throws Exception
     {
         super.setUp();
-
-        LoggerManager loggerManager = getLoggerManager();
-
-        this.logger = loggerManager.getLoggerForComponent( this.getClass().toString() );
 
         applicationConfiguration = lookup( ApplicationConfiguration.class );
 

--- a/nexus/nexus-rest-api/pom.xml
+++ b/nexus/nexus-rest-api/pom.xml
@@ -109,20 +109,6 @@
 
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractArtifactViewProvider.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractArtifactViewProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.restlet.data.Request;
+import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.ResourceStore;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -37,8 +38,7 @@ import org.sonatype.nexus.proxy.router.RequestRoute;
 public abstract class AbstractArtifactViewProvider
     implements ArtifactViewProvider
 {
-    @Requirement
-    private Logger logger;
+    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
     @Requirement
     private RepositoryRouter repositoryRouter;

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ProtectedRepositoryRegistry.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ProtectedRepositoryRegistry.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.access.NexusItemAuthorizer;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
@@ -33,7 +33,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
 
 @Component( role = RepositoryRegistry.class, hint = "protected" )
 public class ProtectedRepositoryRegistry
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements RepositoryRegistry
 {
 

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/feeds/sources/AbstractFeedSource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/feeds/sources/AbstractFeedSource.java
@@ -19,8 +19,8 @@
 package org.sonatype.nexus.rest.feeds.sources;
 
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.sonatype.nexus.Nexus;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 
 /**
@@ -30,7 +30,7 @@ import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
  * @author cstamas
  */
 public abstract class AbstractFeedSource
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements FeedSource
 {
     @Requirement

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/feeds/sources/AbstractNexusItemEventEntryBuilder.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/feeds/sources/AbstractNexusItemEventEntryBuilder.java
@@ -21,15 +21,14 @@ package org.sonatype.nexus.rest.feeds.sources;
 import java.util.Date;
 
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.restlet.data.MediaType;
 import org.sonatype.nexus.Nexus;
 import org.sonatype.nexus.feeds.NexusArtifactEvent;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.access.AccessManager;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.Repository;
-
 import com.sun.syndication.feed.synd.SyndContent;
 import com.sun.syndication.feed.synd.SyndContentImpl;
 import com.sun.syndication.feed.synd.SyndEntry;
@@ -39,7 +38,7 @@ import com.sun.syndication.feed.synd.SyndEntryImpl;
  * @author Juven Xu
  */
 abstract public class AbstractNexusItemEventEntryBuilder
-    extends AbstractLogEnabled
+    extends AbstractLoggingComponent
     implements SyndEntryBuilder<NexusArtifactEvent>
 {
     @Requirement

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/pom.xml
@@ -205,16 +205,9 @@
       <artifactId>jul-to-slf4j</artifactId>
       <scope>compile</scope>
     </dependency>
-    <!-- dependency> <groupId>log4j</groupId> <artifactId>log4j</artifactId> <scope>runtime</scope> </dependency> <dependency>
-      <groupId>org.slf4j</groupId> <artifactId>slf4j-log4j12</artifactId> <scope>runtime</scope> </dependency -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <!-- Deps needed by actual IT modules (like nexus-test-harness-its), and are here just to ease their life (to not have

--- a/nexus/nexus-web-utils/pom.xml
+++ b/nexus/nexus-web-utils/pom.xml
@@ -95,21 +95,6 @@
       <version>${plexus-app-events.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-slf4j-logging</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
   </dependencies>
 

--- a/nexus/nexus-web-utils/src/test/resources/httpunit/WEB-INF/plexus.xml
+++ b/nexus/nexus-web-utils/src/test/resources/httpunit/WEB-INF/plexus.xml
@@ -2,13 +2,6 @@
 
 	<components>
 
-		<component>
-			<role>org.codehaus.plexus.logging.LoggerManager</role>
-			<implementation>org.codehaus.plexus.logging.slf4j.Slf4jLoggerManager</implementation>
-			<configuration>
-				<threshold>DEBUG</threshold>
-			</configuration>
-		</component>
-
 	</components>
+
 </plexus>

--- a/nexus/nexus-webapp/src/main/webapp/WEB-INF/plexus.xml
+++ b/nexus/nexus-webapp/src/main/webapp/WEB-INF/plexus.xml
@@ -21,7 +21,7 @@
 <plexus>
 
 	<components>
-
+<!--
 		<component>
 			<role>org.codehaus.plexus.logging.LoggerManager</role>
 			<implementation>org.codehaus.plexus.logging.slf4j.Slf4jLoggerManager</implementation>
@@ -29,6 +29,7 @@
 				<threshold>DEBUG</threshold>
 			</configuration>
 		</component>
-
+-->
 	</components>
+
 </plexus>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -179,7 +179,6 @@
     <plexus-jetty-testsuite.version>1.7</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18-SNAPSHOT</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
-    <plexus-slf4j-logging.version>1.1</plexus-slf4j-logging.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.4.2</plexus-task-scheduler.version>
     <plexus-velocity.version>1.1.7</plexus-velocity.version>
@@ -421,17 +420,6 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-interpolation</artifactId>
         <version>${plexus-interpolation.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-slf4j-logging</artifactId>
-        <version>${plexus-slf4j-logging.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Consolidate current mess we have in core wrt logging. Realized as "side effect" of working on NEXUS-4521.

What we have here:
- Dropping all the uses of AbstractLogEnabled, switching to AbstractLoggingComponent
- but, since we have classes in core meant to be extended in plugins, keeping "oldie" Plexus logger wherever needed (like AbstractRepository)
