### PR TITLE
Removing Commons IO uses littered across.

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/timeline/DefaultNexusTimeline.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/timeline/DefaultNexusTimeline.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -32,6 +31,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.StartingException;
+import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.timeline.Timeline;
@@ -134,7 +134,7 @@ public class DefaultNexusTimeline
 
         for ( File legacyIndexFile : legacyIndexFiles )
         {
-            FileUtils.moveFileToDirectory( legacyIndexFile, newIndexDir, false );
+            FileUtils.rename( legacyIndexFile, new File( newIndexDir, legacyIndexFile.getName() ));
         }
     }
 

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/timeline/LegacyNexusTimelineTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/timeline/LegacyNexusTimelineTest.java
@@ -21,9 +21,8 @@ package org.sonatype.nexus.timeline;
 import java.io.File;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
-import org.sonatype.nexus.AbstractNexusTestCase;
 import org.sonatype.timeline.TimelineRecord;
 
 public class LegacyNexusTimelineTest
@@ -37,7 +36,7 @@ public class LegacyNexusTimelineTest
 
         File legacyTimelineDir = new File( getWorkHomeDir(), "timeline" );
 
-        FileUtils.copyDirectory( legacyDataDir, legacyTimelineDir );
+        FileUtils.copyDirectoryStructure( legacyDataDir, legacyTimelineDir );
 
         NexusTimeline nexusTimeline = this.lookup( NexusTimeline.class );
 
@@ -58,9 +57,9 @@ public class LegacyNexusTimelineTest
 
         File newTimelineDir = new File( getWorkHomeDir(), "timeline/index" );
 
-        FileUtils.copyDirectory( legacyDataDir, legacyTimelineDir );
+        FileUtils.copyDirectoryStructure( legacyDataDir, legacyTimelineDir );
 
-        FileUtils.copyDirectory( newDataDir, newTimelineDir );
+        FileUtils.copyDirectoryStructure( newDataDir, newTimelineDir );
 
         NexusTimeline nexusTimeline = this.lookup( NexusTimeline.class );
 

--- a/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultScriptStorage.java
+++ b/nexus/nexus-core-plugins/nexus-groovy-console-plugin/src/main/java/com/sonatype/nexus/plugin/groovyconsole/DefaultScriptStorage.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs.FileChangeEvent;
 import org.apache.commons.vfs.FileContent;
 import org.apache.commons.vfs.FileListener;
@@ -42,6 +41,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.plexus.appevents.Event;
@@ -206,7 +206,7 @@ public class DefaultScriptStorage
         try
         {
             FileContent content = file.getContent();
-            script = IOUtils.toString( content.getInputStream() );
+            script = IOUtil.toString( content.getInputStream() );
             content.close();
         }
         catch ( IOException e )

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
@@ -34,8 +34,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.index.context.IndexingContext;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Response;
@@ -154,7 +154,7 @@ public class DownloadRemoteIndexerManagerLRTest
             FileUtils.forceDelete( destination );
             lastMod = indexFile.lastModified();
         }
-        FileUtils.copyDirectory( source, destination, false );
+        FileUtils.copyDirectoryStructure( source, destination );
         long lastMod2 = indexFile.lastModified();
         assertTrue( lastMod < lastMod2 );
 

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/pom.xml
@@ -163,7 +163,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -103,10 +103,6 @@
       <artifactId>shiro-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-core</artifactId>
     </dependency>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.io.IOUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
@@ -520,7 +519,7 @@ public class DefaultAttributesHandler
 
                         tmpFileStream = new FileOutputStream( tmpFile );
 
-                        IOUtils.copy( inputStream, tmpFileStream );
+                        IOUtil.copy( inputStream, tmpFileStream );
 
                         tmpFileStream.flush();
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -28,9 +28,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.io.FilenameUtils;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
+import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.proxy.access.Action;
@@ -303,9 +303,9 @@ public class DefaultFSAttributeStorage
 
         File result = null;
 
-        String path = FilenameUtils.getPath( uid.getPath() );
+        String path = FileUtils.getPath( uid.getPath() );
 
