### PR TITLE
Add a getter also for finding if local status of a repository changed

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryConfigurationUpdatedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryConfigurationUpdatedEvent.java
@@ -36,6 +36,8 @@ public class RepositoryConfigurationUpdatedEvent
 
     private boolean madeSearchable = false;
 
+    private boolean localStatusChanged = false;
+
     public RepositoryConfigurationUpdatedEvent( Repository repository )
     {
         super( repository );
@@ -54,6 +56,11 @@ public class RepositoryConfigurationUpdatedEvent
     public boolean isDownloadRemoteIndexEnabled()
     {
         return downloadRemoteIndexEnabled;
+    }
+
+    public boolean isLocalStatusChanged()
+    {
+        return localStatusChanged;
     }
 
     public void setLocalUrlChanged( boolean localUrlChanged )
@@ -80,4 +87,10 @@ public class RepositoryConfigurationUpdatedEvent
     {
         this.madeSearchable = madeSearchable;
     }
+
+    public void setLocalStatusChanged( boolean localStatusChanged )
+    {
+        this.localStatusChanged = localStatusChanged;
+    }
+
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -163,6 +163,10 @@ public abstract class AbstractRepository
     /** if non-indexable -> indexable change occured, need special handling after save */
     private boolean madeSearchable = false;
 
+    /** if local status changed, need special handling after save */
+    private boolean localStatusChanged = false;
+
+
     // --
 
     protected Logger getLogger()
@@ -215,6 +219,8 @@ public abstract class AbstractRepository
 
         this.madeSearchable = false;
 
+        this.localStatusChanged = false;
+
         return wasDirty;
     }
 
@@ -224,6 +230,8 @@ public abstract class AbstractRepository
         this.localUrlChanged = false;
 
         this.madeSearchable = false;
+
+        this.localStatusChanged = false;
 
         return super.rollbackChanges();
     }
@@ -240,6 +248,7 @@ public abstract class AbstractRepository
 
         event.setLocalUrlChanged( this.localUrlChanged );
         event.setMadeSearchable( this.madeSearchable );
+        event.setLocalStatusChanged( localStatusChanged );
 
         return event;
     }
@@ -377,6 +386,8 @@ public abstract class AbstractRepository
             LocalStatus oldLocalStatus = getLocalStatus();
 
             super.setLocalStatus( localStatus );
+
+            localStatusChanged = true;
 
             getApplicationEventMulticaster().notifyEventListeners(
                 new RepositoryEventLocalStatusChanged( this, oldLocalStatus, localStatus ) );


### PR DESCRIPTION
This is needed as the local status changed event is misleading. this because the event is fired before the change is committed so if for example I do repository.store() item in the moment that event is fired I will get an exception because even if the new status is IN_SERVICE the repository status is not actually in service (yet)
