### PR TITLE
NEXUS-4668: Make Lucene shaded too (as Maven Indexer is already)

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/pom.xml
@@ -158,6 +158,7 @@
             <configuration>
                <classpathDependencyExcludes>
                 <classpathDependencyExclude>org.apache.maven.indexer:indexer-core</classpathDependencyExclude>
+                <classpathDependencyExclude>org.apache.lucene:lucene-core</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
           </execution>
@@ -186,6 +187,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.maven.indexer:indexer-core</include>
+                  <include>org.apache.lucene:lucene-core</include>
                 </includes>
               </artifactSet>
             </configuration>


### PR DESCRIPTION
The nexus-indexer-lucene-plugin main artifact was already "shading" in Maven Indexer. This was needed to make actual components and API reachable to outer world.

This change does the same with Lucene Core, and allows the indexer plugin dependants to use Lucene classes,
since sadly, Maven Indexer API makes use of Lucene classes.
