### PR TITLE
Get the nexus-maven-bridge-plugin working again

### DIFF
--- a/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/pom.xml
@@ -83,32 +83,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model-builder</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-repository-metadata</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-spi</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-impl</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/nexus/nexus-launcher/pom.xml
+++ b/nexus/nexus-launcher/pom.xml
@@ -31,9 +31,6 @@
 
   <artifactId>nexus-launcher</artifactId>
 
-  <properties>
-    <aether.version>1.9</aether.version>
-  </properties>
   <packaging>jar</packaging>
 
   <name>Nexus : Launcher</name>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -155,7 +155,7 @@
     <it.nexus.log.level>INFO</it.nexus.log.level>
 
     <!-- version properties -->
-    <aether.version>1.8.1</aether.version>
+    <aether.version>1.9</aether.version>
     <applifecycle.version>1.4</applifecycle.version>
     <aspectj.version>1.6.11</aspectj.version>
     <commons-beanutils.baseVersion>1.7.0</commons-beanutils.baseVersion>


### PR DESCRIPTION
1. Make sure aether version is consistent throughout the build
2. Fix nexus-maven-bridge-plugin dependencies (those removed from Nexus-core are no longer provided)

These changes fix the nexus-dependency-report-plugin IT failures.
