### PR TITLE
NXCM-3427 - If login return 403 then automatically execute logout routine

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/authentication/NexusLoginPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/authentication/NexusLoginPlexusResource.java
@@ -42,9 +42,10 @@ import org.sonatype.security.rest.model.AuthenticationLoginResourceResponse;
 @Component( role = PlexusResource.class, hint = "LoginPlexusResource" )
 @Path( AbstractLoginPlexusResource.RESOURCE_URI )
 @Produces( { "application/xml", "application/json" } )
-public class NexusLogingPlexusResource
+public class NexusLoginPlexusResource
     extends AbstractLoginPlexusResource
 {
+
     @Override
     public PathProtectionDescriptor getResourceProtection()
     {

--- a/nexus/nexus-webapp/src/main/webapp/js/Sonatype.utils.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/Sonatype.utils.js
@@ -791,6 +791,18 @@
               {
                 Sonatype.repoServer.RepoServer.loginForm.find('name', 'password')[0].focus(true);
               }
+              
+              Ext.Ajax.request({
+                  scope : this,
+                  method : 'GET',
+                  url : Sonatype.config.repos.urls.logout,
+                  callback : function(options, success, response) {
+                	Sonatype.utils.clearCookie('JSESSIONID');
+                    Sonatype.utils.authToken = null;
+                    Sonatype.view.justLoggedOut = true;
+                  }
+                });
+              
             }
 
           });


### PR DESCRIPTION
If a user lacks "Login to UI" priv, they will essentially get a 403 from authentication/login resource when providing valid username and password.  But refreshing screen will present as logged in

To minimize risk:
If 403 received from authentication/login, keep all existing behaviour, but send a logout request to backend immediately and clear client session cookie in browser.
