### PR TITLE
o [NEXUS-4679] Fix validation message key for duplicate repository IDs

### DIFF
--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
@@ -64,13 +64,11 @@ import org.sonatype.nexus.proxy.repository.ShadowRepository;
 @Component( role = ApplicationConfigurationValidator.class )
 public class DefaultApplicationConfigurationValidator
     extends AbstractLoggingComponent
-    implements ApplicationConfigurationValidator, Contextualizable
+    implements ApplicationConfigurationValidator
 {
-    private Random rand = new Random( System.currentTimeMillis() );
+    private final Random rand = new Random( System.currentTimeMillis() );
     
     public static final String REPOSITORY_ID_PATTERN = "^[a-zA-Z0-9_\\-\\.]+$";
-
-    private PlexusContainer plexusContainer;
 
     public String generateId()
     {
@@ -265,8 +263,8 @@ public class DefaultApplicationConfigurationValidator
             {
                 repo.setName( repo.getId() );
 
-                response.addValidationWarning( new ValidationMessage( "id", "Repository with ID='" + repo.getId() )
-                                                   + "' has no name, defaulted to it's ID." );
+                response.addValidationWarning( new ValidationMessage( "id", "Repository with ID='" + repo.getId()
+                                                   + "' has no name, defaulted to it's ID." ) );
 
                 response.setModified( true );
             }
@@ -278,45 +276,6 @@ public class DefaultApplicationConfigurationValidator
                         + repo.getLocalStatus() + "! (Allowed values are: '" + LocalStatus.IN_SERVICE + "' and '"
                         + LocalStatus.OUT_OF_SERVICE + "')" );
             }
