### PR TITLE
NEXUS-4660: Attributes improvements

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/attributes/AttributeStorage.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/attributes/AttributeStorage.java
@@ -18,13 +18,15 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
+import java.io.IOException;
+
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.storage.local.LocalRepositoryStorage;
 
 /**
  * AttributeStorage manages persistence of StorageItem Attributes. Is used by LocalStorages and should not be directly
  * used (ie. by a plugin).
- *
+ * 
  * @author cstamas
  * @see LocalRepositoryStorage
  */
@@ -33,25 +35,31 @@ public interface AttributeStorage
 
     /**
      * Returns the attributes for given key or {@code null} if no attributes found for given key.
-     *
+     * 
      * @param uid the key for which attributes needs to be fetched
      * @return the attributes or {@code null} if no attributes found for given uid.
+     * @throws IOException in case of IO problem.
      */
-    Attributes getAttributes( RepositoryItemUid uid );
+    Attributes getAttributes( RepositoryItemUid uid )
+        throws IOException;
 
     /**
      * Put attributes for given key.
-     *
-     * @param uid        the key
+     * 
+     * @param uid the key
      * @param attributes the attributes to store
+     * @throws IOException in case of IO problem.
      */
-    void putAttributes( RepositoryItemUid uid, Attributes attributes );
+    void putAttributes( RepositoryItemUid uid, Attributes attributes )
+        throws IOException;
 
     /**
      * Deletes attributes associated with given key.
-     *
+     * 
      * @param uid the uid
      * @return true, if delete actually happened (attributes for given uid existed).
+     * @throws IOException in case of IO problem.
      */
-    boolean deleteAttributes( RepositoryItemUid uid );
+    boolean deleteAttributes( RepositoryItemUid uid )
+        throws IOException;
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/attributes/AttributesHandler.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/attributes/AttributesHandler.java
@@ -18,6 +18,8 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
+import java.io.IOException;
+
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
@@ -31,7 +33,7 @@ import org.sonatype.nexus.proxy.repository.Repository;
  * to implementation) and offers some "shortcut" methods to perform updates on some (core used) attributes like
  * "lastRequested" and other. All {@link org.sonatype.nexus.proxy.item.StorageCollectionItem} types does not have
  * persisted attributes, and handler will simply not handle them.
- *
+ * 
  * @author cstamas
  */
 public interface AttributesHandler
@@ -39,14 +41,14 @@ public interface AttributesHandler
 
     /**
      * Returns the AttributeStorage used by this AttributesHandler instance.
-     *
+     * 
      * @return AttributeStorage used by this instance.
      */
     AttributeStorage getAttributeStorage();
 
     /**
      * Sets the attribute storage used by this instance.
-     *
+     * 
      * @param attributeStorage
      * @deprecated For UT uses only!
      */
@@ -55,104 +57,111 @@ public interface AttributesHandler
 
     /**
      * Fetches the item attributes and decorates the supplied item instance with it.
-     *
+     * 
      * @param item the item to have attributes loaded up and decorated with.
      */
-    void fetchAttributes( StorageItem item );
+    void fetchAttributes( StorageItem item )
+        throws IOException;
 
     /**
-     * Stores the item attributes. If non-null content locator is supplied, attributes will be recalculated before saving.
-     *
-     * @param item    the item
+     * Stores the item attributes. If non-null content locator is supplied, attributes will be recalculated before
+     * saving.
+     * 
+     * @param item the item
      * @param content the content of the item if we deal with StorageFileItem
      */
-    void storeAttributes( StorageItem item, ContentLocator content );
+    void storeAttributes( StorageItem item, ContentLocator content )
+        throws IOException;
 
     /**
      * Stores item attributes, as-is, will not try attribute expansion either.
-     *
+     * 
      * @param item the item
      */
-    void storeAttributes( StorageItem item );
+    void storeAttributes( StorageItem item )
+        throws IOException;
 
     /**
      * Removes the item attributes from attribute storage.
-     *
+     * 
      * @param uid the uid
      * @return true if attributes are found and deleted, false otherwise.
      */
-    boolean deleteAttributes( RepositoryItemUid uid );
+    boolean deleteAttributes( RepositoryItemUid uid )
+        throws IOException;
 
     /**
-     * Sets the storageItem's "checkedRemotely" attribute (a timestamp in millis) to the passed in one and persists
-     * the modified attributes.
-     *
+     * Sets the storageItem's "checkedRemotely" attribute (a timestamp in millis) to the passed in one and persists the
+     * modified attributes.
+     * 
      * @param timestamp
      * @param storageItem
      */
-    void touchItemCheckedRemotely( long timestamp, StorageItem storageItem );
+    void touchItemCheckedRemotely( long timestamp, StorageItem storageItem )
+        throws IOException;
 
     /**
-     * Sets the storageItem's "lastRequested" attribute (a timestamp in millis) to the passed in one and persists
-     * the modified attributes.
-     *
+     * Sets the storageItem's "lastRequested" attribute (a timestamp in millis) to the passed in one and persists the
+     * modified attributes.
+     * 
      * @param timestamp
      * @param storageItem
      */
