### PR TITLE
Make possible to set the default log level for nexus via a system property

### DIFF
--- a/nexus/nexus-webapp/src/main/resources/logback.xml
+++ b/nexus/nexus-webapp/src/main/resources/logback.xml
@@ -26,7 +26,7 @@
       <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
+  <root level="${nexus.log.level:-INFO}">
     <appender-ref ref="console"/>
   </root>
 </configuration>


### PR DESCRIPTION
This log back.xml is used by nexus for logging up till the moment that our log back configuration kicks in.
Without being able to change this logging as for example from Sisu it will not be shown.
