### PR TITLE
ErrorReporting IT maintenance

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm1928/NXCM1928ManualErrorReportIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm1928/NXCM1928ManualErrorReportIT.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import org.codehaus.swizzle.jira.Issue;
 import org.codehaus.swizzle.jira.Jira;
 import org.codehaus.swizzle.jira.User;
-import org.restlet.data.Response;
 import org.restlet.data.Status;
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
 import org.sonatype.nexus.rest.model.ErrorReportResponse;
 import org.sonatype.nexus.rest.model.GlobalConfigurationResource;
 import org.sonatype.nexus.test.utils.ErrorReportUtil;
+import org.sonatype.nexus.test.utils.NexusRequestMatchers;
 import org.sonatype.nexus.test.utils.SettingsMessageUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -39,7 +39,7 @@ public class NXCM1928ManualErrorReportIT
 
     private static final String ITS_USER = "sonatypeits";
 
-    // @Test
+    @Test( enabled = false )
     public void generateReportWithAuthentication()
         throws Exception
     {
@@ -59,16 +59,15 @@ public class NXCM1928ManualErrorReportIT
         Assert.assertEquals( ITS_USER, reporter.getName() );
     }
 
-    // @Test
+    @Test( enabled = false )
     public void invalidUsers()
         throws Exception
     {
-        Response response =
-            ErrorReportUtil.generateProblemResponse( "sometitle", "somedescription",
-                                                     "someDummyUserToBreakIntegrationTest",
-                                                     Long.toHexString( System.nanoTime() ) );
-
-        Assert.assertEquals( Status.CLIENT_ERROR_BAD_REQUEST.getCode(), response.getStatus().getCode() );
+        ErrorReportUtil.matchProblemResponse(
+            "sometitle", "somedescription",
+            "someDummyUserToBreakIntegrationTest",
+            Long.toHexString( System.nanoTime() ),
+            NexusRequestMatchers.respondsWithStatus( Status.CLIENT_ERROR_BAD_REQUEST ) );
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm1928/NXCM1928ManualErrorReportIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm1928/NXCM1928ManualErrorReportIT.java
@@ -59,7 +59,7 @@ public class NXCM1928ManualErrorReportIT
         Assert.assertEquals( ITS_USER, reporter.getName() );
     }
 
-    @Test( enabled = false )
+    @Test
     public void invalidUsers()
         throws Exception
     {

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/NexusRequestMatchers.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/NexusRequestMatchers.java
@@ -337,6 +337,12 @@ public class NexusRequestMatchers
     }
 
     @Factory
+    public static <T> RespondsWithStatusCode respondsWithStatus( Status status )
+    {
+        return respondsWithStatusCode( status.getCode() );
+    }
+
+    @Factory
     public static <T> RespondsWithStatusCode respondsWithStatusCode( final int expectedStatusCode )
     {
         return new RespondsWithStatusCode( expectedStatusCode );


### PR DESCRIPTION
Spotted this when looking into failure on grid:
- connections not released properly
- incorrectly ignored test methods
- one test method still disabled, does not work probably because of missing user in JIRA

I added NexusResponseMatchers#respondsWithStatus as a shorthand for using restlets status constants directly.

Reference build will be https://builds.sonatype.org/job/nexus-oss-its-feature/80