-    void touchItemLastRequested( long timestamp, StorageItem storageItem );
+    void touchItemLastRequested( long timestamp, StorageItem storageItem )
+        throws IOException;
 
     // ==
 
     /**
      * Updates the "checkedRemotely" attribute of item in given repository Touch item and sets on it the current time.
-     *
+     * 
      * @deprecated Use {@link #touchItemCheckedRemotely(long, org.sonatype.nexus.proxy.item.StorageItem)} instead.
      */
     @Deprecated
     void touchItemRemoteChecked( Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 
     /**
      * Touch item and sets on it the given timestamp.
-     *
+     * 
      * @deprecated Use {@link #touchItemCheckedRemotely(long, org.sonatype.nexus.proxy.item.StorageItem)} instead.
      */
     @Deprecated
     void touchItemRemoteChecked( long timestamp, Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 
     /**
      * Touch item last requested and sets on it the current time.
-     *
+     * 
      * @deprecated Use {@link #touchItemLastRequested(long, org.sonatype.nexus.proxy.item.StorageItem)} instead.
      */
     @Deprecated
     void touchItemLastRequested( Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 
     /**
      * Touch item last requested and sets on it the given timestamp.
-     *
+     * 
      * @deprecated Use {@link #touchItemLastRequested(long, org.sonatype.nexus.proxy.item.StorageItem)} instead.
      */
     void touchItemLastRequested( long timestamp, Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 
     /**
      * Touch only if request is user-request (coming from outside of nexus).
-     *
+     * 
      * @deprecated Use {@link #touchItemLastRequested(long, org.sonatype.nexus.proxy.item.StorageItem)} instead.
      */
     void touchItemLastRequested( long timestamp, Repository repository, ResourceStoreRequest request,
                                  StorageItem storageItem )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 
     /**
      * Update item attributes, does not modify the content of it.
-     *
+     * 
      * @deprecated Use {@link #storeAttributes(org.sonatype.nexus.proxy.item.StorageItem)} instead!
      */
     @Deprecated
     void updateItemAttributes( Repository repository, ResourceStoreRequest request, StorageItem item )
-        throws ItemNotFoundException, LocalStorageException;
+        throws ItemNotFoundException, LocalStorageException, IOException;
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsItemAttributeMetacontentAttribute.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsItemAttributeMetacontentAttribute.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUid;
  * not holding data serving the basic purpose of this given repository.
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class IsItemAttributeMetacontentAttribute
     implements Attribute<Boolean>

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsItemAttributeMetacontentAttribute.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsItemAttributeMetacontentAttribute.java
@@ -21,21 +21,24 @@ package org.sonatype.nexus.proxy.item.uid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 
 /**
- * Attribute yielding "false" for real repository content, and "true" for all the "meta content", that is actually not
- * holding data serving the basic purpose of this given repository.
+ * Attribute yielding "false" for real repository content, and "true" for all the "item attributes", that is actually
+ * not holding data serving the basic purpose of this given repository.
  * 
  * @author cstamas
  */
-public class IsMetacontentAttribute
+public class IsItemAttributeMetacontentAttribute
     implements Attribute<Boolean>
 {
     public Boolean getValueFor( RepositoryItemUid subject )
     {
-        // stuff not having metadata:
         // /.nexus/attributes
-        // /.nexus/trash
-        // we are specific about these for a good reason (see future)
-        return subject.getBooleanAttributeValue( IsItemAttributeMetacontentAttribute.class )
-            || subject.getBooleanAttributeValue( IsTrashMetacontentAttribute.class );
+        if ( subject.getPath() != null )
+        {
+            return subject.getPath().startsWith( "/.nexus/attributes" );
+        }
+        else
+        {
+            return false;
+        }
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsTrashMetacontentAttribute.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsTrashMetacontentAttribute.java
@@ -21,21 +21,24 @@ package org.sonatype.nexus.proxy.item.uid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 
 /**
- * Attribute yielding "false" for real repository content, and "true" for all the "meta content", that is actually not
+ * Attribute yielding "false" for real repository content, and "true" for all the "trash content", that is actually not
  * holding data serving the basic purpose of this given repository.
  * 
  * @author cstamas
  */
-public class IsMetacontentAttribute
+public class IsTrashMetacontentAttribute
     implements Attribute<Boolean>
 {
     public Boolean getValueFor( RepositoryItemUid subject )
     {
-        // stuff not having metadata:
-        // /.nexus/attributes
         // /.nexus/trash
-        // we are specific about these for a good reason (see future)
-        return subject.getBooleanAttributeValue( IsItemAttributeMetacontentAttribute.class )
-            || subject.getBooleanAttributeValue( IsTrashMetacontentAttribute.class );
+        if ( subject.getPath() != null )
+        {
+            return subject.getPath().startsWith( "/.nexus/trash" );
+        }
+        else
+        {
+            return false;
+        }
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsTrashMetacontentAttribute.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/uid/IsTrashMetacontentAttribute.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUid;
  * holding data serving the basic purpose of this given repository.
  * 
  * @author cstamas
+ * @since 1.10.0
  */
 public class IsTrashMetacontentAttribute
     implements Attribute<Boolean>

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/ApplicationConfigurationAdapter.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/ApplicationConfigurationAdapter.java
@@ -50,9 +50,14 @@ public class ApplicationConfigurationAdapter
         return nexusConfiguration.getWorkingDirectory();
     }
 
-    public File getWorkingDirectory( String key )
+    public File getWorkingDirectory( final String key )
     {
         return nexusConfiguration.getWorkingDirectory( key );
+    }
+
+    public File getWorkingDirectory( final String key, final boolean createIfNeeded )
+    {
+        return nexusConfiguration.getWorkingDirectory( key, createIfNeeded );
     }
 
     public File getTemporaryDirectory()

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
@@ -244,7 +244,8 @@ public class DefaultNexusConfiguration
             applicationEventMulticaster.notifyEventListeners( new ConfigurationCommitEvent( this ) );
 
             String userId = null;
-            Subject subject = ThreadContext.getSubject(); // Use ThreadContext directly, SecurityUtils will associate a new Subject with the thread.
+            Subject subject = ThreadContext.getSubject(); // Use ThreadContext directly, SecurityUtils will associate a
+                                                          // new Subject with the thread.
             if ( subject != null && subject.getPrincipal() != null )
             {
                 userId = subject.getPrincipal().toString();
@@ -353,17 +354,27 @@ public class DefaultNexusConfiguration
 
     public File getWorkingDirectory( String key )
     {
+        return getWorkingDirectory( key, true );
+    }
+
+    public File getWorkingDirectory( final String key, final boolean createIfNeeded )
+    {
         File keyedDirectory = new File( getWorkingDirectory(), key );
 
-        if ( !keyedDirectory.isDirectory() && !keyedDirectory.mkdirs() )
+        if ( createIfNeeded )
         {
-            String message =
-                "\r\n******************************************************************************\r\n"
-                    + "* Could not create work directory [ " + keyedDirectory.toString() + "]!!!! *\r\n"
-                    + "* Nexus cannot start properly until the process has read+write permissions to this folder *\r\n"
-                    + "******************************************************************************";
+            if ( !keyedDirectory.isDirectory() && !keyedDirectory.mkdirs() )
+            {
+                String message =
+                    "\r\n******************************************************************************\r\n"
+                        + "* Could not create work directory [ "
+                        + keyedDirectory.toString()
+                        + "]!!!! *\r\n"
+                        + "* Nexus cannot start properly until the process has read+write permissions to this folder *\r\n"
+                        + "******************************************************************************";
 
-            getLogger().fatalError( message );
+                getLogger().fatalError( message );
+            }
         }
 
         return keyedDirectory;

--- a/nexus/nexus-configuration-model/src/main/java/org/sonatype/nexus/configuration/application/ApplicationConfiguration.java
+++ b/nexus/nexus-configuration-model/src/main/java/org/sonatype/nexus/configuration/application/ApplicationConfiguration.java
@@ -46,6 +46,16 @@ public interface ApplicationConfiguration
     File getWorkingDirectory( String key );
 
     /**
+     * Gets the working directory with some subpath. The directory is created if needed.
+     * 
+     * @param key the subpath you want to have access to
+     * @param createIfNeeded set to {@code true} if you want to have it created, {@code false} otherwise. 
+     * @return
+     * @since 1.10.0
+     */
+    File getWorkingDirectory( String key, boolean createIfNeeded );
+
+    /**
      * Returns the configuration directory. It defaults to $NEXUS_WORK/conf.
      * 
      * @return

--- a/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
+++ b/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
@@ -26,11 +26,9 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
-import org.sonatype.nexus.configuration.AbstractNexusTestCase;
 import org.sonatype.nexus.configuration.ConfigurationCommitEvent;
 import org.sonatype.nexus.configuration.ConfigurationPrepareForSaveEvent;
 import org.sonatype.nexus.configuration.ConfigurationSaveEvent;
-import org.sonatype.nexus.configuration.model.CRemoteConnectionSettings;
 import org.sonatype.nexus.configuration.model.CRepositoryGrouping;
 import org.sonatype.nexus.configuration.model.CRouting;
 import org.sonatype.nexus.configuration.model.Configuration;
@@ -89,7 +87,17 @@ public class SimpleApplicationConfiguration
 
     public File getWorkingDirectory( String key )
     {
-        return new File( getWorkingDirectory(), key );
+        return getWorkingDirectory( key, true );
+    }
+
+    public File getWorkingDirectory( String key, boolean create )
+    {
+        final File result = new File( getWorkingDirectory(), key );
+        if ( !result.exists() )
+        {
+            result.mkdirs();
+        }
+        return result;
     }
 
     public File getTemporaryDirectory()
@@ -140,9 +148,8 @@ public class SimpleApplicationConfiguration
         }
         catch ( ContextException e )
         {
-            throw new RuntimeException(
-                "Missing key from plexus context: " + NexusTestSupport.WORK_CONFIGURATION_KEY, e
-            );
+            throw new RuntimeException( "Missing key from plexus context: " + NexusTestSupport.WORK_CONFIGURATION_KEY,
+                e );
         }
     }
 

--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/src/test/java/org/sonatype/nexus/events/DummyNexusConfiguration.java
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/src/test/java/org/sonatype/nexus/events/DummyNexusConfiguration.java
@@ -65,6 +65,13 @@ public class DummyNexusConfiguration
     }
 
     @Override
+    public File getWorkingDirectory( String key, boolean createIfNeeded )
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
     public File getConfigurationDirectory()
     {
         // TODO Auto-generated method stub

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultAttributesHandler.java
@@ -50,11 +50,11 @@ import org.sonatype.nexus.proxy.storage.local.fs.FileContentLocator;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 
 /**
- * The default implementation of AttributesHandler. Does not have any assumption regarding actual AttributeStorage
- * it uses. It uses {@link StorageItemInspector} and {@link StorageFileItemInspector} components for "expansion"
- * of core (and custom) attributes (those components might come from plugins too). This class also implements some
+ * The default implementation of AttributesHandler. Does not have any assumption regarding actual AttributeStorage it
+ * uses. It uses {@link StorageItemInspector} and {@link StorageFileItemInspector} components for "expansion" of core
+ * (and custom) attributes (those components might come from plugins too). This class also implements some
  * "optimizations" for attribute "lastRequested", by using coarser resolution for it (saving it very n-th hour or so).
- *
+ * 
  * @author cstamas
  */
 @Named
@@ -138,7 +138,7 @@ public class DefaultAttributesHandler
 
     /**
      * Gets the attribute storage.
-     *
+     * 
      * @return the attribute storage
      */
     public DelegatingAttributeStorage getAttributeStorage()
@@ -148,7 +148,7 @@ public class DefaultAttributesHandler
 
     /**
      * Sets the attribute storage.
-     *
+     * 
      * @param attributeStorage the new attribute storage
      * @deprecated For UT use only!
      */
@@ -160,7 +160,7 @@ public class DefaultAttributesHandler
 
     /**
      * Gets the item inspector list.
-     *
+     * 
      * @return the item inspector list
      */
     public List<StorageItemInspector> getItemInspectorList()
@@ -170,7 +170,7 @@ public class DefaultAttributesHandler
 
     /**
      * Sets the item inspector list.
-     *
+     * 
      * @param itemInspectorList the new item inspector list
      */
     public void setItemInspectorList( List<StorageItemInspector> itemInspectorList )
@@ -180,7 +180,7 @@ public class DefaultAttributesHandler
 
     /**
      * Gets the file item inspector list.
-     *
+     * 
      * @return the file item inspector list
      */
     public List<StorageFileItemInspector> getFileItemInspectorList()
@@ -190,7 +190,7 @@ public class DefaultAttributesHandler
 
     /**
      * Sets the file item inspector list.
-     *
+     * 
      * @param fileItemInspectorList the new file item inspector list
      */
     public void setFileItemInspectorList( List<StorageFileItemInspector> fileItemInspectorList )
@@ -203,12 +203,14 @@ public class DefaultAttributesHandler
 
     @Override
     public boolean deleteAttributes( final RepositoryItemUid uid )
+        throws IOException
     {
         return getAttributeStorage().deleteAttributes( uid );
     }
 
     @Override
     public void fetchAttributes( final StorageItem item )
+        throws IOException
     {
         if ( item instanceof StorageCollectionItem )
         {
@@ -242,6 +244,7 @@ public class DefaultAttributesHandler
 
     @Override
     public void storeAttributes( final StorageItem item )
+        throws IOException
     {
         if ( item instanceof StorageCollectionItem )
         {
@@ -254,6 +257,7 @@ public class DefaultAttributesHandler
 
     @Override
     public void storeAttributes( final StorageItem item, final ContentLocator content )
+        throws IOException
     {
         if ( item instanceof StorageCollectionItem )
         {
@@ -285,6 +289,7 @@ public class DefaultAttributesHandler
 
     @Override
     public void touchItemCheckedRemotely( final long timestamp, final StorageItem storageItem )
+        throws IOException
     {
         if ( storageItem instanceof StorageCollectionItem )
         {
@@ -308,6 +313,7 @@ public class DefaultAttributesHandler
 
     @Override
     public void touchItemLastRequested( final long timestamp, final StorageItem storageItem )
+        throws IOException
     {
         if ( storageItem instanceof StorageCollectionItem )
         {
@@ -316,13 +322,14 @@ public class DefaultAttributesHandler
         }
 
         touchItemLastRequested( timestamp, storageItem.getResourceStoreRequest(), storageItem.getRepositoryItemUid(),
-                                storageItem.getRepositoryItemAttributes() );
+            storageItem.getRepositoryItemAttributes() );
     }
 
     // ==
 
     protected void touchItemLastRequested( final long timestamp, final ResourceStoreRequest request,
                                            final RepositoryItemUid uid, final Attributes attributes )
+        throws IOException
     {
         // Touch it only if this is user-originated request (request incoming over HTTP, not a plugin or "internal" one)
         // Currently, we test for IP address presence, since that makes sure it is user request (from REST API) and not
@@ -355,7 +362,8 @@ public class DefaultAttributesHandler
     }
 
     protected boolean isTouchLastRequestedEnabled( final Repository repository )
-    {
+                    throws IOException
+   {
         // the "default"
         boolean doTouch = LAST_REQUEST_ATTRIBUTE_ENABLED;
 
@@ -383,7 +391,7 @@ public class DefaultAttributesHandler
     @Override
     @Deprecated
     public void touchItemRemoteChecked( Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         touchItemRemoteChecked( System.currentTimeMillis(), repository, request );
     }
@@ -391,7 +399,7 @@ public class DefaultAttributesHandler
     @Override
     @Deprecated
     public void touchItemRemoteChecked( long timestamp, Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         RepositoryItemUid uid = repository.createUid( request.getRequestPath() );
 
@@ -411,7 +419,7 @@ public class DefaultAttributesHandler
     @Override
     @Deprecated
     public void touchItemLastRequested( Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         touchItemLastRequested( System.currentTimeMillis(), repository, request );
     }
@@ -419,7 +427,7 @@ public class DefaultAttributesHandler
     @Override
     @Deprecated
     public void touchItemLastRequested( long timestamp, Repository repository, ResourceStoreRequest request )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         RepositoryItemUid uid = repository.createUid( request.getRequestPath() );
 
@@ -438,7 +446,7 @@ public class DefaultAttributesHandler
     @Deprecated
     public void touchItemLastRequested( long timestamp, Repository repository, ResourceStoreRequest request,
                                         StorageItem storageItem )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         if ( storageItem instanceof StorageCollectionItem )
         {
@@ -446,13 +454,13 @@ public class DefaultAttributesHandler
         }
 
         touchItemLastRequested( timestamp, request, storageItem.getRepositoryItemUid(),
-                                storageItem.getRepositoryItemAttributes() );
+            storageItem.getRepositoryItemAttributes() );
     }
 
     @Override
     @Deprecated
     public void updateItemAttributes( Repository repository, ResourceStoreRequest request, StorageItem item )
-        throws ItemNotFoundException, LocalStorageException
+        throws ItemNotFoundException, LocalStorageException, IOException
     {
         storeAttributes( item );
     }
@@ -461,10 +469,10 @@ public class DefaultAttributesHandler
     // Internal
 
     /**
-     * Expand custom item attributes using registered StorageFileItemInspector (for files) or StorageItemInspector
-     * (for everything else) components.
-     *
-     * @param item    the item
+     * Expand custom item attributes using registered StorageFileItemInspector (for files) or StorageItemInspector (for
+     * everything else) components.
+     * 
+     * @param item the item
      * @param content the input stream
      */
     protected void expandCustomItemAttributes( StorageItem item, ContentLocator content )
@@ -513,7 +521,7 @@ public class DefaultAttributesHandler
                         // unpack the file
                         tmpFile =
                             File.createTempFile( "px-" + item.getName(), ".tmp",
-                                                 applicationConfiguration.getTemporaryDirectory() );
+                                applicationConfiguration.getTemporaryDirectory() );
 
                         inputStream = content.getContent();
 
@@ -603,7 +611,7 @@ public class DefaultAttributesHandler
 
     /**
      * For UT access!
-     *
+     * 
      * @return
      */
     public long getLastRequestedResolution()
@@ -613,7 +621,7 @@ public class DefaultAttributesHandler
 
     /**
      * For UT access!
-     *
+     * 
      * @param lastRequestedResolution
      */
     public void setLastRequestedResolution( long lastRequestedResolution )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -68,6 +68,7 @@ public class DefaultLSAttributeStorage
     }
 
     public boolean deleteAttributes( final RepositoryItemUid uid )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -99,10 +100,6 @@ public class DefaultLSAttributeStorage
             {
                 // ignore it
             }
-            catch ( IOException e )
-            {
-                getLogger().warn( "Got IOException during delete of UID=" + uid.toString(), e );
-            }
 
             return false;
         }
@@ -113,6 +110,7 @@ public class DefaultLSAttributeStorage
     }
 
     public Attributes getAttributes( final RepositoryItemUid uid )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -124,16 +122,8 @@ public class DefaultLSAttributeStorage
             {
                 getLogger().debug( "Loading attributes on UID=" + uid.toString() );
             }
-            try
-            {
-                return doGetAttributes( uid );
-            }
-            catch ( IOException ex )
-            {
-                getLogger().error( "Got IOException during reading of UID=" + uid.toString(), ex );
 
-                return null;
-            }
+            return doGetAttributes( uid );
         }
         finally
         {
@@ -141,7 +131,8 @@ public class DefaultLSAttributeStorage
         }
     }
 
-    public void putAttributes( final RepositoryItemUid uid,  Attributes attributes )
+    public void putAttributes( final RepositoryItemUid uid, Attributes attributes )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -190,10 +181,6 @@ public class DefaultLSAttributeStorage
             {
                 // TODO: what here? Is local storage unsuitable for storing attributes?
                 getLogger().error( "Got UnsupportedStorageOperationException during store of UID=" + uid.toString(), ex );
-            }
-            catch ( IOException ex )
-            {
-                getLogger().error( "Got IOException during store of UID=" + uid.toString(), ex );
             }
         }
         finally

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DelegatingAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DelegatingAttributeStorage.java
@@ -18,6 +18,8 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
+import java.io.IOException;
+
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.uid.IsMetadataMaintainedAttribute;
 
@@ -47,6 +49,7 @@ public class DelegatingAttributeStorage
 
     @Override
     public Attributes getAttributes( RepositoryItemUid uid )
+        throws IOException
     {
         if ( isMetadataMaintained( uid ) )
         {
@@ -58,6 +61,7 @@ public class DelegatingAttributeStorage
 
     @Override
     public void putAttributes( RepositoryItemUid uid, Attributes attributes )
+        throws IOException
     {
         if ( isMetadataMaintained( uid ) )
         {
@@ -67,6 +71,7 @@ public class DelegatingAttributeStorage
 
     @Override
     public boolean deleteAttributes( RepositoryItemUid uid )
+        throws IOException
     {
         if ( isMetadataMaintained( uid ) )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
@@ -18,6 +18,8 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
+import java.io.IOException;
+
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -33,7 +35,7 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
  * "fallback" to some secondary instance. Usable for scenarios where "transitioning" (smooth upgrade for example) is to
  * be used, the "main" attribute storage would be "upgraded" from "legacy" attribute storage as the attributes are
  * requested over the time from this instance.
- *
+ * 
  * @author cstamas
  * @since 1.10.0
  */
@@ -61,6 +63,7 @@ public class TransitioningAttributeStorage
 
     @Override
     public Attributes getAttributes( final RepositoryItemUid uid )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -81,7 +84,15 @@ public class TransitioningAttributeStorage
                     if ( result != null )
                     {
                         mainAttributeStorage.putAttributes( uid, result );
-                        fallbackAttributeStorage.deleteAttributes( uid );
+
+                        try
+                        {
+                            fallbackAttributeStorage.deleteAttributes( uid );
+                        }
+                        catch ( IOException e )
+                        {
+                            // ignore
+                        }
                     }
                 }
                 finally
@@ -89,7 +100,7 @@ public class TransitioningAttributeStorage
                     uidLock.unlock();
                 }
             }
-            
+
             return result;
         }
         finally
@@ -100,6 +111,7 @@ public class TransitioningAttributeStorage
 
     @Override
     public void putAttributes( final RepositoryItemUid uid, final Attributes item )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -111,7 +123,14 @@ public class TransitioningAttributeStorage
 
             if ( fallbackAttributeStorage != null )
             {
-                fallbackAttributeStorage.deleteAttributes( uid );
+                try
+                {
+                    fallbackAttributeStorage.deleteAttributes( uid );
+                }
+                catch ( IOException e )
+                {
+                    // ignore it
+                }
             }
         }
         finally
@@ -122,6 +141,7 @@ public class TransitioningAttributeStorage
 
     @Override
     public boolean deleteAttributes( final RepositoryItemUid uid )
+        throws IOException
     {
         final RepositoryItemUidLock uidLock = uid.getAttributeLock();
 
@@ -129,13 +149,25 @@ public class TransitioningAttributeStorage
 
         try
         {
-            return mainAttributeStorage.deleteAttributes( uid )
-                || ( fallbackAttributeStorage != null && fallbackAttributeStorage.deleteAttributes( uid ) );
+            final boolean mainResult = mainAttributeStorage.deleteAttributes( uid );
+
+            try
+            {
+                final boolean legacyResult =
+                    ( fallbackAttributeStorage != null && fallbackAttributeStorage.deleteAttributes( uid ) );
+
+                return mainResult || legacyResult;
+            }
+            catch ( IOException e )
+            {
+                // ignore it
+            }
+
+            return mainResult;
         }
         finally
         {
             uidLock.unlock();
         }
     }
-
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
@@ -91,7 +91,8 @@ public class TransitioningAttributeStorage
                         }
                         catch ( IOException e )
                         {
-                            // ignore
+                            // nag and ignore it
+                            getLogger().debug( "Problem during legacy attribute deletion!", e );
                         }
                     }
                 }
@@ -129,7 +130,8 @@ public class TransitioningAttributeStorage
                 }
                 catch ( IOException e )
                 {
-                    // ignore it
+                    // nag and ignore it
+                    getLogger().debug( "Problem during legacy attribute deletion!", e );
                 }
             }
         }
@@ -160,7 +162,8 @@ public class TransitioningAttributeStorage
             }
             catch ( IOException e )
             {
-                // ignore it
+                // nag and ignore it
+                getLogger().debug( "Problem during legacy attribute deletion!", e );
             }
 
             return mainResult;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusStartedEvent;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
+import org.sonatype.plexus.appevents.Event;
+
+/**
+ * EventInspector that handles upgrade of "legacy attribute storage". It does it by detecting it's presence, and firing
+ * the rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did
+ * happen, to not kick in on any subsequent reboot.
+ * 
+ * @since 1.10.0
+ */
+@Component( role = EventInspector.class, hint = "AttributesUpgradeEventInspector" )
+public class AttributesUpgradeEventInspector
+    extends AbstractEventInspector
+    implements EventInspector, AsynchronousEventInspector
+{
+    @Requirement
+    private ApplicationConfiguration applicationConfiguration;
+
+    @Requirement
+    private RepositoryRegistry repositoryRegistry;
+
+    @Override
+    public boolean accepts( Event<?> evt )
+    {
+        return evt instanceof NexusStartedEvent;
+    }
+
+    @Override
+    public void inspect( Event<?> evt )
+    {
+        final File legacyAttributesDirectory = applicationConfiguration.getWorkingDirectory( "proxy/attributes", false );
+
+        if ( !legacyAttributesDirectory.isDirectory() )
+        {
+            // file not found or not a directory, stay put to not create noise in logs (new or tidied up nexus
+            // instance)
+        }
+        else
+        {
+            if ( isUpgradeDone( legacyAttributesDirectory, null ) )
+            {
+                // nag the user to remove the directory
+                getLogger().info(
+                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
+                        + legacyAttributesDirectory.getAbsolutePath() + "\" folder." );
+            }
+            else
+            {
+                new UpgraderThread( legacyAttributesDirectory, repositoryRegistry ).start();
+            }
+        }
+    }
+
+    // ==
+
+    private static final String MARKER_FILENAME = "README.txt";
+
+    private static final String MARKER_TEXT =
+        "Migration of legacy attributes finished.\nPlease delete, remove or rename this directory!";
+
+    protected static boolean isUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
+            }
+            else
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
+            }
+        }
+        catch ( IOException e )
+        {
+            return false;
+        }
+    }
+
+    protected static void markUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                FileUtils.fileWrite( new File( attributesDirectory, MARKER_FILENAME ), MARKER_TEXT );
+            }
+            else
+            {
+                final File target = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
+                // this step is needed if new repo added while upgrade not done: it will NOT have legacy attributes
+                // as other reposes, that were present in old/upgraded instance
+                target.getParentFile().mkdirs();
+                FileUtils.fileWrite( target, MARKER_TEXT );
+            }
+        }
+        catch ( IOException e )
+        {
+            // hum?
+        }
+    }
+
+    // ==
+
+    protected static class UpgraderThread
+        extends Thread
+    {
+        private Logger logger = LoggerFactory.getLogger( getClass() );
+
+        private final File legacyAttributesDirectory;
+
+        private final RepositoryRegistry repositoryRegistry;
+
+        public UpgraderThread( final File legacyAttributesDirectory, final RepositoryRegistry repositoryRegistry )
+        {
+            this.legacyAttributesDirectory = legacyAttributesDirectory;
+            this.repositoryRegistry = repositoryRegistry;
+            // to have it clearly in thread dumps
+            setName( "LegacyAttributesUpgrader" );
+            // to not prevent sudden reboots (by user, if upgrading, and rebooting)
+            setDaemon( true );
+            // to not interfere much with other stuff
+            setPriority( Thread.MIN_PRIORITY );
+        }
+
+        @Override
+        public void run()
+        {
+            if ( !isUpgradeDone( legacyAttributesDirectory, null ) )
+            {
+                logger.info( "Legacy attribute directory present, and upgrade needed. Upgrading it in background thread." );
+                ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
+                List<Repository> reposes = repositoryRegistry.getRepositories();
+                for ( Repository repo : reposes )
+                {
+                    if ( !isUpgradeDone( legacyAttributesDirectory, repo.getId() ) )
+                    {
+                        logger.info( "Upgrading legacy attributes of repository {}.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                        repo.recreateAttributes( req, null );
+                        markUpgradeDone( legacyAttributesDirectory, repo.getId() );
+                    }
+                }
+                markUpgradeDone( legacyAttributesDirectory, null );
+                logger.info(
+                    "Legacy attribute directory upgrade finished. Please delete, move or rename the \"{}\" folder.",
+                    legacyAttributesDirectory.getAbsolutePath() );
+            }
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/item/uid/CoreRepositoryItemUidAttributeSource.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/item/uid/CoreRepositoryItemUidAttributeSource.java
@@ -40,6 +40,8 @@ public class CoreRepositoryItemUidAttributeSource
         Map<Class<?>, Attribute<?>> attrs = new HashMap<Class<?>, Attribute<?>>( 2 );
 
         attrs.put( IsMetacontentAttribute.class, new IsMetacontentAttribute() );
+        attrs.put( IsTrashMetacontentAttribute.class, new IsTrashMetacontentAttribute() );
+        attrs.put( IsItemAttributeMetacontentAttribute.class, new IsItemAttributeMetacontentAttribute() );
         attrs.put( IsHiddenAttribute.class, new IsHiddenAttribute() );
         attrs.put( IsMetadataMaintainedAttribute.class, new IsMetadataMaintainedAttribute() );
         attrs.put( IsRemotelyAccessibleAttribute.class, new IsRemotelyAccessibleAttribute() );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -18,6 +18,7 @@
  */
 package org.sonatype.nexus.proxy.repository;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,7 +49,6 @@ import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeChanged;
 import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeSet;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheCreate;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheUpdate;
-import org.sonatype.nexus.proxy.events.RepositoryItemValidationEvent;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
@@ -1103,7 +1103,7 @@ public abstract class AbstractProxyRepository
                             // let the user do proper setup and probably it will try again
                             shouldGetRemote = false;
                         }
-                        catch ( StorageException ex )
+                        catch ( IOException ex )
                         {
                             // do not go remote, but we did not mark it as "remote checked" also.
                             // let the user do proper setup and probably it will try again
@@ -1251,7 +1251,7 @@ public abstract class AbstractProxyRepository
     }
 
     protected void markItemRemotelyChecked( final StorageItem item )
-        throws LocalStorageException, ItemNotFoundException
+        throws IOException, ItemNotFoundException
     {
         // remote file unchanged, touch the local one to renew it's Age
         getAttributesHandler().touchItemCheckedRemotely( System.currentTimeMillis(), item );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -49,6 +49,7 @@ import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeChanged;
 import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeSet;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheCreate;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCacheUpdate;
+import org.sonatype.nexus.proxy.events.RepositoryItemValidationEvent;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorageTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorageTest.java
@@ -57,7 +57,7 @@ public class LegacyFSAttributeStorageTest
 
         ApplicationEventMulticaster applicationEventMulticaster = Mockito.mock( ApplicationEventMulticaster.class );
         ApplicationConfiguration applicationConfiguration = Mockito.mock( ApplicationConfiguration.class );
-        Mockito.when( applicationConfiguration.getWorkingDirectory( "proxy/attributes" ) ).thenReturn(
+        Mockito.when( applicationConfiguration.getWorkingDirectory( "proxy/attributes", false ) ).thenReturn(
             proxyAttributesDirectory );
 
         attributeStorage = new LegacyFSAttributeStorage( applicationEventMulticaster, applicationConfiguration );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -161,6 +162,7 @@ public abstract class AttributeStoragePerformanceTestSupport
     // ////////////
     @Test
     public void test0PrimePutAndGettAttribute()
+        throws IOException
     {
         writeEntryToAttributeStorage( "/prime.txt" );
         getStorageItemFromAttributeStore( "/prime.txt" );
@@ -168,12 +170,14 @@ public abstract class AttributeStoragePerformanceTestSupport
 
     @Test
     public void test1PutAttribute()
+        throws IOException
     {
         writeEntryToAttributeStorage( "/a.txt" );
     }
 
     @Test
     public void test2PutAttributeX100()
+        throws IOException
     {
         for ( int ii = 0; ii < ITERATION_COUNT; ii++ )
         {
@@ -183,6 +187,7 @@ public abstract class AttributeStoragePerformanceTestSupport
 
     @Test
     public void test3GetAttribute()
+        throws IOException
     {
         Attributes storageItem = getStorageItemFromAttributeStore( "/a.txt" );
         assertThat( storageItem.get( SHA1_ATTRIBUTE_KEY ), equalTo( SHA1_ATTRIBUTE_VALUE ) );
@@ -190,6 +195,7 @@ public abstract class AttributeStoragePerformanceTestSupport
 
     @Test
     public void test4GetAttributeX100()
+        throws IOException
     {
         for ( int ii = 0; ii < ITERATION_COUNT; ii++ )
         {
@@ -199,12 +205,14 @@ public abstract class AttributeStoragePerformanceTestSupport
 
     // @Test
     public void test5DeleteAttributes()
+        throws IOException
     {
         deleteStorageItemFromAttributeStore( "/a.txt" );
     }
 
     // @Test
     public void test6DeleteAttributesX100()
+        throws IOException
     {
         for ( int ii = 0; ii < ITERATION_COUNT; ii++ )
         {
@@ -240,6 +248,7 @@ public abstract class AttributeStoragePerformanceTestSupport
     }
 
     protected void writeEntryToAttributeStorage( String path )
+        throws IOException
     {
         StorageFileItem storageFileItem =
             new DefaultStorageFileItem( repository, new ResourceStoreRequest( path ), true, true, getContentLocator() );
@@ -253,6 +262,7 @@ public abstract class AttributeStoragePerformanceTestSupport
     }
 
     protected Attributes getStorageItemFromAttributeStore( String path )
+        throws IOException
     {
         RepositoryItemUid repositoryItemUid = new TestRepositoryItemUid( repositoryItemUidFactory, repository, path );
 
@@ -260,6 +270,7 @@ public abstract class AttributeStoragePerformanceTestSupport
     }
 
     private void deleteStorageItemFromAttributeStore( String path )
+        throws IOException
     {
         RepositoryItemUid repositoryItemUid = new TestRepositoryItemUid( repositoryItemUidFactory, repository, path );
         assertThat( "Attribute was not removed from store.", attributeStorage.deleteAttributes( repositoryItemUid ) );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceITLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceITLRTest.java
@@ -19,6 +19,7 @@
 package org.sonatype.nexus.proxy.storage.local.fs.perf;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.hamcrest.MatcherAssert;
@@ -163,7 +164,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceITLRTest
     @BenchmarkOptions( benchmarkRounds = 10, warmupRounds = 1 )
     @Test
     public void validateRetieveItemWithoutLastAccessUpdate()
-        throws LocalStorageException, ItemNotFoundException
+        throws LocalStorageException, ItemNotFoundException, IOException
     {
         AttributeStorage attributeStorageSpy = Mockito.spy( repository.getAttributesHandler().getAttributeStorage() );
         repository.getAttributesHandler().setAttributeStorage( attributeStorageSpy );
@@ -181,7 +182,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceITLRTest
     @BenchmarkOptions( benchmarkRounds = 10, warmupRounds = 1 )
     @Test
     public void validateRetieveItemWithLastAccessUpdate()
-        throws LocalStorageException, ItemNotFoundException
+        throws LocalStorageException, ItemNotFoundException, IOException
     {
         AttributeStorage attributeStorageSpy = Mockito.spy( repository.getAttributesHandler().getAttributeStorage() );
         repository.getAttributesHandler().setAttributeStorage( attributeStorageSpy );
@@ -203,7 +204,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceITLRTest
     @BenchmarkOptions( benchmarkRounds = 10, warmupRounds = 1 )
     @Test
     public void validateRetieveItemWithOutLastAccessUpdateTimeDelay()
-        throws LocalStorageException, ItemNotFoundException
+        throws LocalStorageException, ItemNotFoundException, IOException
     {
         // do the test, but make sure the _iterations_ will not get out of the "resolution" span!
         // Note: this test is just broken as is, what guarantees it will finish the cycles in given X millis?


### PR DESCRIPTION
Contains:
- NEXUS-4676: Upgrade strategy
- NEXUS-4677: Smarter FSPeer to keep backup files in case of attributes

Upgrade strategy

It is implemented in a way to be applicable to all upgrade scenarios (pre2.0-2.0, pre2.0-post2.0, post2.0-post2.0), but is avoiding to use scheduler (to not cause config changes) and also marks work "done" in persistent fashion (by placing marker files in legacy directories) to not have to repeat -- potentially -- huge amount of work between reboots. In short: when detected as needed, a daemon thread (to not interfere with probable reboots during upgrade) is spawned that will simply upgrade attributes of each repository, and when done, will mark the legacy attribute folder of given legacy folder as "done". Once all work is done (all attribute folders marked as "done"), it will nag the user on every Nexus boot to "delete, move or rename" the legacy folder since it's upgraded. Once folder is not present anymore, it goes on silently to not pollute the logs.

Smarter FS Peer

The FS Peer is not able to distinguish is it "attribute being handled" or not, and according to it will perform cleanup (as today) in case of non-attributes or leave backup files in case of attributes (as user chance to perform fixes and not loose data).
