### PR TITLE
o [NXCM-3543] pull up loadHandler into abstract repo editor UI

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
@@ -36,6 +36,10 @@ Sonatype.repoServer.AbstractRepositoryEditor = function(config) {
           submit : {
             fn : this.submitHandler,
             scope : this
+          },
+          load : {
+              fn : this.loadHandler,
+              scope : this
           }
         }
       });
@@ -528,7 +532,8 @@ Ext.extend(Sonatype.repoServer.HostedRepositoryEditor, Sonatype.repoServer.Abstr
             writePolicyField.setValue('ALLOW_WRITE_ONCE');
           }
         }
-      }
+      },
+      loadHandler : function(form, action, receivedData) {}
     });
 
 Sonatype.repoServer.ProxyRepositoryEditor = function(config) {
@@ -1071,13 +1076,7 @@ Sonatype.repoServer.ProxyRepositoryEditor = function(config) {
                         }]
                   }]
             } // end proxy settings
-        ],
-        listeners : {
-          load : {
-            fn : this.loadHandler,
-            scope : this
-          }
-        }
+        ]
       });
 };
 
@@ -1349,7 +1348,8 @@ Ext.extend(Sonatype.repoServer.VirtualRepositoryEditor, Sonatype.repoServer.Abst
                 return false;
               });
         }
-      }
+      },
+      loadHandler : function(form, action, receivedData) {}
     });
 
 Sonatype.Events.addListener('repositoryViewInit', function(cardPanel, rec) {


### PR DESCRIPTION
This small change fixes one UI issue:
The 'Download Remote Index' box will be set to false and disabled for every non-maven2 proxy repository.
That code was lying around but never called because the listener was not registered correctly.
