### PR TITLE
No updates when same properties

### DIFF
--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspector.java
@@ -20,6 +20,7 @@ package org.sonatype.nexus.plugins.capabilities.internal.config;
 
 import static org.sonatype.nexus.plugins.capabilities.internal.config.DefaultCapabilityConfiguration.asMap;
 
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -31,6 +32,7 @@ import org.sonatype.nexus.plugins.capabilities.internal.config.events.Capability
 import org.sonatype.nexus.plugins.capabilities.internal.config.events.CapabilityConfigurationRemoveEvent;
 import org.sonatype.nexus.plugins.capabilities.internal.config.events.CapabilityConfigurationUpdateEvent;
 import org.sonatype.nexus.plugins.capabilities.internal.config.persistence.CCapability;
+import org.sonatype.nexus.plugins.capabilities.internal.config.persistence.CCapabilityProperty;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.plexus.appevents.Event;
 
@@ -111,7 +113,10 @@ public class CapabilityConfigurationEventInspector
             {
                 ref.disable();
             }
-            ref.capability().update( asMap( capabilityConfig.getProperties() ) );
+            if ( !sameProperties( previousCapabilityConfig, capabilityConfig ) )
+            {
+                ref.capability().update( asMap( capabilityConfig.getProperties() ) );
+            }
             if ( !previousCapabilityConfig.isEnabled() && capabilityConfig.isEnabled() )
             {
                 ref.enable();
@@ -129,6 +134,26 @@ public class CapabilityConfigurationEventInspector
             ref.disable();
             ref.capability().remove();
         }
