### PR TITLE
Capabilities lifecycle related changes

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/NexusInitializedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/NexusInitializedEvent.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.events;
+
+/**
+ * The event that is fired as last step of nexus initialization process.
+ * 
+ * @author cstamas
+ */
+public class NexusInitializedEvent
+    extends NexusStateChangeEvent
+{
+    public NexusInitializedEvent( Object sender )
+    {
+        super( sender );
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/NexusInitializedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/NexusInitializedEvent.java
@@ -20,8 +20,6 @@ package org.sonatype.nexus.proxy.events;
 
 /**
  * The event that is fired as last step of nexus initialization process.
- * 
- * @author cstamas
  */
 public class NexusInitializedEvent
     extends NexusStateChangeEvent

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
@@ -63,6 +63,7 @@ import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.NoSuchResourceStoreException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.StorageException;
+import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
 import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
 import org.sonatype.nexus.proxy.item.StorageItem;
@@ -553,6 +554,8 @@ public class DefaultNexus
         applicationStatusSource.getSystemStatus().setOperationMode( OperationMode.STANDALONE );
 
         applicationStatusSource.getSystemStatus().setInitializedAt( new Date() );
+
+        applicationEventMulticaster.notifyEventListeners( new NexusInitializedEvent( this ) );
     }
 
     public void start()

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/Capability.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/Capability.java
@@ -23,14 +23,60 @@ import java.util.Map;
 public interface Capability
 {
 
+    /**
+     * Returns an unique capability identifier.
+     *
+     * @return identifier
+     */
     String id();
 
+    /**
+     * Callback when a new capability is created.
+     *
+     * @param properties capability configuration
+     */
     void create( Map<String, String> properties );
 
+    /**
+     * Callback when a capability configuration is loaded from persisted store (configuration file).
+     *
+     * @param properties capability configuration
+     */
     void load( Map<String, String> properties );
 
+    /**
+     * Callback when a capability configuration is updated.
+     *
+     * @param properties capability configuration
+     */
     void update( Map<String, String> properties );
 
+    /**
+     * Callback when a capability is removed.
+     */
     void remove();
+
+    /**
+     * Capability life cycle. Optionally to be implemented by capabilities that need to react on activation /
+     * passivation.
+     *
+     * @since 1.10.0
+     */
+    static interface LifeCycle
+    {
+
+        /**
+         * Callback when capability is activated. Activation is triggered on create/load (if capability is not disabled)
+         * , or when capability is re-enabled.
+         */
+        void activate();
+
+        /**
+         * Callback when capability is passivated. Passivation will be triggered before a capability is removed, on
+         * Nexus shutdown or when capability is disabled.
+         */
+        void passivate();
+
+    }
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityRegistry.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityRegistry.java
@@ -18,15 +18,54 @@
  */
 package org.sonatype.nexus.plugins.capabilities.api;
 
+import java.util.Collection;
+
+/**
+ * Registry of current configured capabilities.
+ */
 public interface CapabilityRegistry
 {
 
+    /**
+     * Adds a capability to registry.
+     *
+     * @param capability to add
+     */
     void add( Capability capability );
 
+    /**
+     * Removed a capability from registry. If there is no capability with specified id in the registry it will pass
+     * silently.
+     *
+     * @param capabilityId to remove
+     */
     void remove( String capabilityId );
 
+    /**
+     * Retrieves the capability from registry with specified id. If there is no capability with specified id in the
+     * registry it will return null.
+     *
+     * @param capabilityId to retrieve
+     * @return capability with specified id or null if not found
+     */
     Capability get( String capabilityId );
 
+    /**
+     * Retrieves all capabilities from registry. If no capability exists, result will be empty.
+     *
+     * @return collection of capabilities, never null
+     * @since 1.10.0
+     */
+    Collection<Capability> getAll();
+
+    /**
+     * Creates a capability given its id/type. if there is no capability available for specified type it will throw an
+     * runtime exception.
+     *
+     * @param capabilityId   id of capability to be created
+     * @param capabilityType type of capability to be created
+     * @return created capability
+     */
     Capability create( String capabilityId, String capabilityType );
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
@@ -18,9 +18,11 @@
  */
 package org.sonatype.nexus.plugins.capabilities.internal;
 
+import static java.lang.String.format;
+
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -59,6 +61,12 @@ public class DefaultCapabilityRegistry
         return capabilities.get( capabilityId );
     }
 
+    @Override
+    public Collection<Capability> getAll()
+    {
+        return capabilities.values();
+    }
+
     public void remove( final String capabilityId )
     {
         capabilities.remove( capabilityId );
@@ -71,7 +79,7 @@ public class DefaultCapabilityRegistry
         final CapabilityFactory factory = factories.get( capabilityType );
         if ( factory == null )
         {
-            throw new RuntimeException( String.format( "No factory found for a capability of type %s", capabilityType ) );
+            throw new RuntimeException( format( "No factory found for a capability of type %s", capabilityType ) );
         }
 
         final Capability capability = factory.create( capabilityId );

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspector.java
@@ -87,6 +87,10 @@ public class CapabilityConfigurationEventInspector
         final Capability capability = registry.create( capabilityConfig.getId(), capabilityConfig.getTypeId() );
         registry.add( capability );
         capability.create( asMap( capabilityConfig.getProperties() ) );
+        if ( capability instanceof Capability.LifeCycle )
+        {
+            ( (Capability.LifeCycle) capability ).activate();
+        }
     }
 
     private void handle( final CapabilityConfigurationLoadEvent evt )
@@ -95,6 +99,10 @@ public class CapabilityConfigurationEventInspector
         final Capability capability = registry.create( capabilityConfig.getId(), capabilityConfig.getTypeId() );
         registry.add( capability );
         capability.load( asMap( capabilityConfig.getProperties() ) );
+        if ( capability instanceof Capability.LifeCycle )
+        {
+            ( (Capability.LifeCycle) capability ).activate();
+        }
     }
 
     private void handle( final CapabilityConfigurationUpdateEvent evt )
@@ -114,6 +122,10 @@ public class CapabilityConfigurationEventInspector
         if ( capability != null )
         {
             registry.remove( capability.id() );
+            if ( capability instanceof Capability.LifeCycle )
+            {
+                ( (Capability.LifeCycle) capability ).passivate();
+            }
             capability.remove();
         }
     }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusInitializedEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusInitializedEventInspector.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.capabilities.internal.config;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
