### PR TITLE
Plugins shares, not shades anymore

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/pom.xml
@@ -34,6 +34,7 @@
   <description>Adds search capablities for repository content.</description>
 
   <properties>
+    <maven.indexer.version>4.1.3-SNAPSHOT</maven.indexer.version>
     <truezip.version>7.0-rc1</truezip.version>
   </properties>
 
@@ -123,7 +124,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-component-annotations</artifactId>
-      <version>1.5.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -144,46 +144,17 @@
           <execution>
             <id>default-generate-metadata</id>
             <configuration>
-               <classpathDependencyExcludes>
-                <classpathDependencyExclude>org.apache.maven.indexer:indexer-core</classpathDependencyExclude>
-                <classpathDependencyExclude>org.apache.lucene:lucene-core</classpathDependencyExclude>
-                <classpathDependencyExclude>org.apache.lucene:lucene-highlighter</classpathDependencyExclude>
-                <classpathDependencyExclude>org.apache.lucene:lucene-memory</classpathDependencyExclude>
-              </classpathDependencyExcludes>
+              <sharedDependencies>
+                <sharedDependencies>org.apache.maven.indexer:indexer-core</sharedDependencies>
+                <sharedDependencies>org.apache.lucene:lucene-core</sharedDependencies>
+                <sharedDependencies>org.apache.lucene:lucene-highlighter</sharedDependencies>
+                <sharedDependencies>org.apache.lucene:lucene-memory</sharedDependencies>
+              </sharedDependencies>
             </configuration>
           </execution>
         </executions>
       </plugin>
 
-      <!-- We must shade 1st, to make it "shared", then create the bundle -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.3.3</version>
-        <executions>
-          <execution>
-            <id>share-indexer</id>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
-              </transformers>
-              <artifactSet>
-                <includes>
-                  <include>org.apache.maven.indexer:indexer-core</include>
-                  <include>org.apache.lucene:*</include>
-                </includes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>

--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/pom.xml
@@ -103,10 +103,10 @@
           <execution>
             <id>default-generate-metadata</id>
             <configuration>
-               <classpathDependencyExcludes>
-                 <classpathDependencyExclude>org.sonatype.spice:spice-timeline</classpathDependencyExclude>
-                 <classpathDependencyExclude>rome:rome</classpathDependencyExclude>
-              </classpathDependencyExcludes>
+              <sharedDependencies>
+                <sharedDependencies>org.sonatype.spice:spice-timeline</sharedDependencies>
+                <sharedDependencies>rome:rome</sharedDependencies>
+              </sharedDependencies>
             </configuration>
           </execution>
         </executions>
@@ -117,36 +117,6 @@
         <artifactId>plexus-component-metadata</artifactId>
       </plugin>
       
-      <!-- We must shade timeline, to make it "shared", then create the bundle -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.3.3</version>
-        <executions>
-          <execution>
-            <id>share-timeline</id>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
-              </transformers>
-              <artifactSet>
-                <includes>
-                  <include>org.sonatype.spice:spice-timeline</include>
-                  <include>rome:rome</include>
-                </includes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -166,7 +166,6 @@
     <jetty.version>6.1.19</jetty.version>
     <jsw.binaries.version>3.2.3.5</jsw.binaries.version>
     <logback.version>0.9.29</logback.version>
-    <maven.indexer.version>4.1.3-SNAPSHOT</maven.indexer.version>
     <maven.version>3.0.1</maven.version>
     <micromailer.version>1.1.1-SNAPSHOT</micromailer.version>
     <nexus.repository.metadata.version>1.2-SNAPSHOT</nexus.repository.metadata.version>
@@ -1009,11 +1008,6 @@
       </dependency>
 
       <!-- The modules -->
-      <dependency>
-        <groupId>org.apache.maven.indexer</groupId>
-        <artifactId>indexer-artifact</artifactId>
-        <version>${maven.indexer.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.sonatype.nexus</groupId>
         <artifactId>nexus-repository-metadata-api</artifactId>


### PR DESCRIPTION
Using new feature of Plugin Manager, and getting rid of exclusion+shading muck, instead marking such dependencies as simply "shared". And Plugin Manager does the rest.

Also, cleanup in POMs, moving out maven indexer related stuff to the only place
is needed: into maven-indexer-lucene-plugin
