### PR TITLE
Support plain text content inside Nexus repositories

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ContentPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ContentPlexusResource.java
@@ -61,6 +61,9 @@ public class ContentPlexusResource
         // default this presentation to HTML to enable user browsing
         result.add( 0, new Variant( MediaType.TEXT_HTML ) );
 
+        // also support plain text content inside Nexus repositories
+        result.add( new Variant( MediaType.TEXT_PLAIN ) );
+
         return result;
     }
 


### PR DESCRIPTION
This is needed for NuGet support... the VisualStudio client will occasionally send an HTTP GET for a count of the number of updated packages with the Accept header set to "text/plain". The NuGet repository has a content generator that can respond to this request, but because this media-type is not in the list of variants supplied by the ContentPlexusResource we never receive the request (and the client gets a 406).

This is the fix I've been using locally, if there's a better / more correct way to support this I'm happy to use that.
