### PR TITLE
o Turn off maven-specific fields in repo editor UI for non-maven-repositories

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
@@ -1178,7 +1178,7 @@ Ext.extend(Sonatype.repoServer.ProxyRepositoryEditor, Sonatype.repoServer.Abstra
 
         var repoType = receivedData.repoType;
 
-        if (repoType == 'proxy' && !receivedData.remoteStorage.remoteStorageUrl.match(REPO_REMOTE_STORAGE_REGEXP))
+        if (repoType == 'proxy' && receivedData.remoteStorage && !receivedData.remoteStorage.remoteStorageUrl.match(REPO_REMOTE_STORAGE_REGEXP))
         {
           var rsUrl = this.form.findField('remoteStorage.remoteStorageUrl');
           rsUrl.disable();

--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
@@ -326,21 +326,21 @@ Ext.extend(Sonatype.repoServer.AbstractRepositoryEditor, Sonatype.ext.FormPanel,
           }
         }
       },
+      updateFields : function(form, data) {
+        this.updateIndexableCombo(form, data.format);
+        this.updateRepoPolicyField(form, data.format, data.repoPolicy)
+        this.updateDownloadRemoteIndexCombo(form, data.format);
+        this.contribute(data, 'enter')
+      },
       afterProviderSelectHandler : function(combo, rec, index) {
-        this.updateIndexableCombo(this.form, rec.data.format);
-        this.updateRepoPolicyField(this.form, rec.data.format, rec.data.repoPolicy)
-        this.updateDownloadRemoteIndexCombo(this.form, rec.data.format);
+        this.updateFields(this.form, rec.data);
       },
       showHandler : function() {
         this.updateWritePolicy();
       },
       loadHandler : function(form, action, receivedData) {
-        this.updateRepoPolicyField(form, receivedData.format, receivedData.repoPolicy);
-        this.updateIndexableCombo(form, receivedData.format);
-        this.updateDownloadRemoteIndexCombo(form, receivedData.format);
-        this.contribute( receivedData, 'enter' )
+        this.updateFields(form, receivedData)
       }
-
     });
 
 Sonatype.repoServer.HostedRepositoryEditor = function(config) {


### PR DESCRIPTION
This change only enables repoPolicy, indexable and download remote index field for repositories with maven format. It also adds hooks before/after the repo editor contents change, so plugins do not have to handle load and repoProvider.select (for 'New Repository') differently.
