### PR TITLE
NEXUS-4627: downgradeable locks

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SimpleLockResource.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/SimpleLockResource.java
@@ -21,7 +21,7 @@ package org.sonatype.nexus.proxy.item;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Before you continue using this class, stop and read carefully it's description. This "smart" lock is NOT an improved
+ * Before you continue using this class, stop and read carefully its description. This "smart" lock is NOT an improved
  * implementation of Java's ReentrantReadWriteLock in any way. It does NOT implement the unsupported atomic
  * lock-upgrade. All this class allows is following pattern:
  * 
@@ -42,11 +42,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *   }
  * </pre>
  * 
- * So, it is all about being able of "boxing" the locks.
+ * So, it is all about being able to "box" the locks.
  * <p>
- * Caveat No 1: Once you "upgrade" from shared to exclusive lock, you will possess exclusive lock as long as your last
- * {@link #unlock()} is invoked! While this is not totally correct or natural with "expectations", it does fit it's
- * purpose for use in Nexus.
+ * Caveat No 1: When a lock is "upgraded" from shared to exclusive, it remains exclusive until the matching unlock.
+ * <p>
+ * Previous behaviour: <s>Once you "upgrade" from shared to exclusive lock, you will possess exclusive lock as long as
+ * your last {@link #unlock()} is invoked! While this is not totally correct or natural with "expectations", it does fit
+ * it's purpose for use in Nexus.</s>
  * <p>
  * Caveat No 2: The "upgrade" is not atomic, and it is actually not even meant to be atomic. If you take a peek at
  * implementation, by acquiring an exclusive lock, you actually give away all your shared locks, and just then tries to
@@ -56,7 +58,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * 
  * @author cstamas
  */
-class SimpleLockResource
+final class SimpleLockResource
     implements LockResource
 {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -64,9 +66,9 @@ class SimpleLockResource
     @Override
     public void lockShared()
     {
-        if ( lock.getWriteHoldCount() > 0 )
+        if ( lock.isWriteLockedByCurrentThread() )
         {
-            lockExclusively();
+            lock.writeLock().lock();
         }
         else
         {
@@ -77,21 +79,29 @@ class SimpleLockResource
     @Override
     public void lockExclusively()
     {
-        final int readLockCount = lock.getReadHoldCount();
+        // if we already have exclusive lock then we don't need to upgrade...
+        final int readHoldCount = lock.isWriteLockedByCurrentThread() ? 0 : lock.getReadHoldCount();
 
-        for ( int i = 0; i < readLockCount; i++ )
+        if ( readHoldCount > 0 )
         {
-            lock.readLock().unlock();
+            // upgrading: must release all read locks
+            for ( int i = 0; i < readHoldCount; i++ )
+            {
+                lock.readLock().unlock();
+            }
+
+            Thread.yield(); // fairness
         }
 
-        if ( readLockCount > 0 )
-        {
-            Thread.yield();
-        }
+        lock.writeLock().lock();
 
-        for ( int i = 0; i < readLockCount + 1; i++ )
+        if ( readHoldCount > 0 )
         {
-            lock.writeLock().lock();
+            // re-acquire so downgrade works later on
+            for ( int i = 0; i < readHoldCount; i++ )
+            {
+                lock.readLock().lock();
+            }
         }
     }
 
@@ -111,11 +121,7 @@ class SimpleLockResource
     @Override
     public boolean hasLocksHeld()
     {
-        final int reads = lock.getReadHoldCount();
-
-        final int writes = lock.getWriteHoldCount();
-
-        return ( reads + writes ) != 0;
+        return lock.isWriteLockedByCurrentThread() || lock.getReadHoldCount() > 0;
     }
 
     // ==
@@ -123,6 +129,7 @@ class SimpleLockResource
     /**
      * Mainly for debug purposes, see DefaultRepositoryItemUidTest UT how is this used to verify conditions.
      */
+    @Override
     public String toString()
     {
         return lock.toString();

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/AbstractLockResourceTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/AbstractLockResourceTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.item;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonatype.nexus.proxy.access.Action;
+
+public abstract class AbstractLockResourceTest
+{
+    private ExecutorService executor;
+
+    @Before
+    public void prepare()
+    {
+        executor = Executors.newFixedThreadPool( 5 );
+    }
+
+    protected abstract RepositoryItemUidLock getLockResource( final String name );
+
+    /**
+     * Testing shared access: we lock the resource using shared lock, spawn two shared locking threads and we expect
+     * that all of those finish their work before we do.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void sharedLockIsSharedAccess()
+        throws Exception
+    {
+        final RepositoryItemUidLock slr = getLockResource( "foo" );
+
+        final LockResourceRunnable r1 = new LockResourceRunnable( null, slr, Action.read );
+        final LockResourceRunnable r2 = new LockResourceRunnable( null, slr, Action.read );
+
+        slr.lock( Action.read );
+
+        long unlockTs = -1;
+
+        try
+        {
+            executor.execute( r1 );
+            executor.execute( r2 );
+
+            Thread.sleep( 100 );
+
+            unlockTs = System.currentTimeMillis();
+        }
+        finally
+        {
+            slr.unlock();
+        }
+
+        executor.shutdown();
+        executor.awaitTermination( 1000, TimeUnit.MILLISECONDS );
+
+        assertThat( r1.getDoneTs(), lessThanOrEqualTo( unlockTs ) );
+        assertThat( r2.getDoneTs(), lessThanOrEqualTo( unlockTs ) );
+    }
+
+    /**
+     * Testing exclusive access: we lock the resource using exclusive lock, spawn two shared locking threads and we
+     * expect that all of those finish their work after we do.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void exclusiveLockIsNotSharedAccess()
+        throws Exception
+    {
+        final RepositoryItemUidLock slr = getLockResource( "foo" );
+
+        final LockResourceRunnable r1 = new LockResourceRunnable( null, slr, Action.read );
+        final LockResourceRunnable r2 = new LockResourceRunnable( null, slr, Action.read );
+
+        slr.lock( Action.create );
+
+        long unlockTs = -1;
+
+        try
+        {
+            executor.execute( r1 );
+            executor.execute( r2 );
+
+            Thread.sleep( 100 );
+
+            unlockTs = System.currentTimeMillis();
+        }
+        finally
+        {
+            slr.unlock();
+        }
+
+        executor.shutdown();
+        executor.awaitTermination( 1000, TimeUnit.MILLISECONDS );
+
+        assertThat( r1.getDoneTs(), greaterThanOrEqualTo( unlockTs ) );
+        assertThat( r2.getDoneTs(), greaterThanOrEqualTo( unlockTs ) );
+    }
+
+    /**
+     * Testing lock downgrading: we lock the resource using shared lock, then using exclusive lock, spawn two shared
+     * locking threads (that should block since we have exclusive lock), then we unlock (releasing the exclusive lock)
+     * and we expect that all of those finish their work before we do.
+     * <p>
+     * Note: before downgradeable locks, this UT would fail, since after upgrade, exclusive lock would be released on
+     * last unlock invocation. Having this test passing shows that downgrade does happen.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void downgradeLockEnabledSharedAccess()
+        throws Exception
+    {
+        final RepositoryItemUidLock slr = getLockResource( "foo" );
+
+        final LockResourceRunnable r1 = new LockResourceRunnable( null, slr, Action.read );
+        final LockResourceRunnable r2 = new LockResourceRunnable( null, slr, Action.read );
+
+        slr.lock( Action.read );
+
+        long unlockTs = -1;
+
+        try
+        {
+            slr.lock( Action.create );
+
+            try
+            {
+                executor.execute( r1 );
+                executor.execute( r2 );
+            }
+            finally
+            {
+                slr.unlock();
+            }
+
+            Thread.sleep( 100 );
+
+            unlockTs = System.currentTimeMillis();
+        }
+        finally
+        {
+            slr.unlock();
+        }
+
+        executor.shutdown();
+        executor.awaitTermination( 1000, TimeUnit.MILLISECONDS );
+
+        assertThat( r1.getDoneTs(), lessThanOrEqualTo( unlockTs ) );
+        assertThat( r2.getDoneTs(), lessThanOrEqualTo( unlockTs ) );
+    }
+
+    /**
+     * A simple static class that takes a lock and does something with it.
+     * 
+     * @author cstamas
+     */
+    public static class LockResourceRunnable
+        implements Runnable
+    {
+        private final Runnable runnable;
+
+        private final RepositoryItemUidLock uidLock;
+
+        private final Action action;
+
+        private long doneTs;
+
+        public LockResourceRunnable( final Runnable runnable, final RepositoryItemUidLock lockResource,
+                                     final Action action )
+        {
+            this.runnable = runnable;
+            this.uidLock = lockResource;
+            this.action = action;
+            this.doneTs = -1;
+        }
+
+        public long getDoneTs()
+        {
+            return doneTs;
+        }
+
+        @Override
+        public void run()
+        {
+            uidLock.lock( action );
+
+            try
+            {
+                if ( runnable != null )
+                {
+                    runnable.run();
+                }
+            }
+            finally
+            {
+                uidLock.unlock();
+            }
+
+            doneTs = System.currentTimeMillis();
+        }
+    }
+
+}

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SimpleLockResourceTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SimpleLockResourceTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.item;
+
+/**
+ * Test using Nexus' internal SimpleLockResource implementation.
+ * 
+ * @author cstamas
+ */
+public class SimpleLockResourceTest
+    extends AbstractLockResourceTest
+{
+
+    @Override
+    protected RepositoryItemUidLock getLockResource( final String key )
+    {
+        return new DefaultRepositoryItemUidLock( key, new SimpleLockResource() );
+    }
+
+}

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SisuLockResourceTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/item/SisuLockResourceTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.item;
+
+import org.junit.After;
+import org.sonatype.sisu.locks.LocalResourceLockFactory;
+import org.sonatype.sisu.locks.ResourceLockFactory;
+
+/**
+ * Test using SISU Locks LocalResourceLockFactory and it's created locks.
+ * 
+ * @author cstamas
+ */
+public class SisuLockResourceTest
+    extends AbstractLockResourceTest
+{
+    protected ResourceLockFactory resourceLockFactory = new LocalResourceLockFactory();
+
+    @Override
+    protected RepositoryItemUidLock getLockResource( final String key )
+    {
+        return new DefaultRepositoryItemUidLock( key, new SisuLockResource( resourceLockFactory.getResourceLock( key ) ) );
+    }
+
+    @After
+    public void shutdownLockFactory()
+    {
+        resourceLockFactory.shutdown();
+    }
+
+}


### PR DESCRIPTION
This pull request contains following:
- merge of Stuart's change wrt "downgrades", making it actually happening
- added two tests (one for Nexus' SimpleResourceLock and one for SISU Local locks) verifying downgrade _is happening_.
- adjusted existing SimpleLockResourceLRTest wrt it's -- obsolete now -- expectations about locks _not downgrading_.

This pull is just here to be reviewed, is not to be merged yet, since local validation still remains!

Latest what happened:
- rebase against _latest master_ since it has build problems fixed.
- build of this branch _UT/IT_ passes locally on my mac
