### PR TITLE
NXCM-3525: create vs update events

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheCreate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheCreate.java
@@ -26,6 +26,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * (create).
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class RepositoryItemEventCacheCreate
     extends RepositoryItemEventCache

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheCreate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheCreate.java
@@ -22,15 +22,16 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * The event fired on item cache (will probably be followed by retrieve!).
+ * The event fired on item cache (will be followed by retrieve!) when overwrite of cached item does not happens
+ * (create).
  * 
  * @author cstamas
  */
-public abstract class RepositoryItemEventCache
-    extends RepositoryItemEvent
+public class RepositoryItemEventCacheCreate
+    extends RepositoryItemEventCache
 {
 
-    public RepositoryItemEventCache( final Repository repository, final StorageItem item )
+    public RepositoryItemEventCacheCreate( final Repository repository, final StorageItem item )
     {
         super( repository, item );
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheUpdate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheUpdate.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * The event fired on item cache (will be followed by retrieve!) when overwrite of cached item happens (update).
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class RepositoryItemEventCacheUpdate
     extends RepositoryItemEventCache

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheUpdate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventCacheUpdate.java
@@ -22,15 +22,15 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * The event fired on item cache (will probably be followed by retrieve!).
+ * The event fired on item cache (will be followed by retrieve!) when overwrite of cached item happens (update).
  * 
  * @author cstamas
  */
-public abstract class RepositoryItemEventCache
-    extends RepositoryItemEvent
+public class RepositoryItemEventCacheUpdate
+    extends RepositoryItemEventCache
 {
 
-    public RepositoryItemEventCache( final Repository repository, final StorageItem item )
+    public RepositoryItemEventCacheUpdate( final Repository repository, final StorageItem item )
     {
         super( repository, item );
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStore.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStore.java
@@ -26,7 +26,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * 
  * @author cstamas
  */
-public class RepositoryItemEventStore
+public abstract class RepositoryItemEventStore
     extends RepositoryItemEvent
 {
 

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreCreate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreCreate.java
@@ -22,15 +22,15 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * The event fired on item cache (will probably be followed by retrieve!).
+ * The event fired on item store when no overwrite happens (create).
  * 
  * @author cstamas
  */
-public abstract class RepositoryItemEventCache
-    extends RepositoryItemEvent
+public class RepositoryItemEventStoreCreate
+    extends RepositoryItemEventStore
 {
 
-    public RepositoryItemEventCache( final Repository repository, final StorageItem item )
+    public RepositoryItemEventStoreCreate( final Repository repository, final StorageItem item )
     {
         super( repository, item );
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreCreate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreCreate.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * The event fired on item store when no overwrite happens (create).
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class RepositoryItemEventStoreCreate
     extends RepositoryItemEventStore

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreUpdate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreUpdate.java
@@ -22,15 +22,15 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * The event fired on item cache (will probably be followed by retrieve!).
+ * The event fired on item store when overwrite happens (update).
  * 
  * @author cstamas
  */
-public abstract class RepositoryItemEventCache
-    extends RepositoryItemEvent
+public class RepositoryItemEventStoreUpdate
+    extends RepositoryItemEventStore
 {
 
-    public RepositoryItemEventCache( final Repository repository, final StorageItem item )
+    public RepositoryItemEventStoreUpdate( final Repository repository, final StorageItem item )
     {
         super( repository, item );
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreUpdate.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEventStoreUpdate.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * The event fired on item store when overwrite happens (update).
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class RepositoryItemEventStoreUpdate
     extends RepositoryItemEventStore

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/Repository.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/Repository.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.configuration.Configurable;
 import org.sonatype.nexus.plugins.RepositoryType;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
+import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.ResourceStore;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.StorageException;
@@ -169,8 +170,10 @@ public interface Repository
      * 
      * @param action
      * @return
+     * @throws StorageException when some storage (IO) problem happens.
      */
-    Action getResultingActionOnWrite( ResourceStoreRequest rsr );
+    Action getResultingActionOnWrite( ResourceStoreRequest rsr ) 
+        throws LocalStorageException;
 
     /**
      * Is the target repository compatible to this one

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -50,6 +50,10 @@ import org.sonatype.nexus.proxy.events.RepositoryEventEvictUnusedItems;
 import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeChanged;
 import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeSet;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCache;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheCreate;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheUpdate;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventStoreCreate;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventStoreUpdate;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
@@ -877,7 +881,16 @@ public abstract class AbstractProxyRepository
                 itemLock.unlock();
             }
 
-            getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventCache( this, result ) );
+            final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
+
+            if ( Action.create.equals( action ) )
+            {
+                getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventCacheCreate( this, result ) );
+            }
+            else
+            {
+                getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventCacheUpdate( this, result ) );
+            }
 
             result.getItemContext().putAll( item.getItemContext() );
         }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -867,6 +867,8 @@ public abstract class AbstractProxyRepository
 
             itemLock.lock( Action.create );
 
+            final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
+
             try
             {
                 getLocalStorage().storeItem( this, item );
@@ -881,7 +883,7 @@ public abstract class AbstractProxyRepository
                 itemLock.unlock();
             }
 
-            final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
+            result.getItemContext().putAll( item.getItemContext() );
 
             if ( Action.create.equals( action ) )
             {
@@ -891,8 +893,6 @@ public abstract class AbstractProxyRepository
             {
                 getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventCacheUpdate( this, result ) );
             }
-
-            result.getItemContext().putAll( item.getItemContext() );
         }
         catch ( ItemNotFoundException ex )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -54,7 +54,8 @@ import org.sonatype.nexus.proxy.events.RepositoryEventLocalStatusChanged;
 import org.sonatype.nexus.proxy.events.RepositoryEventRecreateAttributes;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventDelete;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
-import org.sonatype.nexus.proxy.events.RepositoryItemEventStore;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventStoreCreate;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventStoreUpdate;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.ByteArrayContentLocator;
 import org.sonatype.nexus.proxy.item.ContentGenerator;
@@ -714,28 +715,18 @@ public abstract class AbstractRepository
         return targetRegistry.hasAnyApplicableTarget( this );
     }
 
-    public Action getResultingActionOnWrite( ResourceStoreRequest rsr )
+    public Action getResultingActionOnWrite( final ResourceStoreRequest rsr )
+        throws LocalStorageException
     {
-        try
-        {
-            boolean isInLocalStorage = getLocalStorage().containsItem( this, rsr );
+        final boolean isInLocalStorage = getLocalStorage().containsItem( this, rsr );
 
-            if ( isInLocalStorage )
-            {
-                return Action.update;
-            }
-            else
-            {
-                return Action.create;
-            }
+        if ( isInLocalStorage )
+        {
+            return Action.update;
         }
-        catch ( StorageException e )
+        else
         {
-            getLogger().error(
-                "Could not resolve the local presence of \"" + rsr.getRequestPath() + "\" path in repository ID=\""
-                    + getId() + "\"!", e );
-
-            return null;
+            return Action.create;
         }
     }
 
@@ -1040,7 +1031,16 @@ public abstract class AbstractRepository
         // remove the "request" item from n-cache if there
         removeFromNotFoundCache( item.getResourceStoreRequest() );
 
-        getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventStore( this, item ) );
+        final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
+
+        if ( Action.create.equals( action ) )
+        {
+            getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventStoreCreate( this, item ) );
+        }
+        else
+        {
+            getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventStoreUpdate( this, item ) );
+        }
     }
 
     public Collection<StorageItem> list( boolean fromTask, ResourceStoreRequest request )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1002,6 +1002,8 @@ public abstract class AbstractRepository
 
         uidUploaderLock.lock( Action.create );
 
+        final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
+
         try
         {
             // NEXUS-4550: we are shared-locking the actual UID (to not prevent downloaders while
@@ -1030,8 +1032,6 @@ public abstract class AbstractRepository
 
         // remove the "request" item from n-cache if there
         removeFromNotFoundCache( item.getResourceStoreRequest() );
-
-        final Action action = getResultingActionOnWrite( item.getResourceStoreRequest() );
 
         if ( Action.create.equals( action ) )
         {

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimplePullTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimplePullTest.java
@@ -120,13 +120,20 @@ public class SimplePullTest
         Collection<StorageItem> dir = ( (StorageCollectionItem) item ).list();
         // we should have listed in root only those things/dirs we pulled, se above!
         assertEquals( 4, dir.size() );
+        
+        // SO FAR, IT's OLD Unit test, except CacheCreate events were changed (it was Cache event).
+        // Now below, we add some more, to cover NXCM-3525 too:
 
         // NXCM-3525
-        // Now we expire local cache, and touch the "remote" files and do it again
+        // Now we expire local cache, and touch the "remote" files to make it newer and hence, to
+        // make nexus refetch them and do all the pulls again:
+        
+        // expire caches
         getRepositoryRegistry().getRepository( "repo1" ).expireCaches( new ResourceStoreRequest( "/" ) );
         getRepositoryRegistry().getRepository( "repo2" ).expireCaches( new ResourceStoreRequest( "/" ) );
         getRepositoryRegistry().getRepository( "repo3" ).expireCaches( new ResourceStoreRequest( "/" ) );
 
+        // touch remote files
         final long now = System.currentTimeMillis();
         getRemoteFile( getRepositoryRegistry().getRepository( "repo1" ),
             "/activemq/activemq-core/1.2/activemq-core-1.2.jar" ).setLastModified( now );
@@ -136,6 +143,7 @@ public class SimplePullTest
             now );
         getRemoteFile( getRepositoryRegistry().getRepository( "repo3" ), "/repo3.txt" ).setLastModified( now );
 
+        // and here we go again
         getTestEventListener().reset();
 
         item =

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimplePullTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/SimplePullTest.java
@@ -20,13 +20,13 @@ package org.sonatype.nexus.proxy;
 
 import java.util.Collection;
 
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
-
-import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.jettytestsuite.ServletServer;
 import org.sonatype.nexus.proxy.access.Action;
-import org.sonatype.nexus.proxy.events.RepositoryItemEventCache;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheCreate;
+import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheUpdate;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
 import org.sonatype.nexus.proxy.item.StorageCollectionItem;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
@@ -62,18 +62,20 @@ public class SimplePullTest
                     new ResourceStoreRequest(
                         "/repositories/repo1/activemq/activemq-core/1.2/broken/activemq-core-1.2", false ) );
 
-            fail();
+            Assert.fail( "We should not be able to pull this path!" );
         }
         catch ( ItemNotFoundException e )
         {
             // good, the layout says this is not a file!
         }
 
+        getTestEventListener().reset();
+
         item =
             getRootRouter().retrieveItem(
                 new ResourceStoreRequest( "/repositories/repo1/activemq/activemq-core/1.2/activemq-core-1.2.jar", false ) );
         checkForFileAndMatchContents( item );
-        assertEquals( RepositoryItemEventCache.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventCacheCreate.class, getTestEventListener().getFirstEvent().getClass() );
         assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
         getTestEventListener().reset();
 
@@ -81,7 +83,7 @@ public class SimplePullTest
             getRootRouter().retrieveItem(
                 new ResourceStoreRequest( "/repositories/repo2/xstream/xstream/1.2.2/xstream-1.2.2.pom", false ) );
         checkForFileAndMatchContents( item );
-        assertEquals( RepositoryItemEventCache.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventCacheCreate.class, getTestEventListener().getFirstEvent().getClass() );
         assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
         getTestEventListener().reset();
 
@@ -104,13 +106,13 @@ public class SimplePullTest
         item =
             getRootRouter().retrieveItem( new ResourceStoreRequest( "/groups/test/rome/rome/0.9/rome-0.9.pom", false ) );
         checkForFileAndMatchContents( item );
-        assertEquals( RepositoryItemEventCache.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventCacheCreate.class, getTestEventListener().getFirstEvent().getClass() );
         assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
         getTestEventListener().reset();
 
         item = getRootRouter().retrieveItem( new ResourceStoreRequest( "/groups/test/repo3.txt", false ) );
         checkForFileAndMatchContents( item );
-        assertEquals( RepositoryItemEventCache.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventCacheCreate.class, getTestEventListener().getFirstEvent().getClass() );
         assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
         getTestEventListener().reset();
 
@@ -118,6 +120,69 @@ public class SimplePullTest
         Collection<StorageItem> dir = ( (StorageCollectionItem) item ).list();
         // we should have listed in root only those things/dirs we pulled, se above!
         assertEquals( 4, dir.size() );
+
+        // NXCM-3525
+        // Now we expire local cache, and touch the "remote" files and do it again
+        getRepositoryRegistry().getRepository( "repo1" ).expireCaches( new ResourceStoreRequest( "/" ) );
+        getRepositoryRegistry().getRepository( "repo2" ).expireCaches( new ResourceStoreRequest( "/" ) );
+        getRepositoryRegistry().getRepository( "repo3" ).expireCaches( new ResourceStoreRequest( "/" ) );
+
+        final long now = System.currentTimeMillis();
+        getRemoteFile( getRepositoryRegistry().getRepository( "repo1" ),
+            "/activemq/activemq-core/1.2/activemq-core-1.2.jar" ).setLastModified( now );
+        getRemoteFile( getRepositoryRegistry().getRepository( "repo1" ), "/rome/rome/0.9/rome-0.9.pom" ).setLastModified(
+            now );
+        getRemoteFile( getRepositoryRegistry().getRepository( "repo2" ), "/xstream/xstream/1.2.2/xstream-1.2.2.pom" ).setLastModified(
+            now );
+        getRemoteFile( getRepositoryRegistry().getRepository( "repo3" ), "/repo3.txt" ).setLastModified( now );
+
+        getTestEventListener().reset();
+
+        item =
+            getRootRouter().retrieveItem(
+                new ResourceStoreRequest( "/repositories/repo1/activemq/activemq-core/1.2/activemq-core-1.2.jar", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventCacheUpdate.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
+        getTestEventListener().reset();
+
+        item =
+            getRootRouter().retrieveItem(
+                new ResourceStoreRequest( "/repositories/repo2/xstream/xstream/1.2.2/xstream-1.2.2.pom", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventCacheUpdate.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
+        getTestEventListener().reset();
+
+        item =
+            getRootRouter().retrieveItem(
+                new ResourceStoreRequest( "/groups/test/activemq/activemq-core/1.2/activemq-core-1.2.jar", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( 2, getTestEventListener().getEvents().size() );
+        getTestEventListener().reset();
+
+        item =
+            getRootRouter().retrieveItem(
+                new ResourceStoreRequest( "/groups/test/xstream/xstream/1.2.2/xstream-1.2.2.pom", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( 2, getTestEventListener().getEvents().size() );
+        getTestEventListener().reset();
+
+        item =
+            getRootRouter().retrieveItem( new ResourceStoreRequest( "/groups/test/rome/rome/0.9/rome-0.9.pom", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventCacheUpdate.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
+        getTestEventListener().reset();
+
+        item = getRootRouter().retrieveItem( new ResourceStoreRequest( "/groups/test/repo3.txt", false ) );
+        checkForFileAndMatchContents( item );
+        assertEquals( RepositoryItemEventCacheUpdate.class, getTestEventListener().getFirstEvent().getClass() );
+        assertEquals( RepositoryItemEventRetrieve.class, getTestEventListener().getLastEvent().getClass() );
+        getTestEventListener().reset();
+
     }
 
     @Test


### PR DESCRIPTION
Adding possibility to have events distinct between create vs update content changes.
## Before this change

Hosted:
- GET: RepositoryItemEventRetrieve
- PUT: RepositoryItemEventStore
- DELETE: RepositoryItemEventDelete

Proxy:
- GET (and not proxying happens): RepositoryItemEventRetrieve
- GET (and proxying happens because it's asked first time): RepositoryItemEventCache, RepositoryItemEventRetrieve
- GET (and proxying happens because it's stale and new remote version exists): RepositoryItemEventCache,RepositoryItemEventRetrieve
## After

Hosted:
- GET: RepositoryItemEventRetrieve
- PUT (create): RepositoryItemEventStoreCreate
- PUT (update): RepositoryItemEventStoreUpdate
- DELETE: RepositoryItemEventDelete

Proxy:
- GET (and not proxying happens): RepositoryItemEventRetrieve
- GET (and proxying happens because it's asked first time): RepositoryItemEventCacheCreate, RepositoryItemEventRetrieve
- GET (and proxying happens because it's stale and new remote version exists): RepositoryItemEventCacheUpdate,RepositoryItemEventRetrieve
