### PR TITLE
Nexus 2692 fix it

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-default.xml
+++ b/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-default.xml
@@ -48,10 +48,12 @@
     <appender-ref ref="console"/>
   </logger>
   <logger name="org.apache.http" level="WARN"/>
-  <logger name="org.restlet" level="WARN">
+  <logger name="org.restlet" level="${it.nexus.log.level:-WARN}">
     <appender-ref ref="console"/>
+    <appender-ref ref="logfile" />
   </logger>
   <logger name="org.apache.commons" level="WARN"/>
+  <logger name="eu.medsea.mimeutil" level="WARN"/>
 
   <root level="${it.nexus.log.level:-INFO}">
     <appender-ref ref="logfile"/>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2692/AbstractEvictTaskIt.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2692/AbstractEvictTaskIt.java
@@ -204,7 +204,8 @@ public class AbstractEvictTaskIt
         age.setKey( "evictOlderCacheItemsThen" );
         age.setValue( String.valueOf( days ) );
 
-        TaskScheduleUtil.runTask( EvictUnusedItemsTaskDescriptor.ID, EvictUnusedItemsTaskDescriptor.ID, prop, age );
+        TaskScheduleUtil.runTask( EvictUnusedItemsTaskDescriptor.ID, EvictUnusedItemsTaskDescriptor.ID, 300, true,
+            prop, age );
 
         getEventInspectorsUtil().waitForCalmPeriod();
     }


### PR DESCRIPTION
This is just a place holder to the changes I made while debugging NEXUS-2692
- logback
  Add back org.restlet INFO, found it very useful while debugging
  2011-12-14 17:42:41 INFO  [roxiedItemsTask] - org.restlet.Component.LogService - 2011-12-14 17:42:41    127.0.0.1   -   127.0.0.1   59693   GET /nexus/service/local/taskhelper attempts=20&name=EvictUnusedProxiedItemsTask    204 18  -   10036   http://localhost:59693  Noelios-Restlet-Engine/1.1.6-SONATYPE-5348-V4   -

Changed eu.medsea.mimeutil to WARN, I see tons of :
2011-12-14 17:59:06 DEBUG [pool-1-thread-1] - eu.medsea.mimeutil.MimeUtil2 - Getting MIME types for file name [S:\nexus\nexus\nexus-test-harness\nexus-test-harness-its\target\nexus\nexus-work-dir\storage\central.nexus\attributes\commons-lang\commons-lang\2.1\commons-lang-2.1.pom].
2011-12-14 17:59:06 DEBUG [pool-1-thread-1] - eu.medsea.mimeutil.MimeUtil2 - Retrieved MIME types [application/xml]

If anyone disagree with either or both just lemme know.
- TaskScheduleUtil
  Add a new runTask() that will fail if the task did not finished.  Right now it always return success, tasks finished or not.