+import org.sonatype.plexus.appevents.Event;
+
+@Singleton
+public class NexusInitializedEventInspector
+    implements EventInspector
+{
+
+    private final CapabilityConfiguration capabilitiesConfiguration;
+
+    @Inject
+    public NexusInitializedEventInspector( final CapabilityConfiguration capabilitiesConfiguration )
+    {
+        this.capabilitiesConfiguration = capabilitiesConfiguration;
+    }
+
+    public boolean accepts( final Event<?> evt )
+    {
+        return evt != null
+            && evt instanceof NexusInitializedEvent;
+    }
+
+    public void inspect( final Event<?> evt )
+    {
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
+        try
+        {
+            capabilitiesConfiguration.load();
+        }
+        catch ( final Exception e )
+        {
+            throw new RuntimeException( "Could not load configurations", e );
+        }
+    }
+
+}

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusStoppedEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusStoppedEventInspector.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.capabilities.internal.config;
+
+import java.util.ArrayList;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.plugins.capabilities.api.Capability;
+import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+import org.sonatype.plexus.appevents.Event;
+
+@Singleton
+public class NexusStoppedEventInspector
+    extends AbstractLoggingComponent
+    implements EventInspector
+{
+
+    private final CapabilityRegistry registry;
+
+    @Inject
+    public NexusStoppedEventInspector( final CapabilityRegistry registry )
+    {
+        this.registry = registry;
+    }
+
+    public boolean accepts( final Event<?> evt )
+    {
+        return evt != null
+            && evt instanceof NexusStoppedEvent;
+    }
+
+    public void inspect( final Event<?> evt )
+    {
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
+        for ( final Capability capability : new ArrayList<Capability>( registry.getAll() ) )
+        {
+            if ( capability instanceof Capability.LifeCycle )
+            {
+                try
+                {
+                    ( (Capability.LifeCycle) capability ).passivate();
+                }
+                catch ( Exception e )
+                {
+                    getLogger().error(
+                        "Could not passivate capability with id '{}' ({})",
+                        new Object[]{ capability.id(), capability, e }
+                    );
+                }
+            }
+        }
+    }
+
+}

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/test/NexusInitializedEventInspectorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/test/NexusInitializedEventInspectorTest.java
@@ -16,48 +16,27 @@
  * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
  * All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.capabilities.internal.config;
