### PR TITLE
o Fix DefaultNotificationManager NPE when unconfigured

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/DefaultNotificationManager.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/notification/DefaultNotificationManager.java
@@ -73,6 +73,12 @@ public class DefaultNotificationManager
     }
 
     @Override
+    protected boolean isConfigured()
+    {
+        return super.isConfigured() && getCurrentConfiguration( false ) != null;
+    }
+
+    @Override
     protected ApplicationConfiguration getApplicationConfiguration()
     {
         return nexusConfig;


### PR DESCRIPTION
While debugging Nexus4593*IT, NPEs from DefaultNotificationManager#isEnabled cluttered the logs, caused by unset section in nexus configuration.
