### PR TITLE
NEXUS-4640: SnapshotRemover improvements

### DIFF
--- a/nexus/nexus-app/pom.xml
+++ b/nexus/nexus-app/pom.xml
@@ -127,8 +127,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
@@ -190,12 +190,6 @@ public class DefaultSnapshotRemover
         {
             return result;
         }
-        // TODO: unsure do we really want to enable this if-block below
-        // if this is not a hosted repo, do nothing
-        // if ( !repository.getRepositoryKind().isFacetAvailable( HostedRepository.class ) )
-        // {
-        //    return result;
-        // }
 
         if ( getLogger().isDebugEnabled() )
         {
@@ -236,17 +230,13 @@ public class DefaultSnapshotRemover
                     + " files on repository " + repository.getId() );
         }
 
-        // Why are we expiring caches in the 1st places? But:
-        // better: Not costly operation, does not walk just flushes EHCache
-        // repository.expireNotFoundCaches( new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT ) );
-        // was: Very costly operation, it flushes EHCache AND Walks the repository to flip "expired" flags
-        // On hosted repositories?
-        // repository.expireCaches( new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT ) );
-
         // if we are processing a hosted-snapshot repository, we need to rebuild maven metadata
         // without this if below, the walk would happen against proxy repositories too, but doing nothing!
         if ( repository.getRepositoryKind().isFacetAvailable( HostedRepository.class ) )
         {
+            // expire NFC since we might create new maven metadata files
+            repository.expireNotFoundCaches( new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT ) );
+
             RecreateMavenMetadataWalkerProcessor metadataRebuildProcessor =
                 new RecreateMavenMetadataWalkerProcessor( Slf4jPlexusLogger.getPlexusLogger( getLogger() ),
                                                           getDeleteOperation( request ) );

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemover.java
@@ -698,11 +698,20 @@ public class DefaultSnapshotRemover
 
                             req.getRequestContext().putAll( context );
 
-                            return mrepository.getLocalStorage().containsItem( mrepository, req );
+                            getLogger().debug( "Checking for release counterpart in repository '{}' and path '{}'", mrepository.getId(), req.toString() );
+
+                            mrepository.retrieveItem( false, req );
+
+                            return true;
+                        }
+                        catch ( ItemNotFoundException e )
+                        {
+                            // nothing
                         }
                         catch ( Exception e )
                         {
                             // nothing
+                            getLogger().debug( "Unexpected exception!", e );
                         }
                     }
                 }


### PR DESCRIPTION
One of the oldest piece in Nexus heavily under-maintained.

In general, lessening the extra-work we were doing even if it was not needed (like extra walks doing nothing).

Fixes:
- moving all the work related/applied to processing hosted repositories into single place
- executing hosted related walk when it is actually needed (before, walk was always done, but the actual WalkerProcessor was disabled)
- not _expiring caches_ (walks whole repository to flip the "expired" flag on items) but just purging NFC (no walk happens, just flushes EHCache), since it was the original need. But, the separate method was not (yet) exposed when snapshot remover was written!
- improved method `releaseExistsForSnapshot()` a bit, but it's still linear (read: slow)
