### PR TITLE
Support filtering of repositories by user-agent

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojo.java
@@ -84,7 +84,7 @@ public class CloseStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getOpenStageRepositoriesForUser( groupId, artifactId, version );
+            repos = filterUserAgent( client.getOpenStageRepositoriesForUser( groupId, artifactId, version ) );
         }
         catch ( RESTLightClientException e )
         {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/DropStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/DropStageRepositoryMojo.java
@@ -59,7 +59,7 @@ public class DropStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositoriesForUser();
+            repos = filterUserAgent( client.getClosedStageRepositoriesForUser() );
         }
         catch ( RESTLightClientException e )
         {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
@@ -46,7 +46,7 @@ public class ListStageRepositoriesMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getOpenStageRepositories();
+            repos = filterUserAgent( client.getOpenStageRepositories() );
         }
         catch ( RESTLightClientException e )
         {
@@ -56,7 +56,7 @@ public class ListStageRepositoriesMojo
         if ( repos != null )
         {
             StringBuilder builder = new StringBuilder();
-            builder.append( "The following OPEN staging repositories were found: " );
+            builder.append( String.format( "The following OPEN staging repositories were found for user-agent: '%s'", getUserAgent() ) );
 
             if ( !repos.isEmpty() )
             {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/PromoteToStageProfileMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/PromoteToStageProfileMojo.java
@@ -79,7 +79,7 @@ public class PromoteToStageProfileMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositories();
+            repos = filterUserAgent( client.getClosedStageRepositories() );
             Collections.sort( repos, new BeanComparator( "repositoryId" ) );
         }
         catch ( RESTLightClientException e )

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ReleaseStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ReleaseStageRepositoryMojo.java
@@ -65,7 +65,7 @@ public class ReleaseStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositoriesForUser();
+            repos = filterUserAgent( client.getClosedStageRepositoriesForUser() );
         }
         catch ( RESTLightClientException e )
         {


### PR DESCRIPTION
In some use cases I have, I may have concurrent deployment of 2 versions of the same g:a.
For instance, 1.1 and 2.0 can be staged at the same time.

To be sure that 2 different staging repositories get allocated, I use a specific user-agent for deployment that is unique to each build.

This change allows to filter all operations of the nexus-maven-plugin using a user-agent.
