### PR TITLE
o drop ancient guava version to make tattletale happy

### DIFF
--- a/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/DefaultPluginConsoleManager.java
+++ b/nexus/nexus-core-plugins/nexus-plugin-console-plugin/src/main/java/org/sonatype/nexus/plugins/plugin/console/DefaultPluginConsoleManager.java
@@ -66,7 +66,7 @@ public class DefaultPluginConsoleManager
     public void initialize()
         throws InitializationException
     {
-        docBundles = new LinkedHashMultimap<String, NexusDocumentationBundle>();
+        docBundles = LinkedHashMultimap.create();
 
         for ( NexusResourceBundle rb : resourceBundles )
         {

--- a/nexus/nexus-mock/src/main/java/org/sonatype/nexus/mock/rest/MockHelper.java
+++ b/nexus/nexus-mock/src/main/java/org/sonatype/nexus/mock/rest/MockHelper.java
@@ -36,10 +36,9 @@ public class MockHelper
 {
     private static final Object lock = new Object();
 
-    private static final HashBiMap<String, MockResponse> mockResponses = new HashBiMap<String, MockResponse>();
+    private static final HashBiMap<String, MockResponse> mockResponses = HashBiMap.create();
 
-    private static final HashBiMap<String, MockListener<Object>> mockListeneres =
-        new HashBiMap<String, MockListener<Object>>();;
+    private static final HashBiMap<String, MockListener<Object>> mockListeneres = HashBiMap.create();
 
     private static final ThreadLocal<List<MockResponse>> responses = new ThreadLocal<List<MockResponse>>();
 

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -126,10 +126,6 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.google-collections</groupId>
-      <artifactId>google-collect</artifactId>
-    </dependency>
      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryTypeRegistry.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryTypeRegistry.java
@@ -41,8 +41,8 @@ import org.sonatype.nexus.proxy.repository.GroupRepository;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 
 @Component( role = RepositoryTypeRegistry.class )
 public class DefaultRepositoryTypeRegistry
@@ -74,7 +74,7 @@ public class DefaultRepositoryTypeRegistry
             if ( repositoryTypeDescriptorsMap == null )
             {
                 Multimap<Class<? extends Repository>, RepositoryTypeDescriptor> result =
-                    Multimaps.newArrayListMultimap();
+                    ArrayListMultimap.create();
 
                 // fill in the defaults
                 Class<? extends Repository> role = null;

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -598,11 +598,6 @@
 
       <!-- Various commonly used deps -->
       <dependency>
-        <groupId>com.google.code.google-collections</groupId>
-        <artifactId>google-collect</artifactId>
-        <version>snapshot-20080530</version>
-      </dependency>
-      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
         <version>2.5</version>


### PR DESCRIPTION
nexus-oss-webapp did not build because of tattletale finding multiple instances of guava. This is a backport of eb31ebb13e3f32fcb752de7ca70316ce7f19194d.

(this is nexus-1.9.2.x branch, obviously ;)
