### PR TITLE
Change license check to ignore target folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             </includes>
             <excludes>
               <!-- we have target pattern in this format because of target package in nexus-api and nexus-proxy modules -->
-              <exclude>**/nexus*/target/**</exclude>
+              <exclude>**/target/**</exclude>
               <exclude>**/nexus-ldap-plugin-parent/ldap-common/target/**</exclude>
               <exclude>**/ext-2.3/**</exclude>
               <exclude>**/js/filetree/**</exclude>


### PR DESCRIPTION
Build is failing here due to:
[INFO] --- maven-license-plugin:1.9.0:check (license-check-agplv2) @ nexus-aggregator ---
[INFO] Checking licenses...
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-faster-windows.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-header-buffer.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-ajp.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-dual-ports-with-ssl.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-simple-https-proxy.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty-ssl.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\jetty.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\jetty.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\examples\proxy-https\jetty.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\metadata\metadata.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\car-nexus-oss\target\assembly\data\${confDir}\plexus.xml
[INFO] Missing header in: S:\nexus\nexus\nexus-distributions\nexus-distribution-archives\itar-plexus-container-guice\target\assembly\metadata\metadata.xml
[INFO] ------------------------------------------------------------------------

Does anyone know if there is any reason to ignore nexus-*/target instead of ALL target folder?
