### PR TITLE
Nexus 4691 progress listener npe

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4520/Nexus4520PlexusPrefixedVariablesArePickedUpIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4520/Nexus4520PlexusPrefixedVariablesArePickedUpIT.java
@@ -78,7 +78,11 @@ public class Nexus4520PlexusPrefixedVariablesArePickedUpIT
     public void restoreOut()
         throws Exception
     {
-        System.setOut( actualOut );
+        if ( actualOut != null )
+        {
+            // if null mean @Before did not ran for some reason
+            System.setOut( actualOut );
+        }
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/report/ProgressListener.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/report/ProgressListener.java
@@ -18,6 +18,8 @@
  */
 package org.sonatype.nexus.integrationtests.report;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.PrintStream;
 
 import org.testng.ITestContext;
@@ -52,7 +54,7 @@ public class ProgressListener
     {
         super.onTestFailure( tr );
 
-        showResult( tr, "FAILED",  System.out );
+        showResult( tr, "FAILED", System.out );
     }
 
     @Override
@@ -60,7 +62,7 @@ public class ProgressListener
     {
         super.onTestSkipped( tr );
 
-        showResult( tr, "skipped",  System.out );
+        showResult( tr, "skipped", System.out );
     }
 
     @Override
@@ -68,11 +70,15 @@ public class ProgressListener
     {
         super.onTestSuccess( tr );
 
-        showResult( tr, "SUCCESS",  System.out );
+        showResult( tr, "SUCCESS", System.out );
     }
 
     private void showResult( ITestResult result, String status, PrintStream printer )
     {
+        checkNotNull( result );
+        checkNotNull( result.getTestClass() );
+        checkNotNull( printer );
+
         printer.println( "Result: " + result.getTestClass().getName() + "." + result.getName() + "() ===> " + status );
     }
 


### PR DESCRIPTION
I added some extra checks on ProgressListener and got more accurate logs
https://builds.sonatype.org/view/nexus/job/nexus-oss-its-feature/jdk=java-6x,label=linux/107/consoleFull
{code}
Caused by: java.lang.NullPointerException
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:187)
    at org.sonatype.nexus.integrationtests.report.ProgressListener.showResult(ProgressListener.java:80)
    at org.sonatype.nexus.integrationtests.report.ProgressListener.onTestFailure(ProgressListener.java:57)
    at org.testng.internal.Invoker.runTestListeners(Invoker.java:1823)
{code}

ProgressListener.java:80 : https://github.com/sonatype/nexus/commit/3036e7d47ecd67c27c396b0f106a23fe60b6eb2c#L0R80
That mean System.out == null

I can change ProgressListener to ignore that, but why did it got null in the first place?

TestNG nature will skip @Test if any exception happens on @Before\* and that happen on NEXUS383.  Once that happen, testNG start skipping, but it doesn't skip Nexus4520PlexusPrefixedVariablesArePickedUpIT.restoreOut()

I will change it to not set out if null, but this can happen again if any future test sets System.out to null.  At least now it is easier to track.
