### PR TITLE
NEXUS-4205 - set content validation to true

### DIFF
--- a/nexus/nexus-configuration-model/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfiguration.java
+++ b/nexus/nexus-configuration-model/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfiguration.java
@@ -53,7 +53,7 @@ public abstract class AbstractProxyRepositoryConfiguration
 
     public boolean isFileTypeValidation()
     {
-        return Boolean.valueOf( getNodeValue( getRootNode(), FILE_TYPE_VALIDATION, "false" ) );
+        return Boolean.valueOf( getNodeValue( getRootNode(), FILE_TYPE_VALIDATION, "true" ) );
     }
 
     public void setFileTypeValidation( boolean doValidate )

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/templates/repositories/RepositoryTemplatePlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/templates/repositories/RepositoryTemplatePlexusResource.java
@@ -192,6 +192,7 @@ public class RepositoryTemplatePlexusResource
         repoRes.setDownloadRemoteIndexes( repoCfg.isDownloadRemoteIndex() );
         repoRes.setArtifactMaxAge( repoCfg.getArtifactMaxAge() );
         repoRes.setMetadataMaxAge( repoCfg.getMetadataMaxAge() );
+        repoRes.setFileTypeValidation( repoCfg.isFileTypeValidation() );
 
         return repoRes;
     }


### PR DESCRIPTION
Enable fileTypeValidation by default for new proxy repositories and for the proxy's that ship in the default configuration.
