### PR TITLE
NEXUS-4715: fixed a major bug and improvements

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepository.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepository.java
@@ -41,22 +41,6 @@ public interface ShadowRepository
     ContentClass getMasterRepositoryContentClass();
 
     /**
-     * Returns the master repository of this ShadowRepository.
-     * 
-     * @return
-     */
-    String getMasterRepositoryId();
-
-    /**
-     * Sets the master repository of this ShadowRepository.
-     * 
-     * @param masterRepository
-     * @throws IncompatibleMasterRepositoryException
-     */
-    void setMasterRepositoryId( String masterRepositoryId )
-        throws NoSuchRepositoryException, IncompatibleMasterRepositoryException;
-
-    /**
      * Gets sync at startup.
      * 
      * @return
@@ -69,6 +53,27 @@ public interface ShadowRepository
      * @param value
      */
     void setSynchronizeAtStartup( boolean value );
+
+    /**
+     * Returns the master repository of this ShadowRepository.
+     * 
+     * @return
+     * @deprecated Use {@link #getMasterRepository()}.getId() instead.
+     */
+    @Deprecated
+    String getMasterRepositoryId();
+
+    /**
+     * Sets the master repository of this ShadowRepository.
+     * 
+     * @param masterRepository
+     * @throws NoSuchRepositoryException
+     * @throws IncompatibleMasterRepositoryException
+     * @deprecated Use {@link #setMasterRepository(Repository)} instead.
+     */
+    @Deprecated
+    void setMasterRepositoryId( String masterRepositoryId )
+        throws NoSuchRepositoryException, IncompatibleMasterRepositoryException;
 
     /**
      * Returns the master.

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1LayoutedM2ShadowRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1LayoutedM2ShadowRepository.java
@@ -70,16 +70,19 @@ public class M1LayoutedM2ShadowRepository
         };
     }
 
+    @Override
     public GavCalculator getGavCalculator()
     {
         return getM1GavCalculator();
     }
 
+    @Override
     public ContentClass getRepositoryContentClass()
     {
         return contentClass;
     }
 
+    @Override
     public ContentClass getMasterRepositoryContentClass()
     {
         return masterContentClass;
@@ -91,17 +94,20 @@ public class M1LayoutedM2ShadowRepository
         return m1LayoutedM2ShadowRepositoryConfigurator;
     }
 
-    protected String transformMaster2Shadow( String path )
+    @Override
+    protected String transformMaster2Shadow( final String path )
     {
         return transformM2toM1( path );
     }
 
-    protected String transformShadow2Master( String path )
+    @Override
+    protected String transformShadow2Master( final String path )
     {
         return transformM1toM2( path );
     }
 
-    public boolean isMavenMetadataPath( String path )
+    @Override
+    public boolean isMavenMetadataPath( final String path )
     {
         return M1ArtifactRecognizer.isMetadata( path );
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2LayoutedM1ShadowRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2LayoutedM1ShadowRepository.java
@@ -70,16 +70,19 @@ public class M2LayoutedM1ShadowRepository
         };
     }
 
+    @Override
     public GavCalculator getGavCalculator()
     {
         return getM2GavCalculator();
     }
 
+    @Override
     public ContentClass getRepositoryContentClass()
     {
         return contentClass;
     }
 
+    @Override
     public ContentClass getMasterRepositoryContentClass()
     {
         return masterContentClass;
@@ -91,19 +94,21 @@ public class M2LayoutedM1ShadowRepository
         return m2LayoutedM1ShadowRepositoryConfigurator;
     }
 
-    protected String transformMaster2Shadow( String path )
+    @Override
+    protected String transformMaster2Shadow( final String path )
     {
         return transformM1toM2( path );
     }
 
-    protected String transformShadow2Master( String path )
+    @Override
+    protected String transformShadow2Master( final String path )
     {
         return transformM2toM1( path );
     }
 
-    public boolean isMavenMetadataPath( String path )
+    @Override
+    public boolean isMavenMetadataPath( final String path )
     {
         return M2ArtifactRecognizer.isMetadata( path );
     }
-
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepositoryConfigurator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepositoryConfigurator.java
@@ -47,7 +47,7 @@ public abstract class AbstractShadowRepositoryConfigurator
 
         try
         {
-            shadowRepository.setMasterRepositoryId( extConf.getMasterRepositoryId() );
+            shadowRepository.setMasterRepository( getRepositoryRegistry().getRepository( extConf.getMasterRepositoryId() ) );
         }
         catch ( IncompatibleMasterRepositoryException e )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
@@ -59,7 +59,7 @@ public class ShadowRepositoryEventInspector
 
             for ( ShadowRepository shadow : shadows )
             {
-                if ( shadow.getMasterRepositoryId().equals( ievt.getRepository().getId() ) )
+                if ( shadow.getMasterRepository().getId().equals( ievt.getRepository().getId() ) )
                 {
                     shadow.onRepositoryItemEvent( ievt );
                 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
-import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
@@ -31,14 +30,17 @@ import org.sonatype.plexus.appevents.Event;
 
 /**
  * A "relaying" event inspector that is made asynchronous and is used to relay the repository content change related
- * events to ShadowRepository instances present in system.
+ * events to ShadowRepository instances present in system. Note: this event inspector should be async to not slow down
+ * the request-processing cycle of it's master, but strange cases might happen then, like "delete" event flies in before
+ * "create" event. That is not "deadly", but might leave shadow too easily in inconsistent state. So, leave this
+ * inspector as sync until we come up with some better solution.
  * 
  * @author cstamas
  */
 @Component( role = EventInspector.class, hint = "ShadowRepositoryEventInspector" )
 public class ShadowRepositoryEventInspector
     extends AbstractEventInspector
