### PR TITLE
NEXUS-4640: The Parent-O-Matic device

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/ParentOMatic.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/ParentOMatic.java
@@ -1,0 +1,409 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.walker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.util.Node;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+/**
+ * A helper class to "optimize" when some sort of "gathering for later processing" (most notable collection of
+ * directories to start Walks from) of repository paths happens, that are to be processed in some subsequent step by
+ * "walking" them (recurse them, a la "visitor" pattern). This utility class simply maintains a "tree" with
+ * <em>marked</em> nodes, while the meaning of "marked" is left to class user. One assumption does exists against
+ * "marked": some recursive processing is planned against it. It currently applies these simple rules to it.
+ * <p>
+ * <ul>
+ * <li>rule A: if parent node of the currently added node is already "marked", do not mark the currently added node
+ * (reason: it will be anyway processes when marked parent processing starts to recurse)</li>
+ * <li>rule B: if all the children nodes of the currently added node's parent as "marked", mark the parent and unmark
+ * it's children (reason: it's usually cheaper to fire off one walk level above, from parent, instead firing, for
+ * example 100, independent walks from children one by one)</li>
+ * </ul>
+ * <p>
+ * Note: all the input paths are expected to be "normalized ones": being absolute, using generic "/" character as path
+ * separator (since these are NOT File paths, but just hierarchical paths of strings). For example:
+ * {@link RepositoryItemUid#getPath()} returns paths like these.
+ * <p>
+ * This class also "optimizes" the tree size to lessen memory use. This "optimization" can be turned off, see
+ * constructors.
+ * <p>
+ * This class makes use of {@link Node} to implement the tree hierarchy.
+ * 
+ * @author cstamas
+ * @since 1.10.0
+ */
+public class ParentOMatic
+{
+    public static class Payload
+    {
+        private final String path;
+
+        private boolean marked;
+
+        public Payload( String path )
+        {
+            this.path = Preconditions.checkNotNull( path );
+            this.marked = false;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+
+        public boolean isMarked()
+        {
+            return marked;
+        }
+
+        public void setMarked( boolean marked )
+        {
+            this.marked = marked;
+        }
+    }
+
+    /**
+     * If true, all the nodes below marked ones will be simply cut away, to lessen tree size and hence, memory
+     * consumption. They have no need to stay in memory, since the result will not need them anyway, will not be
+     * returned by {@link #getMarkedPaths()}.
+     */
+    private final boolean optimizeTreeSize;
+
+    /**
+     * The root node.
+     */
+    private final Node<Payload> ROOT;
+
+    /**
+     * Creates new instance of ParentOMatic with default settings.
+     */
+    public ParentOMatic()
+    {
+        this( true );
+    }
+
+    public ParentOMatic( final boolean optimizeTreeSize )
+    {
+        super();
+        this.optimizeTreeSize = optimizeTreeSize;
+        this.ROOT = new Node<Payload>( null, "ROOT", new Payload( "/" ) );
+    }
+
+    /**
+     * Adds a path to this ParentOMatic instance without marking it.
+     * 
+     * @param path
+     * @return
+     */
+    public Node<Payload> addPath( final String path )
+    {
+        return addPath( path, true );
+    }
+
+    /**
+     * Adds a path to this ParentOMatic and marks it. This might result in changes in tree that actually tries to
+     * "optimize" the markings, and it may result in tree where the currently added and marked path is not marked, but
+     * it's some parent is.
+     * 
+     * @param path
+     */
+    public void addAndMarkPath( final String path )
+    {
+        final Node<Payload> currentNode = addPath( path, false );
+
+        // unmark children if any
+        applyRecursively( currentNode, new Function<Node<Payload>, Node<Payload>>()
+        {
+            @Override
+            public Node<Payload> apply( Node<Payload> input )
+            {
+                input.getPayload().setMarked( false );
+                return input;
+            }
+        } );
+
+        currentNode.getPayload().setMarked( true );
+
+        // reorganize if needed
+        final Node<Payload> flippedNode = reorganizeForRecursion( currentNode );
+
+        // optimize tree size if asked for
+        if ( optimizeTreeSize )
+        {
+            optimizeTreeSize( flippedNode );
+        }
+    }
+
+    /**
+     * Returns the list of the marked paths.
+     * 
+     * @return
+     */
+    public List<String> getMarkedPaths()
+    {
+        // doing scanning
+        final ArrayList<String> markedPaths = new ArrayList<String>();
+        final Function<Node<Payload>, Node<Payload>> markedCollector = new Function<Node<Payload>, Node<Payload>>()
+        {
+            @Override
+            public Node<Payload> apply( Node<Payload> input )
+            {
+                if ( input.getPayload().isMarked() )
+                {
+                    markedPaths.add( input.getPayload().getPath() );
+                }
+                return null;
+            }
+        };
+        applyRecursively( ROOT, markedCollector );
+        return markedPaths;
+    }
+
+    // ==
+
+    /**
+     * "Dumps" the tree, for tests.
+     * 
+     * @return
+     */
+    public String dump()
+    {
+        final StringBuilder sb = new StringBuilder();
+        dump( ROOT, 0, sb );
+        return sb.toString();
+    }
+
+    protected void dump( final Node<Payload> node, final int depth, final StringBuilder sb )
+    {
+        sb.append( Strings.repeat( "  ", depth ) );
+        sb.append( node.getLabel() );
+        sb.append( " (" ).append( node.getPayload().getPath() ).append( ")" );
+        if ( node.getPayload().isMarked() )
+        {
+            sb.append( "*" );
+        }
+        sb.append( "\n" );
+        for ( Node<Payload> child : node.getChildren() )
+        {
+            dump( child, depth + 1, sb );
+        }
+    }
+
+    // ==
+
+    protected Node<Payload> addPath( final String path, final boolean optimize )
+    {
+        final List<String> pathElems = getPathElements( Preconditions.checkNotNull( path ) );
+        final List<String> actualPathElems = Lists.newArrayList();
+
+        Node<Payload> currentNode = ROOT;
+
+        for ( String pathElem : pathElems )
+        {
+            actualPathElems.add( pathElem );
+            final Node<Payload> node = currentNode.getChildByLabel( pathElem );
+
+            if ( node == null )
+            {
+                currentNode = currentNode.addChild( pathElem, new Payload( getPathElementsAsPath( actualPathElems ) ) );
+            }
+            else
+            {
+                currentNode = node;
+            }
+        }
+
+        if ( optimize )
+        {
+            optimizeTreeSize( currentNode );
+        }
+
+        return currentNode;
+    }
+
+    /**
+     * Reorganizes the tree by applying the rules to the tree from the changed node and returns a node that was top most
+     * of the flipped ones.
+     * 
+     * @param changedNode
+     */
+    protected Node<Payload> reorganizeForRecursion( final Node<Payload> changedNode )
+    {
+        // rule a: if parent is marked already, do not mark the child
+        if ( isParentMarked( changedNode ) )
+        {
+            changedNode.getPayload().setMarked( false );
+            return changedNode.getParent();
+        }
+
+        // rule b: if this parent's all children are marked, mark parent, unmark children
+        if ( isParentAllChildMarkedForRuleB( changedNode ) )
+        {
+            changedNode.getParent().getPayload().setMarked( true );
+            for ( Node<Payload> child : changedNode.getParent().getChildren() )
+            {
+                child.getPayload().setMarked( false );
+            }
+            return changedNode.getParent();
+        }
+
+        return changedNode;
+    }
+
+    /**
+     * Optimizes the tree by making the marked nodes as leafs, basically cutting all the branches that are below marked
+     * node.
+     * 
+     * @param changedNode
+     */
+    protected void optimizeTreeSize( final Node<Payload> changedNode )
+    {
+        // simply "cut off" children if any
+        for ( Node<Payload> child : changedNode.getChildren() )
+        {
+            changedNode.removeChild( child );
+        }
+    }
+
+    /**
+     * Applies function recursively from the given node.
+     * 
+     * @param fromNode
+     * @param modifier
+     */
+    protected void applyRecursively( final Node<Payload> fromNode, final Function<Node<Payload>, Node<Payload>> modifier )
+    {
+        modifier.apply( fromNode );
+
+        for ( Node<Payload> child : fromNode.getChildren() )
+        {
+            applyRecursively( child, modifier );
+        }
+    }
+
+    /**
+     * Returns true if parent exists (passed in node is not ROOT), and if parent {@link Payload#isMarked()} returns
+     * {@code true}.
+     * 
+     * @param node
+     * @return
+     */
+    protected boolean isParentMarked( final Node<Payload> node )
+    {
+        final Node<Payload> parent = node.getParent();
+
+        if ( parent != null )
+        {
+            if ( parent.getPayload().isMarked() )
+            {
+                return true;
+            }
+            else
+            {
+                return isParentMarked( parent );
+            }
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if parent exists (passed in node is not ROOT), and parent's all children are marked (their
+     * {@link Payload#isMarked()} is {@code true} for all of them.
+     * 
+     * @param node
+     * @return
+     */
+    protected boolean isParentAllChildMarkedForRuleB( final Node<Payload> node )
+    {
+        final Node<Payload> parent = node.getParent();
+
+        if ( parent != null )
+        {
+            final List<Node<Payload>> children = parent.getChildren();
+
+            if ( children.size() < 2 )
+            {
+                return false;
+            }
+
+            for ( Node<Payload> child : children )
+            {
+                if ( !child.getPayload().isMarked() )
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * Builds a path from path elements list.
+     * 
+     * @param pathElems
+     * @return
+     */
+    protected String getPathElementsAsPath( final List<String> pathElems )
+    {
+        final StringBuilder sb = new StringBuilder( "/" );
+        for ( String elem : pathElems )
+        {
+            sb.append( elem ).append( "/" );
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds a path elements list from passed in path.
+     * 
+     * @param path
+     * @return
+     */
+    protected List<String> getPathElements( final String path )
+    {
+        final List<String> result = Lists.newArrayList();
+        final String[] elems = path.split( "/" );
+
+        for ( String elem : elems )
+        {
+            if ( !Strings.isNullOrEmpty( elem ) )
+            {
+                result.add( elem );
+            }
+        }
+
+        return result;
+    }
+}

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/ParentOMaticTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/ParentOMaticTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.walker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.codehaus.plexus.util.IOUtil;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Tests for ParentOMatic class.
+ * 
+ * @author cstamas
+ */
+public class ParentOMaticTest
+{
+    protected void printListPerLine( final List<String> strings )
+    {
+        for ( String string : strings )
+        {
+            print( string );
+        }
+    }
+
+    /**
+     * Flip this to false if you want to see output on System.out instead do actual comparison. Useful if behaviour
+     * changes, and you need to generate text files that you can save (after you verifies it's correctness) to assert
+     * against it. With having COMPARE=false this test will never fail!
+     */
+    private final boolean COMPARE = true;
+
+    private StringBuilder stringBuilder;
+
+    protected void print( final String str )
+    {
+        if ( COMPARE )
+        {
+            stringBuilder.append( str ).append( "\n" );
+        }
+        else
+        {
+            System.out.println( str );
+        }
+    }
+
+    protected void doAssert()
+        throws Exception
+    {
+        if ( COMPARE )
+        {
+            final String callerName = getCallerMethodName();
+            final String actualClasspathName = getClass().getSimpleName() + "-" + callerName + ".txt";
+            final InputStream actualInputStream = getClass().getResourceAsStream( actualClasspathName );
+            final String actual = IOUtil.toString( actualInputStream );
+
+            assertThat( actual, Matchers.equalTo( stringBuilder.toString() ) );
+        }
+    }
+
+    protected String getCallerMethodName()
+    {
+        final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        return stackTrace[3].getMethodName();
+    }
+
+    /**
+     * Simple "naive" case. Just adding a bunch of paths.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void exampleCase()
+        throws Exception
+    {
+        stringBuilder = new StringBuilder();
+        final ParentOMatic cn = new ParentOMatic();
+
+        print( "Example case" );
+        print( "" );
+        cn.addAndMarkPath( "/foo/bam/car2" );
+        cn.addAndMarkPath( "/foo/baz" );
+        cn.addAndMarkPath( "/foo/baz/foo" );
+        cn.addAndMarkPath( "/foo/bar" );
+        cn.addAndMarkPath( "/foo/bar/car1" );
+        cn.addAndMarkPath( "/foo/bar/car3" );
+        print( cn.dump() );
+        print( "" );
+        print( "Maven MD recreate would run against paths:" );
+        printListPerLine( cn.getMarkedPaths() );
+        doAssert();
+    }
+
+    /**
+     * "Peter's case" as Peter did actually implement this and realized that snapshot removal (main work) takes 3
+     * minutes, and all the "bookkeeping" takes 20 minutes. This is kinda "generated" repository and snapshot removals
+     * are equally spread out.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void petersCase()
+        throws Exception
+    {
+        stringBuilder = new StringBuilder();
+        final ParentOMatic cn = new ParentOMatic();
+
+        print( "Peter's case" );
+        print( "" );
+        cn.addAndMarkPath( "/g1/a1/v1" );
+        cn.addAndMarkPath( "/g1/a1/v2" );
+        cn.addAndMarkPath( "/g1/a1/v3" );
+        cn.addAndMarkPath( "/g1/a2/v1" );
+        cn.addAndMarkPath( "/g1/a2/v2" );
+        cn.addAndMarkPath( "/g1/a2/v3" );
+        cn.addAndMarkPath( "/g1/a3/v1" );
+        cn.addAndMarkPath( "/g1/a3/v2" );
+        cn.addAndMarkPath( "/g1/a3/v3" );
+        print( cn.dump() );
+        print( "" );
+        print( "Maven MD recreate would run against paths:" );
+        printListPerLine( cn.getMarkedPaths() );
+        doAssert();
+    }
+
+}

--- a/nexus/nexus-api/src/test/resources/org/sonatype/nexus/proxy/walker/ParentOMaticTest-exampleCase.txt
+++ b/nexus/nexus-api/src/test/resources/org/sonatype/nexus/proxy/walker/ParentOMaticTest-exampleCase.txt
@@ -1,0 +1,14 @@
+Example case
+
+ROOT (/)
+  foo (/foo/)
+    bam (/foo/bam/)
+      car2 (/foo/bam/car2/)*
+    baz (/foo/baz/)*
+    bar (/foo/bar/)*
+
+
+Maven MD recreate would run against paths:
+/foo/bam/car2/
+/foo/baz/
+/foo/bar/

--- a/nexus/nexus-api/src/test/resources/org/sonatype/nexus/proxy/walker/ParentOMaticTest-petersCase.txt
+++ b/nexus/nexus-api/src/test/resources/org/sonatype/nexus/proxy/walker/ParentOMaticTest-petersCase.txt
@@ -1,0 +1,13 @@
+Peter's case
+
+ROOT (/)
+  g1 (/g1/)
+    a1 (/g1/a1/)*
+    a2 (/g1/a2/)*
+    a3 (/g1/a3/)*
+
+
+Maven MD recreate would run against paths:
+/g1/a1/
+/g1/a2/
+/g1/a3/

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/SnapshotRemovalRequest.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/maven/tasks/SnapshotRemovalRequest.java
@@ -31,8 +31,6 @@ public class SnapshotRemovalRequest
 
     private final boolean removeIfReleaseExists;
 
-    private final Set<String> metadataRebuildPaths;
-    
     private final Set<String> processedRepos;
 
     private final boolean deleteImmediately;
@@ -50,7 +48,8 @@ public class SnapshotRemovalRequest
     }
 
     public SnapshotRemovalRequest( String repositoryId, int minCountOfSnapshotsToKeep,
-                                   int removeSnapshotsOlderThanDays, boolean removeIfReleaseExists, boolean deleteImmediately )
+                                   int removeSnapshotsOlderThanDays, boolean removeIfReleaseExists,
+                                   boolean deleteImmediately )
     {
         this.repositoryId = repositoryId;
 
@@ -60,13 +59,10 @@ public class SnapshotRemovalRequest
 
         this.removeIfReleaseExists = removeIfReleaseExists;
 
-        this.metadataRebuildPaths = new HashSet<String>();
-
         this.processedRepos = new HashSet<String>();
 
         this.deleteImmediately = deleteImmediately;
     }
-
 
     public String getRepositoryId()
     {
@@ -88,16 +84,11 @@ public class SnapshotRemovalRequest
         return removeIfReleaseExists;
     }
 
-    public Set<String> getMetadataRebuildPaths()
-    {
-        return metadataRebuildPaths;
-    }
-    
     public void addProcessedRepo( String repoId )
     {
         this.processedRepos.add( repoId );
     }
-    
+
     public boolean isProcessedRepo( String repoId )
     {
         return this.processedRepos.contains( repoId );

--- a/nexus/nexus-utils/pom.xml
+++ b/nexus/nexus-utils/pom.xml
@@ -41,9 +41,17 @@
 
   <dependencies>
 
+    <!-- To move away from, it's "legacy" from oldie Plexus times -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <!-- Target to move to -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>compile</scope>
     </dependency>
 
     <!-- Testing -->

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/Node.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/Node.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A simple and generic "tree like" structure for use cases where applicable. It assumes root node has {@code null}
+ * parent, but you can easily override the {@link #isRoot()} method if needed. Implementation uses {@link LinkedHashMap}
+ * to store keyed children, hence it should be fast, and preserve addition ordering, but not so conservative on memory
+ * in case of huge trees.
+ * 
+ * @author cstamas
+ * @param <P>
+ * @since 1.10.0
+ */
+public class Node<P>
+{
+    private final Node<P> parent;
+
+    private final String label;
+
+    private final P payload;
+
+    private final LinkedHashMap<String, Node<P>> children;
+
+    /**
+     * Contructs a node instance.
+     * 
+     * @param parent the parent of the created node.
+     * @param label the label of the created node.
+     * @param payload the payload of the created node.
+     */
+    public Node( final Node<P> parent, final String label, final P payload )
+    {
+        this.parent = parent;
+        this.label = Preconditions.checkNotNull( label );
+        this.payload = payload;
+        this.children = new LinkedHashMap<String, Node<P>>();
+    }
+
+    // ==
+
+    /**
+     * Returns the parent node of this node, or {@code null} if this is "root" node.
+     * 
+     * @return
+     */
+    public Node<P> getParent()
+    {
+        return parent;
+    }
+
+    /**
+     * Returns {@code true} if this node is root node.
+     * 
+     * @return
+     */
+    public boolean isRoot()
+    {
+        return getParent() == null;
+    }
+
+    /**
+     * Returns the depth from the "root" node. Root node has depth 0.
+     * 
+     * @return
+     */
+    public int getDepth()
+    {
+        Node<P> currentNode = this;
+        int result = 0;
+        while ( !currentNode.isRoot() )
+        {
+            currentNode = currentNode.getParent();
+            result++;
+        }
+        return result;
+    }
+
+    /**
+     * Returns the "label" of this node, never {@code null}.
+     * 
+     * @return
+     */
+    public String getLabel()
+    {
+        return label;
+    }
+
+    /**
+     * Returns the "payload" associated with this node.
+     * 
+     * @return
+     */
+    public P getPayload()
+    {
+        return payload;
+    }
+
+    /**
+     * Creates a child node of this node, and returns it, never returns {@code null}.
+     * 
+     * @param label
+     * @param payload
+     * @return
+     */
+    public Node<P> addChild( final String label, final P payload )
+    {
+        final Node<P> node = new Node<P>( this, label, payload );
+        this.children.put( node.getLabel(), node );
+        return node;
+    }
+
+    /**
+     * Removes the child from this node's children.
+     * 
+     * @param child
+     */
+    public void removeChild( final Node<P> child )
+    {
+        children.remove( child.getLabel() );
+    }
+
+    /**
+     * Returns the child of this node that has "labal" equals to the passed in, or {@code null} if no child present with
+     * such label.
+     * 
+     * @param label
+     * @return
+     */
+    public Node<P> getChildByLabel( final String label )
+    {
+        return children.get( label );
+    }
+
+    /**
+     * Returns an immutable snapshot of this node's children as list of nodes.
+     * 
+     * @return
+     */
+    public List<Node<P>> getChildren()
+    {
+        return new ImmutableList.Builder<Node<P>>().addAll( children.values() ).build();
+    }
+
+}


### PR DESCRIPTION
As Peter's testing against generated snapshot repository with 13000 artifacts revealed an interesting results (snapshot removal using 1.9.2.3 takes 3(!) minutes, but the "post processing" is 20 minutes, hence to complete the task you need to wait cca 23 minutes), the need for a special device emerged.

And here it is: Parent-O-Matic!

The problem with Snapshot remover was actually a lame "optimization" added in there, that seemed correct in "laboratory" circumstances (and ITs), but resulted in "anti-optimization" in real life: there was a Map that gathered which paths need to have "rebuild maven metadata" regeneration applied. On large repositories, this path ended up with all the existing paths in repository, and even OOMed Nexus. 

Finally, this change does not makes previous (already merged) pull request also related to NEXUS-4640 obsolete. While it also fixed major issues, it's fix covered so to tell just 10% of the problem, while this fix covers the rest of it, and even OOM related issue (the one linked to NEXUS-4640).