-        String name = FilenameUtils.getName( uid.getPath() );
+        String name = FileUtils.removePath( uid.getPath() );
 
         result = new File( repoBase, path + "/" + name );
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorage.java
@@ -21,14 +21,15 @@ package org.sonatype.nexus.proxy.attributes;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.io.FilenameUtils;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
+import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.proxy.access.Action;
@@ -42,6 +43,7 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 import org.sonatype.plexus.appevents.Event;
 import org.sonatype.plexus.appevents.EventListener;
+
 import com.google.common.io.Closeables;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
@@ -250,9 +252,9 @@ public class LegacyFSAttributeStorage
 
         File result = null;
 
-        String path = FilenameUtils.getPath( uid.getPath() );
+        String path = FileUtils.getPath(  uid.getPath() );
 
-        String name = FilenameUtils.getName( uid.getPath() );
+        String name = FileUtils.removePath(  uid.getPath() );
 
         result = new File( repoBase, path + "/" + name );
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -107,9 +106,8 @@ public abstract class AttributeStoragePerformanceTestSupport
 
         // write a test file
         File testFile = new File( repoStorageDir, testFilePath );
-        FileUtils.writeStringToFile( testFile, "CONTENT" );
-
-        FileUtils.writeStringToFile( CONTENT_TEST_FILE, "CONTENT" );
+        org.codehaus.plexus.util.FileUtils.fileWrite( testFile, "CONTENT" );
+        org.codehaus.plexus.util.FileUtils.fileWrite( CONTENT_TEST_FILE, "CONTENT" );
 
         // Mocks
         Wastebasket wastebasket = mock( Wastebasket.class );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceITLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceITLRTest.java
@@ -20,7 +20,6 @@ package org.sonatype.nexus.proxy.storage.local.fs.perf;
 
 import java.io.File;
 
-import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -113,7 +112,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceITLRTest
 
         // write a test file
         File testFile = new File( repositoryStorageDir, testFilePath );
-        FileUtils.writeStringToFile( testFile, "CONTENT" );
+        org.codehaus.plexus.util.FileUtils.fileWrite( testFile, "CONTENT" );
 
         // this test expects "old" behaviour:
         ( (DefaultAttributesHandler) repository.getAttributesHandler() ).setLastRequestedResolution( 0 );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceLRTest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -93,7 +92,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceLRTest
 
         // write a test file
         File testFile = new File( repoStorageDir, testFilePath );
-        FileUtils.writeStringToFile( testFile, "CONTENT" );
+        org.codehaus.plexus.util.FileUtils.fileWrite( testFile, "CONTENT" );
 
         // Mocks
         Wastebasket wastebasket = mock( Wastebasket.class );

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/rt/prefs/FilePreferences.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/rt/prefs/FilePreferences.java
@@ -31,7 +31,7 @@ import java.util.TreeMap;
 import java.util.prefs.AbstractPreferences;
 import java.util.prefs.BackingStoreException;
 
-import org.apache.commons.io.IOUtils;
+import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,7 +168,7 @@ public class FilePreferences
                 }
                 finally
                 {
-                    IOUtils.closeQuietly( in );
+                    IOUtil.close( in );
                 }
 
                 StringBuilder sb = new StringBuilder();
@@ -234,7 +234,7 @@ public class FilePreferences
                     }
                     finally
                     {
-                        IOUtils.closeQuietly( in );
+                        IOUtil.close( in );
                     }
 
                     List<String> toRemove = new ArrayList<String>();
@@ -278,7 +278,7 @@ public class FilePreferences
                 }
                 finally
                 {
-                    IOUtils.closeQuietly( out );
+                    IOUtil.close( out );
                 }
             }
             catch ( IOException e )


### PR DESCRIPTION
We already have Plexus Utils, and just added Guava. There is no need
(and never was) to use IO related commons. In many classes that were changed
below, Plexus IOUtil was already imported! And many times, equiv
method with even same name was present.

So, in future please try to verify what you are using, and tend to use Plexus Utils OR Guava, but not both nor any third one.