-    implements EventInspector, AsynchronousEventInspector
+    implements EventInspector
 {
     @Requirement
     private RepositoryRegistry repositoryRegistry;

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
@@ -433,7 +433,7 @@ public abstract class AbstractRepositoryPlexusResource
 
         resource.setFormat( shadow.getRepositoryContentClass().getId() );
 
-        resource.setShadowOf( shadow.getMasterRepositoryId() );
+        resource.setShadowOf( shadow.getMasterRepository().getId() );
 
         resource.setSyncAtStartup( shadow.isSynchronizeAtStartup() );
 

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
@@ -45,7 +45,6 @@ import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
 import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
 import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
-import org.sonatype.nexus.proxy.repository.AbstractProxyRepository;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
 import org.sonatype.nexus.proxy.repository.RemoteConnectionSettings;
@@ -150,8 +149,8 @@ public class RepositoryPlexusResource
                         shadow.setName( model.getName() );
 
                         shadow.setExposed( resource.isExposed() );
-
-                        shadow.setMasterRepositoryId( model.getShadowOf() );
+                        
+                        shadow.setMasterRepository( getRepositoryRegistry().getRepository( model.getShadowOf() ) );
 
                         shadow.setSynchronizeAtStartup( model.isSyncAtStartup() );
 

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryStatusPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryStatusPlexusResource.java
@@ -200,7 +200,7 @@ public class RepositoryStatusPlexusResource
                     for ( ShadowRepository shadow : getRepositoryRegistry().getRepositoriesWithFacet(
                                                                                                       ShadowRepository.class ) )
                     {
-                        if ( repository.getId().equals( shadow.getMasterRepositoryId() ) )
+                        if ( repository.getId().equals( shadow.getMasterRepository().getId() ) )
                         {
                             shadow.setLocalStatus( localStatus );
                         }
@@ -213,7 +213,7 @@ public class RepositoryStatusPlexusResource
                     for ( ShadowRepository shadow : getRepositoryRegistry().getRepositoriesWithFacet(
                                                                                                       ShadowRepository.class ) )
                     {
-                        if ( repository.getId().equals( shadow.getMasterRepositoryId() ) )
+                        if ( repository.getId().equals( shadow.getMasterRepository().getId() ) )
                         {
                             RepositoryDependentStatusResource dependent = new RepositoryDependentStatusResource();
 


### PR DESCRIPTION
Shadows were neglected a bit.

The bug

The call from master happened on wrong method, thus it was avoiding UID locking but also NFC management (and many other things). This way it not only let Nexus instance to access same files from multiple threads, but also generated unjustified traffic (if master is proxy).

The improvements

Methods that were doubling the master setting were deprecated (setMasterRepositoryId, and it's getter pair), since they just double the code and were not used (except few classes in REST API) with easy changes.

Also, source code "refreshed" by adding @Overrides, finals and fixing some (mainly) minor code issues.
