### PR TITLE
NEXUS-4682: decouple shadows from master repositories.

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepository.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepository.java
@@ -20,6 +20,7 @@ package org.sonatype.nexus.proxy.repository;
 
 import org.sonatype.nexus.plugins.RepositoryType;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
+import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
 import org.sonatype.nexus.proxy.registry.ContentClass;
 
 /**
@@ -88,4 +89,13 @@ public interface ShadowRepository
      * Triggers syncing with master repository.
      */
     void synchronizeWithMaster();
+
+    /**
+     * Performs some activity if the event is coming from it's master repository. Implementation should filter and take
+     * care what repository is the origin of the event, and simply discard event if not interested in it.
+     * 
+     * @param evt
+     * @since 1.10.0
+     */
+    void onRepositoryItemEvent( RepositoryItemEvent evt );
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
@@ -76,7 +76,7 @@ public abstract class AbstractConfigurable
         applicationEventMulticaster.removeEventListener( this );
     }
 
-    public void onEvent( Event<?> evt )
+    public void onEvent( final Event<?> evt )
     {
         // act automatically on config events
         if ( evt instanceof ConfigurationPrepareForLoadEvent )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
@@ -1,0 +1,51 @@
+package org.sonatype.nexus.proxy.repository;
+
+import java.util.List;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.plexus.appevents.Event;
+
+/**
+ * A "relaying" event inspector that is made asynchronous and is used to relay the repository content change related
+ * events to ShadowRepository instances present in system.
+ * 
+ * @author cstamas
+ */
+@Component( role = EventInspector.class, hint = "ShadowRepositoryEventInspector" )
+public class ShadowRepositoryEventInspector
+    extends AbstractEventInspector
+    implements EventInspector, AsynchronousEventInspector
+{
+    @Requirement
+    private RepositoryRegistry repositoryRegistry;
+
+    @Override
+    public boolean accepts( Event<?> evt )
+    {
+        return evt instanceof RepositoryItemEvent;
+    }
+
+    @Override
+    public void inspect( Event<?> evt )
+    {
+        if ( evt instanceof RepositoryItemEvent )
+        {
+            final RepositoryItemEvent ievt = (RepositoryItemEvent) evt;
+            final List<ShadowRepository> shadows = repositoryRegistry.getRepositoriesWithFacet( ShadowRepository.class );
+
+            for ( ShadowRepository shadow : shadows )
+            {
+                if ( shadow.getMasterRepositoryId().equals( ievt.getRepository().getId() ) )
+                {
+                    shadow.onRepositoryItemEvent( ievt );
+                }
+            }
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.repository;
 
 import java.util.List;


### PR DESCRIPTION
Today, as many shadows (UI calls them "virtuals") you have against one master repository, the slow-down adds up to master repository slowdown, since all the content changes in shadows are done synchronously.

Before this change, shadow implementations were using the "low level" eventing in Nexus (plexus-app-events) that does not support async event handlers. This change simply "moves" shadow event processing into "high level" Nexus EventInspectors, and adds one new async EventInspector that replays the content change events asynchronously.

This way, the master repository performance is not affected (minimally is, but not in a way it was before: slowdown is not anymore linearly paired with number of shadows against it), or is minimally affected.

The fact that a M1 layouted artifact appears momentarily or few millis later when a M2 receives a deploy is not important at all.
