### PR TITLE
Passivate on nexus stop

### DIFF
--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/AbstractCapability.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/AbstractCapability.java
@@ -20,7 +20,10 @@ package org.sonatype.nexus.plugins.capabilities.api;
 
 import java.util.Map;
 
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+
 public abstract class AbstractCapability
+    extends AbstractLoggingComponent
     implements Capability
 {
 

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityReference.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityReference.java
@@ -16,27 +16,38 @@
  * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
  * All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.capabilities.internal.config.test;
+package org.sonatype.nexus.plugins.capabilities.api;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import org.junit.Test;
-import org.sonatype.nexus.plugins.capabilities.internal.config.CapabilityConfiguration;
-import org.sonatype.nexus.plugins.capabilities.internal.config.NexusInitializedEventInspector;
-import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
-
-public class NexusInitializedEventInspectorTest
+/**
+ * Reference to a capability and its state.
+ *
+ * @since 1.10.0
+ */
+public interface CapabilityReference
 {
 
-    @Test
-    public void capabilitiesAreLoadedWhenNexusIsInitialized()
-        throws Exception
-    {
-        final CapabilityConfiguration capabilityConfiguration = mock( CapabilityConfiguration.class );
-        new NexusInitializedEventInspector( capabilityConfiguration ).inspect( new NexusInitializedEvent( this ) );
+    /**
+     * Returns referenced capability.
+     *
+     * @return referenced capability
+     */
+    Capability capability();
 
-        verify( capabilityConfiguration ).load();
-    }
+    /**
+     * Whether the referenced capability is active.
+     *
+     * @return true, if capability was activated and not yet passivated
+     */
+    boolean isActive();
+
+    /**
+     * Activates the referenced capability.
+     */
+    void activate();
+
+    /**
+     * Passivate the referenced capability.
+     */
+    void passivate();
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityRegistry.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/api/CapabilityRegistry.java
@@ -27,19 +27,25 @@ public interface CapabilityRegistry
 {
 
     /**
-     * Adds a capability to registry.
+     * Creates a capability given its id/type. if there is no capability available for specified type it will throw an
+     * runtime exception.
      *
-     * @param capability to add
+     * @param capabilityId   id of capability to be created
+     * @param capabilityType type of capability to be created
+     * @return created capability
+     * @since 1.10.0
      */
-    void add( Capability capability );
+    CapabilityReference create( String capabilityId, String capabilityType );
 
     /**
      * Removed a capability from registry. If there is no capability with specified id in the registry it will pass
      * silently.
      *
      * @param capabilityId to remove
+     * @return removed capability (if any), null otherwise
+     * @since 1.10.0
      */
-    void remove( String capabilityId );
+    CapabilityReference remove( String capabilityId );
 
     /**
      * Retrieves the capability from registry with specified id. If there is no capability with specified id in the
@@ -47,8 +53,9 @@ public interface CapabilityRegistry
      *
      * @param capabilityId to retrieve
      * @return capability with specified id or null if not found
+     * @since 1.10.0
      */
-    Capability get( String capabilityId );
+    CapabilityReference get( String capabilityId );
 
     /**
      * Retrieves all capabilities from registry. If no capability exists, result will be empty.
@@ -56,16 +63,6 @@ public interface CapabilityRegistry
      * @return collection of capabilities, never null
      * @since 1.10.0
      */
-    Collection<Capability> getAll();
-
-    /**
-     * Creates a capability given its id/type. if there is no capability available for specified type it will throw an
-     * runtime exception.
-     *
-     * @param capabilityId   id of capability to be created
-     * @param capabilityType type of capability to be created
-     * @return created capability
-     */
-    Capability create( String capabilityId, String capabilityType );
+    Collection<CapabilityReference> getAll();
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityReference.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityReference.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.capabilities.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.plugins.capabilities.api.Capability;
+import org.sonatype.nexus.plugins.capabilities.api.CapabilityReference;
+
+/**
+ * Default {@link CapabilityReference} implementation.
+ *
+ * @since 1.10.0
+ */
+class DefaultCapabilityReference
+    extends AbstractLoggingComponent
+    implements CapabilityReference
+{
+
+    private final Capability capability;
+
+    private boolean active;
+
+    DefaultCapabilityReference( final Capability capability )
+    {
+        this.capability = checkNotNull( capability );
+    }
+
+    @Override
+    public Capability capability()
+    {
+        return capability;
+    }
+
+    @Override
+    public boolean isActive()
+    {
+        return active;
+    }
+
+    @Override
+    public void activate()
+    {
+        if ( !isActive() )
+        {
+            try
+            {
+                capability().activate();
+                active = true;
+            }
+            catch ( Exception e )
+            {
+                getLogger().error(
+                    "Could not activate capability with id '{}' ({})", new Object[]{ capability.id(), capability, e }
+                );
+            }
+        }
+    }
+
+    @Override
+    public void passivate()
+    {
+        if ( isActive() )
+        {
+            try
+            {
+                active = false;
+                capability().passivate();
+            }
+            catch ( Exception e )
+            {
+                getLogger().error(
+                    "Could not passivate capability with id '{}' ({})", new Object[]{ capability.id(), capability, e }
+                );
+            }
+        }
+    }
+}

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityRegistry.java
@@ -29,11 +29,15 @@ import javax.inject.Singleton;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.nexus.plugins.capabilities.api.Capability;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityFactory;
+import org.sonatype.nexus.plugins.capabilities.api.CapabilityReference;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
 
+/**
+ * Default {@link CapabilityRegistry} implementation.
+ */
 @Singleton
 @Named
-public class DefaultCapabilityRegistry
+class DefaultCapabilityRegistry
     implements CapabilityRegistry
 {
 
@@ -41,38 +45,25 @@ public class DefaultCapabilityRegistry
     @Requirement( role = CapabilityFactory.class )
     private Map<String, CapabilityFactory> factories;
 
-    private final Map<String, Capability> capabilities;
+    private final Map<String, CapabilityReference> capabilities;
 
-    public DefaultCapabilityRegistry()
+    DefaultCapabilityRegistry()
     {
-        capabilities = new HashMap<String, Capability>();
+        capabilities = new HashMap<String, CapabilityReference>();
     }
 
-    public void add( final Capability capability )
-    {
-        assert capability != null : "Capability cannot be null";
-        assert capability.id() != null : "Capability id cannot be null";
-
-        capabilities.put( capability.id(), capability );
-    }
-
-    public Capability get( final String capabilityId )
+    public CapabilityReference get( final String capabilityId )
     {
         return capabilities.get( capabilityId );
     }
 
     @Override
-    public Collection<Capability> getAll()
+    public Collection<CapabilityReference> getAll()
     {
         return capabilities.values();
     }
 
-    public void remove( final String capabilityId )
-    {
-        capabilities.remove( capabilityId );
-    }
-
-    public Capability create( final String capabilityId, final String capabilityType )
+    public CapabilityReference create( final String capabilityId, final String capabilityType )
     {
         assert capabilityId != null : "Capability id cannot be null";
 
@@ -84,7 +75,12 @@ public class DefaultCapabilityRegistry
 
         final Capability capability = factory.create( capabilityId );
 
-        return capability;
+        return new DefaultCapabilityReference( capability );
+    }
+
+    public CapabilityReference remove( final String capabilityId )
+    {
+        return capabilities.remove( capabilityId );
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityReferenceTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/DefaultCapabilityReferenceTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.capabilities.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.sonatype.nexus.plugins.capabilities.api.Capability;
+
+/**
+ * {@link DefaultCapabilityReference} UTs.
+ *
+ * @since 1.10.0
+ */
+public class DefaultCapabilityReferenceTest
+{
+
+    /**
+     * Capability is activated and active flag is set on activate.
+     */
+    @Test
+    public void activateWhenNotActive()
+    {
+        final Capability capability = mock( Capability.class );
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+        underTest.activate();
+        assertThat( underTest.isActive(), is( true ) );
+        verify( capability ).activate();
+    }
+
+    /**
+     * Capability is not activated activated again once it has been activated.
+     */
+    @Test
+    public void activateWhenActive()
+    {
+        final Capability capability = mock( Capability.class );
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+        underTest.activate();
+        assertThat( underTest.isActive(), is( true ) );
+        verify( capability ).activate();
+
+        underTest.activate();
+        assertThat( underTest.isActive(), is( true ) );
+        verifyNoMoreInteractions( capability );
+    }
+
+    /**
+     * Capability is not passivated when is not active.
+     */
+    @Test
+    public void passivateWhenNotActive()
+    {
+        final Capability capability = mock( Capability.class );
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+
+        assertThat( underTest.isActive(), is( false ) );
+        underTest.passivate();
+        assertThat( underTest.isActive(), is( false ) );
+        verifyNoMoreInteractions( capability );
+    }
+
+    /**
+     * Capability is passivated when is active.
+     */
+    @Test
+    public void passivateWhenActive()
+    {
+        final Capability capability = mock( Capability.class );
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+
+        underTest.activate();
+        assertThat( underTest.isActive(), is( true ) );
+
+        underTest.passivate();
+        assertThat( underTest.isActive(), is( false ) );
+        verify( capability ).passivate();
+    }
+
+    /**
+     * Capability is not passivated when activation fails.
+     */
+    @Test
+    public void activateProblem()
+    {
+        final Capability capability = mock( Capability.class );
+        when( capability.id() ).thenReturn( "test" );
+        doThrow( new UnsupportedOperationException( "on purpose" ) ).when( capability ).activate();
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+
+        underTest.activate();
+        assertThat( underTest.isActive(), is( false ) );
+        verify( capability ).activate();
+        verify( capability ).id();
+        underTest.passivate();
+        verifyNoMoreInteractions( capability );
+    }
+
+    /**
+     * Active flag is set when passivation problem.
+     */
+    @Test
+    public void passivateProblem()
+    {
+        final Capability capability = mock( Capability.class );
+        when( capability.id() ).thenReturn( "test" );
+        doThrow( new UnsupportedOperationException( "on purpose" ) ).when( capability ).passivate();
+        final DefaultCapabilityReference underTest = new DefaultCapabilityReference( capability );
+
+        underTest.activate();
+        assertThat( underTest.isActive(), is( true ) );
+        underTest.passivate();
+        verify( capability ).passivate();
+        assertThat( underTest.isActive(), is( false ) );
+    }
+
+}

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/DefaultCapabilityConfigurationTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/DefaultCapabilityConfigurationTest.java
@@ -16,7 +16,7 @@
  * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
  * All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.capabilities.internal.config.test;
+package org.sonatype.nexus.plugins.capabilities.internal.config;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/DefaultCapabilityConfigurationValidatorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/DefaultCapabilityConfigurationValidatorTest.java
@@ -16,7 +16,7 @@
  * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
  * All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.capabilities.internal.config.test;
+package org.sonatype.nexus.plugins.capabilities.internal.config;
 
 import org.junit.Test;
 import org.sonatype.configuration.validation.ValidationRequest;

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusInitializedEventInspectorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusInitializedEventInspectorTest.java
@@ -16,39 +16,32 @@
  * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
  * All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.capabilities.internal.config.test;
+package org.sonatype.nexus.plugins.capabilities.internal.config;
 
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
 
 import org.junit.Test;
-import org.sonatype.nexus.plugins.capabilities.api.Capability;
-import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
-import org.sonatype.nexus.plugins.capabilities.internal.config.NexusStoppedEventInspector;
-import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+import org.sonatype.nexus.plugins.capabilities.internal.config.CapabilityConfiguration;
+import org.sonatype.nexus.plugins.capabilities.internal.config.NexusInitializedEventInspector;
+import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
 
-public class NexusStoppedEventInspectorTest
+/**
+ * {@link NexusInitializedEvent} UTs.
+ *
+ * @since 1.10.0
+ */
+public class NexusInitializedEventInspectorTest
 {
 
     @Test
-    public void capabilitiesArePassivated()
+    public void capabilitiesAreLoadedWhenNexusIsInitialized()
         throws Exception
     {
-        final Capability capability1 = mock( Capability.class );
-        final Capability capability2 = mock( Capability.class );
-        when( capability2.id() ).thenReturn( "capability-2" );
-        doThrow( new RuntimeException( "something went wrong" ) ).when( capability2 ).passivate();
-        final CapabilityRegistry capabilityRegistry = mock( CapabilityRegistry.class );
-        when( capabilityRegistry.getAll() ).thenReturn( Arrays.asList( capability1, capability2 ) );
+        final CapabilityConfiguration capabilityConfiguration = mock( CapabilityConfiguration.class );
+        new NexusInitializedEventInspector( capabilityConfiguration ).inspect( new NexusInitializedEvent( this ) );
 
-        new NexusStoppedEventInspector( capabilityRegistry ).inspect( new NexusStoppedEvent( this ) );
-
-        verify( capability1 ).passivate();
-        verify( capability2 ).passivate();
+        verify( capabilityConfiguration ).load();
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusStoppedEventInspectorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/NexusStoppedEventInspectorTest.java
@@ -18,47 +18,42 @@
  */
 package org.sonatype.nexus.plugins.capabilities.internal.config;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import java.util.Arrays;
 
+import org.junit.Test;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityReference;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
-import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.plugins.capabilities.internal.config.NexusStoppedEventInspector;
 import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
-import org.sonatype.plexus.appevents.Event;
 
-@Singleton
-public class NexusStoppedEventInspector
-    implements EventInspector
+/**
+ * {@link NexusStoppedEventInspector} UTs.
+ *
+ * @since 1.10.0
+ */
+public class NexusStoppedEventInspectorTest
 {
 
-    private final CapabilityRegistry registry;
-
-    @Inject
-    public NexusStoppedEventInspector( final CapabilityRegistry registry )
+    /**
+     * When Nexus stops all capabilities are passivated.
+     */
+    @Test
+    public void capabilitiesArePassivated()
     {
-        this.registry = checkNotNull( registry );
-    }
+        final CapabilityReference ref1 = mock( CapabilityReference.class );
+        final CapabilityReference ref2 = mock( CapabilityReference.class );
 
-    public boolean accepts( final Event<?> evt )
-    {
-        return evt != null
-            && evt instanceof NexusStoppedEvent;
-    }
+        final CapabilityRegistry capabilityRegistry = mock( CapabilityRegistry.class );
+        when( capabilityRegistry.getAll() ).thenReturn( Arrays.asList( ref1, ref2 ) );
 
-    public void inspect( final Event<?> evt )
-    {
-        if ( !accepts( evt ) )
-        {
-            return;
-        }
-        for ( final CapabilityReference reference : new ArrayList<CapabilityReference>( registry.getAll() ) )
-        {
-            reference.passivate();
-        }
+        new NexusStoppedEventInspector( capabilityRegistry ).inspect( new NexusStoppedEvent( this ) );
+
+        verify( ref1 ).passivate();
+        verify( ref1 ).passivate();
     }
 
 }

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/test/TouchTestCapability.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/test/TouchTestCapability.java
@@ -18,61 +18,44 @@
  */
 package org.sonatype.nexus.plugins.capabilities.test;
 
-import java.io.ByteArrayInputStream;
 import java.util.Map;
 
-import org.sonatype.nexus.plugins.capabilities.api.AbstractRepositoryCapability;
+import org.sonatype.nexus.plugins.capabilities.api.AbstractCapability;
 import org.sonatype.nexus.plugins.capabilities.api.Capability;
-import org.sonatype.nexus.proxy.ResourceStoreRequest;
-import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
-import org.sonatype.nexus.proxy.repository.Repository;
 
 public class TouchTestCapability
-    extends AbstractRepositoryCapability
+    extends AbstractCapability
     implements Capability
 {
 
     public static final String ID = "TouchTest";
 
-    protected TouchTestCapability( String id, RepositoryRegistry repositoryRegistry )
+    protected TouchTestCapability( String id )
     {
-        super( id, repositoryRegistry );
+        super( id );
     }
 
     @Override
     public void create( Map<String, String> properties )
     {
-        doIt( properties );
+        getLogger().info( "Create capability with id {} and properties {}", id(), properties );
     }
 
     @Override
     public void update( Map<String, String> properties )
     {
-        doIt( properties );
+        getLogger().info( "Update capability with id {} and properties {}", id(), properties );
     }
 
     @Override
     public void load( Map<String, String> properties )
     {
-        doIt( properties );
+        getLogger().info( "Load capability with id {} and properties {}", id(), properties );
     }
 
-    private void doIt( final Map<String, String> properties )
+    @Override
+    public void remove()
     {
-        final Repository repo = getRepository( TouchTestCapabilityDescriptor.FIELD_REPO_OR_GROUP_ID, properties );
-
-        try
-        {
-            repo.storeItem(
-                new ResourceStoreRequest( "/capability/test.txt" ),
-                new ByteArrayInputStream(
-                    ( "capabilities test!\n" + properties.get( TouchTestCapabilityDescriptor.FIELD_MSG_ID ) + "\n" + properties.get( TouchTestCapabilityDescriptor.FIELD_REPO_OR_GROUP_ID ) ).getBytes() ),
-                null );
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e.getMessage(), e );
-        }
-
+        getLogger().info( "Remove capability with id {}", id() );
     }
 }

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/test/TouchTestCapabilityFactory.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/test/TouchTestCapabilityFactory.java
@@ -29,12 +29,9 @@ public class TouchTestCapabilityFactory
     implements CapabilityFactory
 {
 
-    @Requirement
-    private RepositoryRegistry repositoryRegistry;
-
     public Capability create( String id )
     {
-        return new TouchTestCapability( id, repositoryRegistry );
+        return new TouchTestCapability( id );
     }
 
 }

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3699/Nexus3699CapabilityIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3699/Nexus3699CapabilityIT.java
@@ -90,42 +90,4 @@ public class Nexus3699CapabilityIT
         CapabilitiesMessageUtil.delete( r.getId() );
     }
 
-    @Test
-    public void execution()
-        throws Exception
-    {
-        List<CapabilityListItemResource> data = CapabilitiesMessageUtil.list();
-
-        Assert.assertFalse( data.isEmpty() );
-        MatcherAssert.assertThat( data.get( 0 ).getId(), CoreMatchers.equalTo( "4fde59a80f4" ) );
-        MatcherAssert.assertThat( data.get( 0 ).getDescription(), CoreMatchers.equalTo( "test-capability" ) );
-        MatcherAssert.assertThat( data.get( 0 ).getTypeId(), CoreMatchers.equalTo( "TouchTest" ) );
-
-        File touch = new File( nexusWorkDir, "storage/nexus-test-harness-repo/capability/test.txt" );
-        assertTrue( touch.exists() );
-
-        String content = FileUtils.readFileToString( touch );
-        MatcherAssert.assertThat( content, containsString( "capabilities test!" ) );
-        MatcherAssert.assertThat( content, containsString( "repo_nexus-test-harness-repo" ) );
-
-        CapabilityResource cap = CapabilitiesMessageUtil.read( "4fde59a80f4" );
-        setMessage( cap, "capability updated!" );
-        CapabilitiesMessageUtil.update( cap );
-
-        content = FileUtils.readFileToString( touch );
-        MatcherAssert.assertThat( content, containsString( "capability updated!" ) );
-        MatcherAssert.assertThat( content, containsString( "repo_nexus-test-harness-repo" ) );
-    }
-
-    private void setMessage( CapabilityResource cap, String msg )
-    {
-        for ( CapabilityPropertyResource prop : cap.getProperties() )
-        {
-            if ( prop.getKey().equals( "message" ) )
-            {
-                prop.setValue( msg );
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
Fix problem with passivation being called even if not activated.
Refactor to allow state of capability to be kept in registry.
Add more UTs.
Make IT just check a proper setup as UTs are already testing inner workings.
