### PR TITLE
o Let nexus log at debug level with -Pdebug in ITs

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-default.xml
+++ b/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-default.xml
@@ -48,7 +48,6 @@
     <appender-ref ref="console"/>
   </logger>
   <logger name="org.apache.http" level="WARN"/>
-  <logger name="org.sonatype.nexus" level="INFO"/>
   <logger name="org.restlet" level="WARN">
     <appender-ref ref="console"/>
   </logger>


### PR DESCRIPTION
The debug profile sets the root level of the nexus logger, but org.sonatype.nexus was still set to INFO.