-    /*
-            if ( !validateRepositoryType( repo.getType() ) )
-            {
-                response.addValidationError( "TYPE='" + repo.getType() + "' of repository with ID='" + repo.getId()
-                    + "' is wrong!" );
-            }
-    
-            if ( !CRepository.PROXY_MODE_ALLOW.equals( repo.getProxyMode() )
-                && !CRepository.PROXY_MODE_BLOCKED_MANUAL.equals( repo.getProxyMode() )
-                && !CRepository.PROXY_MODE_BLOCKED_AUTO.equals( repo.getProxyMode() ) )
-            {
-                response.addValidationError( "ProxyMode of repository with ID='" + repo.getId()
-                    + "' is wrong! (Allowed values are: " + CRepository.PROXY_MODE_ALLOW + ", "
-                    + CRepository.PROXY_MODE_BLOCKED_MANUAL + " and " + CRepository.PROXY_MODE_BLOCKED_AUTO + ")" );
-            }
-    
-            if ( repo.getRepositoryPolicy() == null
-                || ( !CRepository.REPOSITORY_POLICY_RELEASE.equals( repo.getRepositoryPolicy() ) && !CRepository.REPOSITORY_POLICY_SNAPSHOT
-                    .equals( repo.getRepositoryPolicy() ) ) )
-            {
-                response.addValidationError( "Repository " + repo.getId() + " have wrong repository policy: \""
-                    + repo.getRepositoryPolicy() + "\". Repository policy may be \""
-                    + CRepository.REPOSITORY_POLICY_RELEASE + "\" or \"" + CRepository.REPOSITORY_POLICY_SNAPSHOT
-                    + "\" only." );
-            }
-    
-            if ( repo.getChecksumPolicy() == null
-                || ( !CRepository.CHECKSUM_POLICY_IGNORE.equals( repo.getChecksumPolicy() )
-                    && !CRepository.CHECKSUM_POLICY_WARN.equals( repo.getChecksumPolicy() )
-                    && !CRepository.CHECKSUM_POLICY_STRICT.equals( repo.getChecksumPolicy() ) && !CRepository.CHECKSUM_POLICY_STRICT_IF_EXISTS
-                    .equals( repo.getChecksumPolicy() ) ) )
-            {
-                response.addValidationError( "Repository " + repo.getId() + " have wrong checksum policy: \""
-                    + repo.getChecksumPolicy() + "\". Repository checksum policy may be \""
-                    + CRepository.CHECKSUM_POLICY_IGNORE + "\", \"" + CRepository.CHECKSUM_POLICY_WARN + "\", \""
-                    + CRepository.CHECKSUM_POLICY_STRICT_IF_EXISTS + "\" or \"" + CRepository.CHECKSUM_POLICY_STRICT
-                    + "\" only." );
-            }
-    */
             if ( context.getExistingRepositoryIds() != null )
             {
                 if ( context.getExistingRepositoryIds().contains( repo.getId() ) )
@@ -364,7 +323,7 @@ public class DefaultApplicationConfigurationValidator
 
         if ( settings.getPathMappings() != null )
         {
-            for ( CPathMappingItem item : (List<CPathMappingItem>) settings.getPathMappings() )
+            for ( CPathMappingItem item : settings.getPathMappings() )
             {
                 response.append( validateGroupsSettingPathMappingItem( context, item ) );
             }
@@ -415,7 +374,7 @@ public class DefaultApplicationConfigurationValidator
             response.addValidationError( "The Route with ID='" + item.getId() + "' must contain at least one Route Pattern." );
         }
 
-        for ( String regexp : (List<String>) item.getRoutePatterns() )
+        for ( String regexp : item.getRoutePatterns() )
         {
             if ( !isValidRegexp( regexp ) )
             {
@@ -439,20 +398,10 @@ public class DefaultApplicationConfigurationValidator
                 + CPathMappingItem.BLOCKING_RULE_TYPE + "'." );
         }
 
-        if ( !CPathMappingItem.BLOCKING_RULE_TYPE.equals( item.getRouteType() ) )
-        {
-            // NOT TRUE ANYMORE:
-            // if you delete a repo(ses) that were belonging to a route, we insist on
-            // leaving the route "empty" (to save a users hardly concieved regexp) but with empty
-            // repo list
-
-            // here we must have a repo list
-            // if ( item.getRepositories() == null || item.getRepositories().size() == 0 )
-            // {
-            // response.addValidationError( "The repository list in Route with ID='" + item.getId()
-            // + "' is not valid: it cannot be empty!" );
-            // }
-        }
+        // REMOVED: check that a blocking route is not empty
+        // if you delete a repo(ses) that were belonging to a route, we insist on
+        // leaving the route "empty" (to save a users hardly concieved regexp) but with empty
+        // repo list
 
         if ( context.getExistingRepositoryIds() != null && context.getExistingRepositoryShadowIds() != null )
         {
@@ -460,7 +409,7 @@ public class DefaultApplicationConfigurationValidator
 
             List<String> existingShadows = context.getExistingRepositoryShadowIds();
 
-            for ( String repoId : (List<String>) item.getRepositories() )
+            for ( String repoId : item.getRepositories() )
             {
                 if ( !existingReposes.contains( repoId ) && !existingShadows.contains( repoId ) )
                 {
@@ -481,8 +430,6 @@ public class DefaultApplicationConfigurationValidator
         {
             response.setContext( ctx );
         }
-
-        // ApplicationValidationContext context = (ApplicationValidationContext) response.getContext();
 
         if ( settings.getPort() < 80 )
         {
@@ -780,18 +727,6 @@ public class DefaultApplicationConfigurationValidator
         return LocalStatus.IN_SERVICE.name().equals( ls ) || LocalStatus.OUT_OF_SERVICE.name().equals( ls );
     }
 
-    protected boolean validateRepositoryType( String type )
-    {
-        // TODO introduce getComponentDescriptor(Class, String)
-        return plexusContainer.getComponentDescriptor( Repository.class.getName(), type ) != null;
-    }
-
-    protected boolean validateShadowRepositoryType( String type )
-    {
-        // TODO introduce getComponentDescriptor(Class, String)
-        return plexusContainer.getComponentDescriptor( ShadowRepository.class.getName(), type ) != null;
-    }
-
     protected boolean isValidRegexp( String regexp )
     {
         if ( regexp == null )
@@ -809,11 +744,5 @@ public class DefaultApplicationConfigurationValidator
         {
             return false;
         }
-    }
-
-    public void contextualize( Context ctx )
-        throws ContextException
-    {
-        this.plexusContainer = (PlexusContainer) ctx.get( PlexusConstants.PLEXUS_KEY );
     }
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
@@ -250,12 +250,13 @@ public class DefaultApplicationConfigurationValidator
 
         if ( StringUtils.isEmpty( repo.getId() ) )
         {
-            response.addValidationError( "Repository ID's may not be empty!" );
+            response.addValidationError( new ValidationMessage( "id", "Repository ID's may not be empty!" ) );
         }
         else if ( !repo.getId().matches( REPOSITORY_ID_PATTERN ) )
         {
-            response
-                .addValidationError( "Only letters, digits, underscores(_), hyphens(-), and dots(.) are allowed in Repository ID" );
+            response.addValidationError(
+                new ValidationMessage( "id",
+                                       "Only letters, digits, underscores(_), hyphens(-), and dots(.) are allowed in Repository ID" ) );
         }
         // if repo id isn't valid, nothing below here will validate properly
         else
@@ -263,17 +264,19 @@ public class DefaultApplicationConfigurationValidator
             if ( StringUtils.isEmpty( repo.getName() ) )
             {
                 repo.setName( repo.getId() );
-    
-                response.addValidationWarning( "Repository with ID='" + repo.getId()
-                    + "' has no name, defaulted to it's ID." );
-    
+
+                response.addValidationWarning( new ValidationMessage( "id", "Repository with ID='" + repo.getId() )
+                                                   + "' has no name, defaulted to it's ID." );
+
                 response.setModified( true );
             }
-    
+
             if ( !validateLocalStatus( repo.getLocalStatus() ) )
             {
-                response.addValidationError( "LocalStatus of repository with ID='" + repo.getId() + "' is wrong " + repo.getLocalStatus() + "! (Allowed values are: '" + LocalStatus.IN_SERVICE + "' and '"
-                    + LocalStatus.OUT_OF_SERVICE + "')" );
+                response.addValidationError(
+                    new ValidationMessage( "id", "LocalStatus of repository with ID='" + repo.getId() ) + "' is wrong "
+                        + repo.getLocalStatus() + "! (Allowed values are: '" + LocalStatus.IN_SERVICE + "' and '"
+                        + LocalStatus.OUT_OF_SERVICE + "')" );
             }
     /*
             if ( !validateRepositoryType( repo.getType() ) )
@@ -318,7 +321,7 @@ public class DefaultApplicationConfigurationValidator
             {
                 if ( context.getExistingRepositoryIds().contains( repo.getId() ) )
                 {
-                    response.addValidationError( "Repository " + repo.getId() + " declared more than once!" );
+                    response.addValidationError( new ValidationMessage( "id", "Repository with ID=" + repo.getId() + " already exists!" ) );
                 }
     
                 context.getExistingRepositoryIds().add( repo.getId() );
@@ -328,8 +331,8 @@ public class DefaultApplicationConfigurationValidator
             {
                 if ( context.getExistingRepositoryShadowIds().contains( repo.getId() ) )
                 {
-                    response.addValidationError( "Repository " + repo.getId()
-                        + " conflicts with existing Shadow with same ID='" + repo.getId() + "'!" );
+                    response.addValidationError( new ValidationMessage( "id", "Repository " + repo.getId()
+                        + " conflicts with existing Shadow with same ID='" + repo.getId() + "'!" ) );
                 }
             }
     
@@ -337,8 +340,8 @@ public class DefaultApplicationConfigurationValidator
             {
                 if ( context.getExistingRepositoryGroupIds().contains( repo.getId() ) )
                 {
-                    response.addValidationError( "Repository " + repo.getId()
-                        + " conflicts with existing Group with same ID='" + repo.getId() + "'!" );
+                    response.addValidationError( new ValidationMessage( "id", "Repository " + repo.getId()
+                        + " conflicts with existing Group with same ID='" + repo.getId() + "'!" ) );
                 }
             }
         }

--- a/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/validator/DefaultApplicationConfigurationValidatorTest.java
+++ b/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/validator/DefaultApplicationConfigurationValidatorTest.java
@@ -18,6 +18,17 @@
  */
 package org.sonatype.nexus.configuration.application.validator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -30,17 +41,22 @@ import java.util.List;
 
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Test;
+import org.sonatype.configuration.validation.ValidationMessage;
 import org.sonatype.configuration.validation.ValidationRequest;
 import org.sonatype.configuration.validation.ValidationResponse;
 import org.sonatype.nexus.configuration.AbstractNexusTestCase;
-import org.sonatype.nexus.configuration.application.upgrade.ApplicationConfigurationUpgrader;
 import org.sonatype.nexus.configuration.model.CRepository;
 import org.sonatype.nexus.configuration.model.Configuration;
 import org.sonatype.nexus.configuration.model.DefaultCRepository;
 import org.sonatype.nexus.configuration.model.io.xpp3.NexusConfigurationXpp3Reader;
 import org.sonatype.nexus.configuration.model.io.xpp3.NexusConfigurationXpp3Writer;
 import org.sonatype.nexus.configuration.validator.ApplicationConfigurationValidator;
+import org.sonatype.nexus.configuration.validator.ApplicationValidationContext;
+import org.sonatype.nexus.configuration.validator.DefaultApplicationConfigurationValidator;
+import org.sonatype.nexus.proxy.repository.LocalStatus;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
 import org.sonatype.nexus.util.ExternalConfigUtil;
 
@@ -48,20 +64,13 @@ public class DefaultApplicationConfigurationValidatorTest
     extends AbstractNexusTestCase
 {
 
-    protected ApplicationConfigurationValidator configurationValidator;
+    protected DefaultApplicationConfigurationValidator underTest;
 
-    protected ApplicationConfigurationUpgrader configurationUpgrader;
-
+    @Before
     public void setUp()
         throws Exception
     {
-        super.setUp();
-
-        this.configurationValidator = (ApplicationConfigurationValidator) lookup( ApplicationConfigurationValidator.class );
-
-        // I don't want to test both the validator, and the upgrade at the same time, but manually touching all these
-        // config files is worse.
-        this.configurationUpgrader = (ApplicationConfigurationUpgrader) lookup( ApplicationConfigurationUpgrader.class );
+        this.underTest = new DefaultApplicationConfigurationValidator();
     }
 
     protected Configuration getConfigurationFromStream( InputStream is )
@@ -72,7 +81,6 @@ public class DefaultApplicationConfigurationValidatorTest
         Reader fr = new InputStreamReader( is );
 
         return reader.read( fr );
-
     }
 
     protected Configuration loadNexusConfig( File configFile )
@@ -139,16 +147,15 @@ public class DefaultApplicationConfigurationValidatorTest
         config.addRepository( badShadow );
 
         // now validate it
-        ValidationResponse response = configurationValidator.validateModel( new ValidationRequest( config ) );
+        ValidationResponse response = underTest.validateModel( new ValidationRequest( config ) );
 
-        // XXX cstamas-merge assertEquals( 3, response.getValidationWarnings().size() );
-
-        // XXX cstamas-merge assertEquals( 1, response.getValidationErrors().size() );
+        assertThat( response.getValidationWarnings(), hasSize( 1 ) );
+        assertThat( response.getValidationErrors(), hasSize( 0 ) );
 
         // codehaus-snapshots has no name, it will be defaulted
-        assertTrue( response.isModified() );
+        assertThat( response.isModified(), is( true ) );
 
-     // XXX cstamas-merge assertFalse( response.isValid() );
+        assertThat( response.isValid(), is( true ) );
     }
 
     @Test
@@ -157,17 +164,18 @@ public class DefaultApplicationConfigurationValidatorTest
     {
         // get start with the default config
         this.copyDefaultConfigToPlace();
+        this.copyResource( "/META-INF/nexus/default-oss-nexus.xml", getNexusConfiguration() );
         Configuration config = this.loadNexusConfig( new File( this.getNexusConfiguration() ) );
 
         // make it bad
 
         // invalid policy
-        CRepository invalidPolicyRepo = (CRepository) config.getRepositories().get( 0 );
+        CRepository invalidPolicyRepo = config.getRepositories().get( 0 );
         Xpp3Dom externalConfig = (Xpp3Dom) invalidPolicyRepo.getExternalConfiguration();
         ExternalConfigUtil.setNodeValue( externalConfig, "repositoryPolicy", "badPolicy" );
 
         // duplicate the repository id
-        for ( CRepository repo : (List<CRepository>) config.getRepositories() )
+        for ( CRepository repo : config.getRepositories() )
         {
             if ( !repo.getId().equals( "central" ) )
             {
@@ -180,15 +188,13 @@ public class DefaultApplicationConfigurationValidatorTest
         // TODO: add more errors here
 
         // now validate it
-        ValidationResponse response = configurationValidator.validateModel( new ValidationRequest( config ) );
+        ValidationResponse response = underTest.validateModel( new ValidationRequest( config ) );
 
-        assertFalse( response.isValid() );
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
 
-        assertFalse( response.isModified() );
-
-     // XXX cstamas-merge assertEquals( 6, response.getValidationErrors().size() );
-
-     // XXX cstamas-merge  assertEquals( 0, response.getValidationWarnings().size() );
+        assertThat( response.getValidationErrors(), hasSize( greaterThan( 0 ) ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
     }
 
     @Test
@@ -203,17 +209,15 @@ public class DefaultApplicationConfigurationValidatorTest
         // and you have the diff, and you already have to manually update the good one.
 
         // this was before fix: groupId/repoId name clash
-        ValidationResponse response = configurationValidator.validateModel( new ValidationRequest(
+        ValidationResponse response = underTest.validateModel( new ValidationRequest(
             getConfigurationFromStream( getClass().getResourceAsStream(
                 "/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result-bad" ) ) ) );
 
-        assertFalse( response.isValid() );
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
 
-        assertFalse( response.isModified() );
-
-        assertEquals( 1, response.getValidationErrors().size() );
-
-        assertEquals( 0, response.getValidationWarnings().size() );
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
     }
 
     @Test
@@ -221,13 +225,137 @@ public class DefaultApplicationConfigurationValidatorTest
         throws Exception
     {
         // this is after fix: groupId is appended by "-group" to resolve clash
-        ValidationResponse response = configurationValidator.validateModel( new ValidationRequest(
+        ValidationResponse response = underTest.validateModel( new ValidationRequest(
             getConfigurationFromStream( getClass().getResourceAsStream(
                 "/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result" ) ) ) );
 
-        assertTrue( response.isValid() );
+        assertThat( response.isValid(), is( true ) );
+        assertThat( response.isModified(), is( false ) );
 
-        assertFalse( response.isModified() );
+        assertThat( response.getValidationErrors(), hasSize( 0 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+    }
 
+    @Test
+    public void repoEmptyId()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+
+        CRepository repo = new CRepository();
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+        repo.setName( "name" );
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+        assertThat( response.getValidationErrors().get( 0 ), hasKey("id") );
+    }
+
+    private Matcher<? super ValidationMessage> hasKey( final String id )
+    {
+        return hasProperty( "key", equalTo( "id") );
+    }
+
+    @Test
+    public void repoIllegalId()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+        CRepository repo = new CRepository();
+        repo.setId( " " );
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+        repo.setName( "name" );
+
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+        assertThat( response.getValidationErrors().get( 0 ), hasKey("id") );
+    }
+
+    @Test
+    public void repoClashRepoId()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+        ctx.addExistingRepositoryIds();
+        ctx.getExistingRepositoryIds().add( "id" );
+        CRepository repo = new CRepository();
+        repo.setId( "id" );
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+        repo.setName( "name" );
+
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+        assertThat( response.getValidationErrors().get( 0 ), hasKey("id") );
+    }
+    @Test
+    public void repoClashGroupId()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+        ctx.addExistingRepositoryGroupIds();
+        ctx.getExistingRepositoryGroupIds().add( "id" );
+        CRepository repo = new CRepository();
+        repo.setId( "id" );
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+        repo.setName( "name" );
+
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+        assertThat( response.getValidationErrors().get( 0 ), hasKey("id") );
+    }
+
+    @Test
+    public void repoClashShadowId()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+        ctx.addExistingRepositoryShadowIds();
+        ctx.getExistingRepositoryShadowIds().add( "id" );
+        CRepository repo = new CRepository();
+        repo.setId( "id" );
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+        repo.setName( "name" );
+
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( false ) );
+        assertThat( response.isModified(), is( false ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 1 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 0 ) );
+        assertThat( response.getValidationErrors().get( 0 ), hasKey("id") );
+    }
+
+    @Test
+    public void repoEmptyName()
+    {
+        ApplicationValidationContext ctx = new ApplicationValidationContext();
+        CRepository repo = new CRepository();
+        repo.setId( "id" );
+        repo.setLocalStatus( LocalStatus.IN_SERVICE.toString() );
+
+        ValidationResponse response = underTest.validateRepository( ctx, repo );
+
+        assertThat( response.isValid(), is( true ) );
+        assertThat( response.isModified(), is( true ) );
+
+        assertThat( response.getValidationErrors(), hasSize( 0 ) );
+        assertThat( response.getValidationWarnings(), hasSize( 1 ) );
+        ValidationMessage actual = response.getValidationWarnings().get( 0 );
+        assertThat( actual, hasKey("id") );
     }
 }


### PR DESCRIPTION
If no explicite key is used for validation errors, the REST reply will have numerical IDs that do not match field names and will not be displayed anywhere.