+package org.sonatype.nexus.plugins.capabilities.internal.config.test;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import org.sonatype.nexus.proxy.events.EventInspector;
-import org.sonatype.nexus.proxy.events.NexusStartedEvent;
-import org.sonatype.plexus.appevents.Event;
+import org.junit.Test;
+import org.sonatype.nexus.plugins.capabilities.internal.config.CapabilityConfiguration;
+import org.sonatype.nexus.plugins.capabilities.internal.config.NexusInitializedEventInspector;
+import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
 
-@Singleton
-public class NexusStartedEventInspector
-    implements EventInspector
+public class NexusInitializedEventInspectorTest
 {
 
-    private final CapabilityConfiguration capabilitiesConfiguration;
-
-    @Inject
-    public NexusStartedEventInspector( final CapabilityConfiguration capabilitiesConfiguration )
+    @Test
+    public void capabilitiesAreLoadedWhenNexusIsInitialized()
+        throws Exception
     {
-        this.capabilitiesConfiguration = capabilitiesConfiguration;
-    }
+        final CapabilityConfiguration capabilityConfiguration = mock( CapabilityConfiguration.class );
+        new NexusInitializedEventInspector( capabilityConfiguration ).inspect( new NexusInitializedEvent( this ) );
 
-    public boolean accepts( final Event<?> evt )
-    {
-        return evt != null
-            && evt instanceof NexusStartedEvent;
-    }
-
-    public void inspect( final Event<?> evt )
-    {
-        if ( !accepts( evt ) )
-        {
-            return;
-        }
-        try
-        {
-            capabilitiesConfiguration.load();
-        }
-        catch ( final Exception e )
-        {
-            throw new RuntimeException( "Could not load configurations", e );
-        }
+        verify( capabilityConfiguration ).load();
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/test/NexusStoppedEventInspectorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/test/NexusStoppedEventInspectorTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.capabilities.internal.config.test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.sonatype.nexus.plugins.capabilities.api.Capability;
+import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
+import org.sonatype.nexus.plugins.capabilities.internal.config.NexusStoppedEventInspector;
+import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+
+public class NexusStoppedEventInspectorTest
+{
+
+    @Test
+    public void capabilitiesArePassivated()
+        throws Exception
+    {
+        final Capability capability1 = mock( Capability.class );
+        final TestCapability capability2 = mock( TestCapability.class );
+        when( capability2.id() ).thenReturn( "capability-2" );
+        doThrow( new RuntimeException( "something went wrong" ) ).when( capability2 ).passivate();
+        final TestCapability capability3 = mock( TestCapability.class );
+        final CapabilityRegistry capabilityRegistry = mock( CapabilityRegistry.class );
+        when( capabilityRegistry.getAll() ).thenReturn( Arrays.asList( capability1, capability2, capability3 ) );
+
+        new NexusStoppedEventInspector( capabilityRegistry ).inspect( new NexusStoppedEvent( this ) );
+
+        verify( capability2 ).passivate();
+        verify( capability3 ).passivate();
+    }
+
+    private static interface TestCapability
+        extends Capability, Capability.LifeCycle
+    {
+
+    }
+
+}


### PR DESCRIPTION
Smart proxy and capabilities in general needs a way to be activated/deactivated
Also capabilities should be loaded early before nexus components start emitting events (this is needed by smart proxy to catch all item events)