+    }
+
+    // @TestAccessible //
+    static boolean sameProperties( final CCapability capability1, final CCapability capability2 )
+    {
+        final List<CCapabilityProperty> p1 = capability1.getProperties();
+        final List<CCapabilityProperty> p2 = capability2.getProperties();
+        if ( p1 == null )
+        {
+            return p2 == null;
+        }
+        else if ( p2 == null )
+        {
+            return false;
+        }
+        if ( p1.size() != p2.size() )
+        {
+            return false;
+        }
+        return p1.equals( p2 );
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/mdo/capabilities-configuration.xml
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/main/mdo/capabilities-configuration.xml
@@ -20,20 +20,20 @@
 
 -->
 <model xmlns="http://modello.codehaus.org/MODELLO/1.4.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://modello.codehaus.org/MODELLO/1.4.0 http://modello.codehaus.org/xsd/modello-1.4.0.xsd"
-  xsd.namespace="http://www.sonatype.com/xsd/nexus-capabilities-configuration-1.0.0"
-  xsd.targetNamespace="http://www.sonatype.com/xsd/nexus-capabilities-configuration-1.0.0">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://modello.codehaus.org/MODELLO/1.4.0 http://modello.codehaus.org/xsd/modello-1.4.0.xsd"
+       xsd.namespace="http://www.sonatype.com/xsd/nexus-capabilities-configuration-1.0.0"
+       xsd.targetNamespace="http://www.sonatype.com/xsd/nexus-capabilities-configuration-1.0.0">
 
   <id>capabilities-configuration</id>
   <name>NexusCapabilitiesConfiguration</name>
 
-	<description>
-        <![CDATA[
+  <description>
+    <![CDATA[
         <p>Nexus Capabilities Configuration.</p>
         ]]>
-	</description>
-	
+  </description>
+
   <defaults>
     <default>
       <key>package</key>
@@ -150,6 +150,7 @@
           <version>1.0.0+</version>
           <type>String</type>
           <required>true</required>
+          <identifier>true</identifier>
           <description>Property key.</description>
         </field>
         <field>
@@ -157,23 +158,12 @@
           <version>1.0.0+</version>
           <type>String</type>
           <required>true</required>
+          <identifier>true</identifier>
           <description>Property value.</description>
         </field>
       </fields>
-      <codeSegments>
-        <codeSegment>
-          <version>1.0.0</version>
-          <code><![CDATA[
-    @Override
-    public String toString()
-    {
-        return String.format( "%s=%s", key, value );
-    }
-]]></code>
-        </codeSegment>
-      </codeSegments>      
     </class>
-    
+
   </classes>
-  
+
 </model>

--- a/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspectorTest.java
+++ b/nexus/nexus-core-plugins/nexus-capabilities-plugin/src/test/java/org/sonatype/nexus/plugins/capabilities/internal/config/CapabilityConfigurationEventInspectorTest.java
@@ -18,10 +18,13 @@
  */
 package org.sonatype.nexus.plugins.capabilities.internal.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.plugins.capabilities.internal.config.CapabilityConfigurationEventInspector.sameProperties;
 
 import java.util.Map;
 
@@ -30,9 +33,9 @@ import org.mockito.Matchers;
 import org.sonatype.nexus.plugins.capabilities.api.Capability;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityReference;
 import org.sonatype.nexus.plugins.capabilities.api.CapabilityRegistry;
-import org.sonatype.nexus.plugins.capabilities.internal.config.CapabilityConfigurationEventInspector;
 import org.sonatype.nexus.plugins.capabilities.internal.config.events.CapabilityConfigurationUpdateEvent;
 import org.sonatype.nexus.plugins.capabilities.internal.config.persistence.CCapability;
+import org.sonatype.nexus.plugins.capabilities.internal.config.persistence.CCapabilityProperty;
 
 /**
  * {@link CapabilityConfigurationEventInspector} UTs.
@@ -42,17 +45,38 @@ import org.sonatype.nexus.plugins.capabilities.internal.config.persistence.CCapa
 public class CapabilityConfigurationEventInspectorTest
 {
 
+    private static final boolean ENABLED = true;
+
+    private static final boolean DISABLED = false;
+
+    private static final boolean SAME_PROPERTIES = true;
+
+    private static final boolean DIFFERENT_PROPERTIES = false;
+
     /**
      * If previous configuration was enabled and new configuration is not enabled, disable() is called.
      */
     @Test
     public void capabilityUpdated01()
     {
-        CapabilityReference reference = prepareForUpdate( true, false );
+        CapabilityReference reference = prepareForUpdate( ENABLED, DISABLED, DIFFERENT_PROPERTIES );
         doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
 
         verify( reference ).disable();
         verify( reference.capability() ).update( Matchers.<Map<String, String>>any() );
+    }
+
+    /**
+     * If previous configuration was enabled and new configuration is not enabled, disable() is called.
+     * Update not called as they have same properties.
+     */
+    @Test
+    public void capabilityUpdated01SameProperties()
+    {
+        CapabilityReference reference = prepareForUpdate( ENABLED, DISABLED, SAME_PROPERTIES );
+        doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
+
+        verify( reference ).disable();
     }
 
     /**
@@ -61,11 +85,23 @@ public class CapabilityConfigurationEventInspectorTest
     @Test
     public void capabilityUpdated02()
     {
-        CapabilityReference reference = prepareForUpdate( false, false );
+        CapabilityReference reference = prepareForUpdate( DISABLED, DISABLED, DIFFERENT_PROPERTIES );
         doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
         doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
 
         verify( reference.capability() ).update( Matchers.<Map<String, String>>any() );
+    }
+
+    /**
+     * If previous configuration was not enabled and new configuration is not enabled, enable() is not called.
+     * Update not called as they have same properties.
+     */
+    @Test
+    public void capabilityUpdated02SameProperties()
+    {
+        CapabilityReference reference = prepareForUpdate( DISABLED, DISABLED, SAME_PROPERTIES );
+        doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
+        doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
     }
 
     /**
@@ -74,11 +110,23 @@ public class CapabilityConfigurationEventInspectorTest
     @Test
     public void capabilityUpdated03()
     {
-        CapabilityReference reference = prepareForUpdate( true, true );
+        CapabilityReference reference = prepareForUpdate( ENABLED, DISABLED, DIFFERENT_PROPERTIES );
         doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
         doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
 
         verify( reference.capability() ).update( Matchers.<Map<String, String>>any() );
+    }
+
+    /**
+     * If previous configuration was enabled and new configuration is enabled, enable() is not called.
+     * Update not called as they have same properties.
+     */
+    @Test
+    public void capabilityUpdated03SameProperties()
+    {
+        CapabilityReference reference = prepareForUpdate( ENABLED, DISABLED, DIFFERENT_PROPERTIES );
+        doThrow( new AssertionError( "Enable not expected to be called" ) ).when( reference ).enable();
+        doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
     }
 
     /**
@@ -87,14 +135,29 @@ public class CapabilityConfigurationEventInspectorTest
     @Test
     public void capabilityUpdated04()
     {
-        CapabilityReference reference = prepareForUpdate( false, true );
+        CapabilityReference reference = prepareForUpdate( DISABLED, ENABLED, DIFFERENT_PROPERTIES );
         doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
 
         verify( reference ).enable();
         verify( reference.capability() ).update( Matchers.<Map<String, String>>any() );
     }
 
-    private CapabilityReference prepareForUpdate( final boolean oldEnabled, final boolean newEnabled )
+    /**
+     * If previous configuration was not enabled and new configuration is enabled, enable() is called.
+     * Update not called as they have same properties.
+     */
+    @Test
+    public void capabilityUpdated04SameProperties()
+    {
+        CapabilityReference reference = prepareForUpdate( DISABLED, ENABLED, DIFFERENT_PROPERTIES );
+        doThrow( new AssertionError( "Disable not expected to be called" ) ).when( reference ).disable();
+
+        verify( reference ).enable();
+    }
+
+    private CapabilityReference prepareForUpdate( final boolean oldEnabled,
+                                                  final boolean newEnabled,
+                                                  final boolean sameProperties )
     {
         final Capability capability = mock( Capability.class );
         when( capability.id() ).thenReturn( "test" );
@@ -113,11 +176,135 @@ public class CapabilityConfigurationEventInspectorTest
         newCapability.setId( "test" );
         newCapability.setEnabled( newEnabled );
 
+        if ( sameProperties )
+        {
+            doThrow( new AssertionError( "Capability update not expected to be called" ) ).when( capability ).update(
+                Matchers.<Map<String, String>>any() );
+        }
+        else
+        {
+            {
+                final CCapabilityProperty ccp = new CCapabilityProperty();
+                ccp.setKey( "foo" );
+                ccp.setKey( "bar" );
+                oldCapability.getProperties().add( ccp );
+            }
+            {
+                final CCapabilityProperty ccp = new CCapabilityProperty();
+                ccp.setKey( "bar" );
+                ccp.setKey( "foo" );
+                newCapability.getProperties().add( ccp );
+            }
+        }
+
         new CapabilityConfigurationEventInspector( capabilityRegistry ).inspect(
             new CapabilityConfigurationUpdateEvent( newCapability, oldCapability )
         );
 
         return reference;
+    }
+
+    @Test
+    public void samePropertiesWhenBothNull()
+    {
+        final CCapability cc1 = new CCapability();
+        cc1.setProperties( null );
+        final CCapability cc2 = new CCapability();
+        cc2.setProperties( null );
+        assertThat( sameProperties( cc1, cc2 ), is( true ) );
+    }
+
+    @Test
+    public void samePropertiesWhenOldAreNull()
+    {
+        final CCapability cc1 = new CCapability();
+        cc1.setProperties( null );
+        final CCapability cc2 = new CCapability();
+        final CCapabilityProperty ccp2 = new CCapabilityProperty();
+        ccp2.setKey( "ccp2" );
+        ccp2.setValue( "ccp2" );
+        cc2.getProperties().add( ccp2 );
+        assertThat( sameProperties( cc1, cc2 ), is( false ) );
+    }
+
+    @Test
+    public void samePropertiesWhenNewAreNull()
+    {
+        final CCapability cc1 = new CCapability();
+        final CCapabilityProperty ccp1 = new CCapabilityProperty();
+        ccp1.setKey( "ccp1" );
+        ccp1.setValue( "ccp1" );
+        cc1.getProperties().add( ccp1 );
+        final CCapability cc2 = new CCapability();
+        cc2.setProperties( null );
+        assertThat( sameProperties( cc1, cc2 ), is( false ) );
+    }
+
+    @Test
+    public void samePropertiesWhenBothAreSame()
+    {
+        final CCapability cc1 = new CCapability();
+        final CCapabilityProperty ccp1 = new CCapabilityProperty();
+        ccp1.setKey( "ccp" );
+        ccp1.setValue( "ccp" );
+        cc1.getProperties().add( ccp1 );
+        final CCapability cc2 = new CCapability();
+        final CCapabilityProperty ccp2 = new CCapabilityProperty();
+        ccp2.setKey( "ccp" );
+        ccp2.setValue( "ccp" );
+        cc2.getProperties().add( ccp2 );
+        assertThat( sameProperties( cc1, cc2 ), is( true ) );
+    }
+
+    @Test
+    public void samePropertiesWhenDifferentValueSameKey()
+    {
+        final CCapability cc1 = new CCapability();
+        final CCapabilityProperty ccp1 = new CCapabilityProperty();
+        ccp1.setKey( "ccp" );
+        ccp1.setValue( "ccp1" );
+        cc1.getProperties().add( ccp1 );
+        final CCapability cc2 = new CCapability();
+        final CCapabilityProperty ccp2 = new CCapabilityProperty();
+        ccp2.setKey( "ccp" );
+        ccp2.setValue( "ccp2" );
+        cc2.getProperties().add( ccp2 );
+        assertThat( sameProperties( cc1, cc2 ), is( false ) );
+    }
+
+    @Test
+    public void samePropertiesWhenDifferentSize()
+    {
+        final CCapability cc1 = new CCapability();
+        final CCapabilityProperty ccp1 = new CCapabilityProperty();
+        ccp1.setKey( "ccp" );
+        ccp1.setValue( "ccp1" );
+        final CCapabilityProperty ccp1_1 = new CCapabilityProperty();
+        ccp1_1.setKey( "ccp1.1" );
+        ccp1_1.setValue( "ccp1.1" );
+        cc1.getProperties().add( ccp1 );
+        final CCapability cc2 = new CCapability();
+        final CCapabilityProperty ccp2 = new CCapabilityProperty();
+        ccp2.setKey( "ccp" );
+        ccp2.setValue( "ccp2" );
+        cc2.getProperties().add( ccp2 );
+        assertThat( sameProperties( cc1, cc2 ), is( false ) );
+    }
+
+    @Test
+    public void samePropertiesWhenDifferentKeys()
+    {
+        final CCapability cc1 = new CCapability();
+        final CCapabilityProperty ccp1 = new CCapabilityProperty();
+        ccp1.setKey( "ccp1" );
+        ccp1.setValue( "ccp" );
+        cc1.getProperties().add( ccp1 );
+        final CCapability cc2 = new CCapability();
+        final CCapabilityProperty ccp2 = new CCapabilityProperty();
+        ccp2.setKey( "ccp2" );
+        ccp2.setValue( "ccp" );
+        cc2.getProperties().add( ccp2 );
+        assertThat( sameProperties( cc1, cc2 ), is( false ) );
     }
 
 }


### PR DESCRIPTION
Do not call update on capabilities if previous capability properties are the same as the new ones.
