### PR TITLE
NEXUS-4735 as initial reason, but many IT fixes

### DIFF
--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade146to1100.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade146to1100.java
@@ -29,6 +29,8 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
+import org.sonatype.nexus.configuration.model.CErrorReporting;
+import org.sonatype.nexus.configuration.model.CNotification;
 import org.sonatype.nexus.configuration.model.CRepository;
 import org.sonatype.nexus.configuration.model.v1_10_0.upgrade.BasicVersionUpgrade;
 import org.sonatype.nexus.proxy.repository.AbstractProxyRepositoryConfiguration;
@@ -102,6 +104,18 @@ public class Upgrade146to1100
         };
 
         org.sonatype.nexus.configuration.model.Configuration newc = versionConverter.upgradeConfiguration( oldc );
+        
+        // this should go into much "older" upgrader, this was a mistake!
+        if (newc.getErrorReporting() == null) {
+            CErrorReporting errorReporting = new CErrorReporting();
+            errorReporting.setEnabled( false );
+            newc.setErrorReporting( errorReporting );
+        }
+        if (newc.getNotification() == null) {
+            CNotification notification = new CNotification();
+            notification.setEnabled( false );
+            newc.setNotification( notification );
+        }
 
         newc.setVersion( org.sonatype.nexus.configuration.model.Configuration.MODEL_VERSION );
         message.setModelVersion( org.sonatype.nexus.configuration.model.Configuration.MODEL_VERSION );

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/FileConfigurationSource.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/source/FileConfigurationSource.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.configuration.validation.InvalidConfigurationException;
+import org.sonatype.configuration.validation.ValidationMessage;
 import org.sonatype.configuration.validation.ValidationRequest;
 import org.sonatype.configuration.validation.ValidationResponse;
 import org.sonatype.nexus.ApplicationStatusSource;
@@ -195,6 +196,8 @@ public class FileConfigurationSource
 
         ValidationResponse vResponse =
             getConfigurationValidator().validateModel( new ValidationRequest( getConfiguration() ) );
+        
+        dumpValidationErrors( vResponse );
 
         setValidationResponse( vResponse );
 
@@ -212,6 +215,45 @@ public class FileConfigurationSource
         else
         {
             throw new InvalidConfigurationException( vResponse );
+        }
+    }
+
+    protected void dumpValidationErrors( final ValidationResponse response )
+    {
+        // summary
+        if ( response.getValidationErrors().size() > 0 || response.getValidationWarnings().size() > 0 )
+        {
+            getLogger().error( "* * * * * * * * * * * * * * * * * * * * * * * * * *" );
+
+            getLogger().error( "Nexus configuration has validation errors/warnings" );
+
+            getLogger().error( "* * * * * * * * * * * * * * * * * * * * * * * * * *" );
+
+            if ( response.getValidationErrors().size() > 0 )
+            {
+                getLogger().error( "The ERRORS:" );
+
+                for ( ValidationMessage msg : response.getValidationErrors() )
+                {
+                    getLogger().error( msg.toString() );
+                }
+            }
+
+            if ( response.getValidationWarnings().size() > 0 )
+            {
+                getLogger().error( "The WARNINGS:" );
+
+                for ( ValidationMessage msg : response.getValidationWarnings() )
+                {
+                    getLogger().error( msg.toString() );
+                }
+            }
+
+            getLogger().error( "* * * * * * * * * * * * * * * * * * * * *" );
+        }
+        else
+        {
+            getLogger().info( "Nexus configuration validated succesfully." );
         }
     }
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/validator/DefaultApplicationConfigurationValidator.java
@@ -23,12 +23,7 @@ import java.util.Random;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.configuration.validation.ValidationMessage;
 import org.sonatype.configuration.validation.ValidationRequest;
@@ -50,10 +45,7 @@ import org.sonatype.nexus.configuration.model.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.CScheduledTask;
 import org.sonatype.nexus.configuration.model.CSmtpConfiguration;
 import org.sonatype.nexus.configuration.model.Configuration;
-import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.repository.LocalStatus;
-import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.proxy.repository.ShadowRepository;
 
 /**
  * The default configuration validator provider. It checks the model for semantical validity.
@@ -63,7 +55,6 @@ import org.sonatype.nexus.proxy.repository.ShadowRepository;
  */
 @Component( role = ApplicationConfigurationValidator.class )
 public class DefaultApplicationConfigurationValidator
-    extends AbstractLoggingComponent
     implements ApplicationConfigurationValidator
 {
     private final Random rand = new Random( System.currentTimeMillis() );
@@ -192,42 +183,6 @@ public class DefaultApplicationConfigurationValidator
         }
 
         response.append( validateSmtpConfiguration( context, model.getSmtpConfiguration() ) );
-
-        // summary
-        if ( response.getValidationErrors().size() > 0 || response.getValidationWarnings().size() > 0 )
-        {
-            getLogger().error( "* * * * * * * * * * * * * * * * * * * * * * * * * *" );
-
-            getLogger().error( "Nexus configuration has validation errors/warnings" );
-
-            getLogger().error( "* * * * * * * * * * * * * * * * * * * * * * * * * *" );
-
-            if ( response.getValidationErrors().size() > 0 )
-            {
-                getLogger().error( "The ERRORS:" );
-
-                for ( ValidationMessage msg : response.getValidationErrors() )
-                {
-                    getLogger().error( msg.toString() );
-                }
-            }
-
-            if ( response.getValidationWarnings().size() > 0 )
-            {
-                getLogger().error( "The WARNINGS:" );
-
-                for ( ValidationMessage msg : response.getValidationWarnings() )
-                {
-                    getLogger().error( msg.toString() );
-                }
-            }
-
-            getLogger().error( "* * * * * * * * * * * * * * * * * * * * *" );
-        }
-        else
-        {
-            getLogger().info( "Nexus configuration validated succesfully." );
-        }
 
         return response;
     }

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/client/nexus725/Nexus725InitialRestClientIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/client/nexus725/Nexus725InitialRestClientIT.java
@@ -54,7 +54,7 @@ public class Nexus725InitialRestClientIT
         throws Exception
     {
 
-        NexusClient client = (NexusClient) lookup( NexusClient.ROLE );
+        NexusClient client = lookup( NexusClient.class );
         TestContext context = TestContainer.getInstance().getTestContext();
         client.connect( AbstractNexusIntegrationTest.nexusBaseUrl, context.getAdminUsername(),
                         context.getAdminPassword() );
@@ -259,7 +259,7 @@ public class Nexus725InitialRestClientIT
         throws Exception
     {
 
-        NexusClient client = (NexusClient) lookup( NexusClient.ROLE );
+        NexusClient client = lookup( NexusClient.class );
         try
         {
             client.connect( "http://nexus.invalid.url/nexus", "", "" );
@@ -278,7 +278,7 @@ public class Nexus725InitialRestClientIT
     public void invalidPassword()
         throws Exception
     {
-        NexusClient client = (NexusClient) lookup( NexusClient.ROLE );
+        NexusClient client = lookup( NexusClient.class );
 
         try
         {

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1329/AbstractMirrorIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1329/AbstractMirrorIT.java
@@ -53,7 +53,7 @@ public abstract class AbstractMirrorIT
     public void start()
         throws Exception
     {
-        server = (ControlledServer) lookup( ControlledServer.ROLE );
+        server = lookup( ControlledServer.class );
     }
 
     @AfterMethod

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2120/Nexus2120EnableDownloadRemoteIndexIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2120/Nexus2120EnableDownloadRemoteIndexIT.java
@@ -62,7 +62,7 @@ public class Nexus2120EnableDownloadRemoteIndexIT
     public void start()
         throws Exception
     {
-        server = (ControlledServer) lookup( ControlledServer.ROLE );
+        server = lookup( ControlledServer.class );
         repoUtil = new RepositoryMessageUtil( this, XStreamFactory.getXmlXStream(), MediaType.APPLICATION_XML );
     }
 

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2860/Nexus2860SMTPPasswordUpgradeIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2860/Nexus2860SMTPPasswordUpgradeIT.java
@@ -30,7 +30,8 @@ public class Nexus2860SMTPPasswordUpgradeIT
     public void upgradeSmtp()
         throws Exception
     {
-        String pw = getNexusConfigUtil().getNexusConfig().getSmtpConfiguration().getPassword();
+        // we need this to have access to uncrypted password (see assertion below)
+        String pw = getNexusConfigUtil().loadAndUpgradeNexusConfiguration().getSmtpConfiguration().getPassword();
         // ensuring it wasn't encrypted twice
         Assert.assertEquals( "IT-password", pw );
     }

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2991/Nexus2991DeleteRepositoryBeforeSearchIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus2991/Nexus2991DeleteRepositoryBeforeSearchIT.java
@@ -43,7 +43,7 @@ public class Nexus2991DeleteRepositoryBeforeSearchIT
     private NexusClient getConnectedNexusClient()
         throws Exception
     {
-        NexusClient client = (NexusClient) lookup( NexusClient.ROLE );
+        NexusClient client = lookup( NexusClient.class );
         TestContext context = TestContainer.getInstance().getTestContext();
         client.connect( AbstractNexusIntegrationTest.nexusBaseUrl, context.getAdminUsername(), context
             .getAdminPassword() );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3638/Nexus3638IndexProxiedMavenPluginIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3638/Nexus3638IndexProxiedMavenPluginIT.java
@@ -49,7 +49,7 @@ public class Nexus3638IndexProxiedMavenPluginIT
     public void start()
         throws Exception
     {
-        server = (ControlledServer) lookup( ControlledServer.ROLE );
+        server = lookup( ControlledServer.class );
         server.addServer( "nexus3638", getTestFile( "repo" ), 10 );
         server.start();
     }

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/AutoBlockITSupport.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/AutoBlockITSupport.java
@@ -132,19 +132,20 @@ public abstract class AutoBlockITSupport
      * 
      * @param mode
      */
-    protected RepositoryStatusResource waitFor( RemoteStatus status, ProxyMode mode )
+    protected RepositoryStatusResource waitFor( RemoteStatus status, ProxyMode mode, boolean force )
         throws Exception
     {
+        repoUtil.getStatus( REPO, force );
         RepositoryStatusResource s = null;
         for ( int i = 0; i < 1000; i++ )
         {
-            s = this.repoUtil.getStatus( REPO );
+            s = repoUtil.getStatus( REPO, false );
             log.debug( "Waiting for: " + status + "," + mode + " - " + getJsonXStream().toXML( s ) );
             if ( status.name().equals( s.getRemoteStatus() ) && mode.name().equals( s.getProxyMode() ) )
             {
                 return s;
             }
-            Thread.sleep( 500 );
+            Thread.sleep( 1500 );
         }
 
         assertRepositoryStatus( s, status, mode );
@@ -187,7 +188,7 @@ public abstract class AutoBlockITSupport
         // let's stall the response
         sleepTime = 100;
         shakeNexus();
-        waitFor( RemoteStatus.UNAVAILABLE, ProxyMode.BLOCKED_AUTO );
+        waitFor( RemoteStatus.UNAVAILABLE, ProxyMode.BLOCKED_AUTO, false );
         // ensure nexus did touch server
         assertThat( pathsTouched, not( Matchers.<String>empty() ) );
         pathsTouched.clear();
@@ -202,7 +203,7 @@ public abstract class AutoBlockITSupport
         throws Exception
     {
         sleepTime = -1;
-        waitFor( RemoteStatus.AVAILABLE, ProxyMode.ALLOW );
+        waitFor( RemoteStatus.AVAILABLE, ProxyMode.ALLOW, true );
         // ensure nexus did touch server
         assertThat( pathsTouched, not( Matchers.<String>empty() ) );
         pathsTouched.clear();

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/NEXUS4539ManualBlockIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/NEXUS4539ManualBlockIT.java
@@ -42,7 +42,7 @@ public class NEXUS4539ManualBlockIT
         throws Exception
     {
         // initial status, timing out
-        waitFor( RemoteStatus.UNAVAILABLE, ProxyMode.BLOCKED_AUTO );
+        waitFor( RemoteStatus.UNAVAILABLE, ProxyMode.BLOCKED_AUTO, false );
 
         // set manual block
         repoUtil.setBlockProxy( REPO, true );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635/Nexus4635FirstStartIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635/Nexus4635FirstStartIT.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 /**
  * 1st start of "virgin" Nexus<BR>
- * http://goo.gl/dxQbh
+ * https://issues.sonatype.org/browse/NEXUS-4635
  * 
  * <pre>
  * <firstStart>true</firstStart>
@@ -58,9 +58,10 @@ public class Nexus4635FirstStartIT
     }
 
     @BeforeClass
-    public void setSecureTest()
+    public void doNotVerifyConfig()
     {
-        this.setVerifyNexusConfigBeforeStart( false );
+        // no verification, since it would upgrade and hence, modify it
+        setVerifyNexusConfigBeforeStart( false );
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635/Nexus4635FirstStartIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635/Nexus4635FirstStartIT.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
+import org.sonatype.nexus.integrationtests.TestContainer;
 import org.sonatype.nexus.rest.model.StatusResource;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,6 +42,11 @@ import org.testng.annotations.Test;
 public class Nexus4635FirstStartIT
     extends AbstractNexusIntegrationTest
 {
+    @BeforeClass
+    protected void disableSecurity()
+    {
+        TestContainer.getInstance().getTestContext().setSecureTest( false );
+    }
 
     @Override
     protected void copyConfigFiles()
@@ -55,13 +61,6 @@ public class Nexus4635FirstStartIT
         {
             throw new IOException( e );
         }
-    }
-
-    @BeforeClass
-    public void doNotVerifyConfig()
-    {
-        // no verification, since it would upgrade and hence, modify it
-        setVerifyNexusConfigBeforeStart( false );
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635nexusVersion/Nexus4635OldNexusVersionIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635nexusVersion/Nexus4635OldNexusVersionIT.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 /**
  * tampering the nexusVersion to 1.9.3<BR>
- * http://goo.gl/dxQbh
+ * https://issues.sonatype.org/browse/NEXUS-4635
  * 
  * <pre>
  * <firstStart>false</firstStart>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635nexusVersion/Nexus4635OldNexusVersionIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635nexusVersion/Nexus4635OldNexusVersionIT.java
@@ -37,6 +37,13 @@ import org.testng.annotations.Test;
  * <instanceUpgraded>true</instanceUpgraded>
  * <configurationUpgraded>false</configurationUpgraded>
  * </pre>
+ * 
+ * cstamas: this test was disabled since it does not quite makes sense. It would test following scenario: nexus.xml does
+ * not need upgrade, but the nexusVersion field contains old nexus version. To properly test this, you'd need a Nexus
+ * version (CURRENT), and a (CURRENT-1) that has previous constrants: nexus.xml model version did not change, but the
+ * obviously versions did change. Due how security is molded in this play, this is impossible to test without having
+ * those two true. By blindly upgrading and "just setting" the field this will never work, since security NPEs for
+ * mysterious reasons.
  */
 public class Nexus4635OldNexusVersionIT
     extends AbstractNexusIntegrationTest
@@ -47,7 +54,7 @@ public class Nexus4635OldNexusVersionIT
         TestContainer.getInstance().getTestContext().setSecureTest( false );
     }
 
-    @Test
+    @Test( enabled = false )
     public void checkState()
         throws Exception
     {

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635same/Nexus4635SubsequentStartIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635same/Nexus4635SubsequentStartIT.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 
 /**
  * subsequent start of same instance<br>
- * http://goo.gl/dxQbh
+ * https://issues.sonatype.org/browse/NEXUS-4635
  * 
  * <pre>
  * <firstStart>false</firstStart>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635same/Nexus4635SubsequentStartIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635same/Nexus4635SubsequentStartIT.java
@@ -21,7 +21,9 @@ package org.sonatype.nexus.integrationtests.nexus4635same;
 import static org.testng.Assert.assertFalse;
 
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
+import org.sonatype.nexus.integrationtests.TestContainer;
 import org.sonatype.nexus.rest.model.StatusResource;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -37,11 +39,20 @@ import org.testng.annotations.Test;
 public class Nexus4635SubsequentStartIT
     extends AbstractNexusIntegrationTest
 {
+    @BeforeClass
+    protected void disableSecurity()
+    {
+        TestContainer.getInstance().getTestContext().setSecureTest( false );
+    }
 
     @Test
     public void checkState()
         throws Exception
     {
+        // initial nexus start upgraded config, so we just bounce it
+        stopNexus();
+        startNexus();
+
         StatusResource status = getNexusStatusUtil().getNexusStatus().getData();
         assertFalse( status.isFirstStart() );
         assertFalse( status.isInstanceUpgraded() );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635upgrade/Nexus4635FullUpgradeIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635upgrade/Nexus4635FullUpgradeIT.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 
 /**
  * placing old config to force upgrade and firing up Nexus.<BR>
- * http://goo.gl/dxQbh
+ * https://issues.sonatype.org/browse/NEXUS-4635
  * 
  * <pre>
  * <firstStart>false</firstStart>
@@ -41,9 +41,10 @@ public class Nexus4635FullUpgradeIT
 {
 
     @BeforeClass
-    public void setSecureTest()
+    public void doNotVerifyConfig()
     {
-        this.setVerifyNexusConfigBeforeStart( false );
+        // no verification, since it would upgrade and hence, modify it
+        setVerifyNexusConfigBeforeStart( false );
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635upgrade/Nexus4635FullUpgradeIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4635upgrade/Nexus4635FullUpgradeIT.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
+import org.sonatype.nexus.integrationtests.TestContainer;
 import org.sonatype.nexus.rest.model.StatusResource;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -39,12 +40,10 @@ import org.testng.annotations.Test;
 public class Nexus4635FullUpgradeIT
     extends AbstractNexusIntegrationTest
 {
-
     @BeforeClass
-    public void doNotVerifyConfig()
+    protected void disableSecurity()
     {
-        // no verification, since it would upgrade and hence, modify it
-        setVerifyNexusConfigBeforeStart( false );
+        TestContainer.getInstance().getTestContext().setSecureTest( false );
     }
 
     @Test

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1089/Nexus1089SecureProxyIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1089/Nexus1089SecureProxyIT.java
@@ -39,7 +39,7 @@ public class Nexus1089SecureProxyIT
     public void startProxy()
         throws Exception
     {
-        ServletServer server = (ServletServer) this.lookup( ServletServer.ROLE, "secure" );
+        ServletServer server = lookup( ServletServer.class, "secure" );
         server.start();
     }
 
@@ -48,7 +48,7 @@ public class Nexus1089SecureProxyIT
     public void stopProxy()
         throws Exception
     {
-        ServletServer server = (ServletServer) this.lookup( ServletServer.ROLE, "secure" );
+        ServletServer server = lookup( ServletServer.class, "secure" );
         server.stop();
     }
 

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1111/Nexus1111ProxyRemote500ErrorIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1111/Nexus1111ProxyRemote500ErrorIT.java
@@ -30,10 +30,7 @@ import org.sonatype.nexus.rest.model.ScheduledServicePropertyResource;
 import org.sonatype.nexus.tasks.descriptors.ExpireCacheTaskDescriptor;
 import org.sonatype.nexus.test.utils.RepositoryMessageUtil;
 import org.sonatype.nexus.test.utils.TaskScheduleUtil;
-import org.sonatype.tests.http.server.api.ServerProvider;
 import org.sonatype.tests.http.server.fluent.Server;
-import org.sonatype.tests.http.server.jetty.behaviour.ErrorBehaviour;
-import org.sonatype.tests.http.server.jetty.impl.JettyServerProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -57,7 +54,7 @@ public class Nexus1111ProxyRemote500ErrorIT
         downloadArtifact( "nexus1111", "artifact", "1.0", "jar", null, "target/downloads" );
 
         // stop the healthy server
-        ServletServer server = (ServletServer) this.lookup( ServletServer.ROLE );
+        ServletServer server = lookup( ServletServer.class );
         server.stop();
 
         int port = server.getPort();

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/upgrades/nexus652/Nexus652Beta5To10UpgradeIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/upgrades/nexus652/Nexus652Beta5To10UpgradeIT.java
@@ -42,7 +42,6 @@ public class Nexus652Beta5To10UpgradeIT
     @BeforeClass
     public void setSecureTest()
     {
-        this.setVerifyNexusConfigBeforeStart( false );
         TestContainer.getInstance().getTestContext().setSecureTest( true );
     }
 
@@ -55,7 +54,8 @@ public class Nexus652Beta5To10UpgradeIT
         SecurityConfigurationSource securitySource = lookup( SecurityConfigurationSource.class, "file" );
         SecurityConfiguration securityConfig = securitySource.loadConfiguration();
 
-        Configuration nexusConfig = getNexusConfigUtil().getNexusConfig();
+        // we need this to have access to uncrypted password (see assertion below)
+        Configuration nexusConfig = getNexusConfigUtil().loadAndUpgradeNexusConfiguration();
 
         Assert.assertEquals( nexusConfig.getSmtpConfiguration().getHostname(), "foo.org", "Smtp host:" );
         Assert.assertEquals( nexusConfig.getSmtpConfiguration().getPassword(), "now", "Smtp password:" );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/webproxy/AbstractNexusWebProxyIntegrationTest.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/webproxy/AbstractNexusWebProxyIntegrationTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractNexusWebProxyIntegrationTest
     public void startWebProxy()
         throws Exception
     {
-        server = (ProxyServer) lookup( ProxyServer.ROLE );
+        server = lookup( ProxyServer.class );
         server.start();
     }
 

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
@@ -46,12 +47,7 @@ import org.apache.maven.index.artifact.Gav;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.plexus.ContainerConfiguration;
-import org.codehaus.plexus.DefaultContainerConfiguration;
-import org.codehaus.plexus.DefaultPlexusContainer;
-import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -63,6 +59,7 @@ import org.restlet.data.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.sonatype.nexus.rest.model.GlobalConfigurationResource;
 import org.sonatype.nexus.rt.prefs.FilePreferencesFactory;
 import org.sonatype.nexus.test.utils.DeployUtils;
 import org.sonatype.nexus.test.utils.EventInspectorsUtil;
@@ -73,6 +70,7 @@ import org.sonatype.nexus.test.utils.NexusConfigUtil;
 import org.sonatype.nexus.test.utils.NexusStatusUtil;
 import org.sonatype.nexus.test.utils.SearchMessageUtil;
 import org.sonatype.nexus.test.utils.SecurityConfigUtil;
+import org.sonatype.nexus.test.utils.SettingsMessageUtil;
 import org.sonatype.nexus.test.utils.TaskScheduleUtil;
 import org.sonatype.nexus.test.utils.TestProperties;
 import org.sonatype.nexus.test.utils.WagonDeployer;
@@ -82,6 +80,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
 import com.thoughtworks.xstream.XStream;
@@ -161,11 +160,6 @@ public abstract class AbstractNexusIntegrationTest
         System.setProperty( "guice.executor.class", "NONE" );
     }
 
-    /**
-     * Flag that says if we should verify the config before startup, we do not want to do this for upgrade tests.
-     */
-    private boolean verifyNexusConfigBeforeStart = true;
-
     static
     {
         nexusApplicationPort = TestProperties.getInteger( "nexus.application.port" );
@@ -228,24 +222,21 @@ public abstract class AbstractNexusIntegrationTest
     {
         if ( deployUtils == null )
         {
-            deployUtils = new DeployUtils(
-                RequestFacade.getNexusRestClient(),
-                new WagonDeployer.Factory()
+            deployUtils = new DeployUtils( RequestFacade.getNexusRestClient(), new WagonDeployer.Factory()
+            {
+                @Override
+                public Wagon get( final String protocol )
                 {
-                    @Override
-                    public Wagon get( final String protocol )
+                    try
                     {
-                        try
-                        {
-                            return (Wagon) getITPlexusContainer().lookup( Wagon.ROLE, protocol );
-                        }
-                        catch ( ComponentLookupException e )
-                        {
-                            throw Throwables.propagate( e );
-                        }
+                        return (Wagon) getITPlexusContainer().lookup( Wagon.ROLE, protocol );
+                    }
+                    catch ( ComponentLookupException e )
+                    {
+                        throw Throwables.propagate( e );
                     }
                 }
-            );
+            } );
         }
 
         return deployUtils;
@@ -323,7 +314,7 @@ public abstract class AbstractNexusIntegrationTest
      * static, so we don't have access to the package name of the running tests. We are going to use the package name to
      * find resources for additional setup. NOTE: With this setup running multiple Test at the same time is not
      * possible.
-     *
+     * 
      * @throws Exception
      */
     @BeforeMethod( alwaysRun = true )
@@ -334,9 +325,6 @@ public abstract class AbstractNexusIntegrationTest
         {
             if ( NEEDS_INIT )
             {
-                // this will trigger PlexusContainer creation when test is instantiated, but only if needed
-                getITPlexusContainer( getClass() );
-
                 // tell the console what we are doing, now that there is no output its
                 String logMessage = "Running Test: " + getTestId() + " - Class: " + this.getClass().getSimpleName();
                 staticLog.info( String.format( "%1$-" + logMessage.length() + "s", " " ).replaceAll( " ", "*" ) );
@@ -350,25 +338,26 @@ public abstract class AbstractNexusIntegrationTest
 
                 this.copyConfigFiles();
 
-                // TODO: Below, Nexus configuration upgrade happens! But this is insane, since it is the IT that
-                // upgrades
-                // nexus config, not the tested product! If, by any chance, we start to test another product, that is
-                // not in this buildtree (hence, the configuration classes will not be equal like currently), this is
-                // make hell loose!
-
-                // we need to make sure the config is valid, so we don't need to hunt through log files
-                if ( this.verifyNexusConfigBeforeStart )
-                {
-                    getNexusConfigUtil().validateConfig();
-                }
-
-                // the validation needs to happen before we enable security it triggers an upgrade.
-                getNexusConfigUtil().enableSecurity(
-                    TestContainer.getInstance().getTestContext().isSecureTest()
-                        || Boolean.valueOf( System.getProperty( "secure.test" ) ) );
-
                 // start nexus
                 startNexus();
+
+                final boolean testRequiresSecurityEnabled =
+                    TestContainer.getInstance().getTestContext().isSecureTest()
+                        || Boolean.valueOf( System.getProperty( "secure.test" ) );
+
+                // set security enabled/disabled as expected by current IT
+                TestContainer.getInstance().invokeAsAdministrator( new Callable<Object>()
+                {
+                    @Override
+                    public Object call()
+                        throws Exception
+                    {
+                        final GlobalConfigurationResource globalConfig = SettingsMessageUtil.getCurrentSettings();
+                        globalConfig.setSecurityEnabled( testRequiresSecurityEnabled );
+                        SettingsMessageUtil.save( globalConfig );
+                        return null;
+                    }
+                } );
 
                 // deploy artifacts
                 deployArtifacts();
@@ -388,7 +377,8 @@ public abstract class AbstractNexusIntegrationTest
         throws Exception
     {
         // reset this for each test
-        TestContainer.getInstance().getTestContext().useAdminForRequests();
+        TestContainer.getInstance().reset();
+        TestContainer.getInstance().getTestContext().setSecureTest( true );
     }
 
     @AfterClass( alwaysRun = true )
@@ -418,9 +408,6 @@ public abstract class AbstractNexusIntegrationTest
         stopNexus();
 
         takeSnapshot();
-
-        // kill existing container if around
-        killITPlexusContainer();
     }
 
     protected void runOnce()
@@ -553,7 +540,7 @@ public abstract class AbstractNexusIntegrationTest
 
     /**
      * Deploys all the provided files needed before IT actually starts.
-     *
+     * 
      * @throws Exception
      */
     protected void deployArtifacts()
@@ -569,7 +556,7 @@ public abstract class AbstractNexusIntegrationTest
      * This is a "switchboard" to detech HOW to deploy. For now, just using the protocol from POM's
      * DistributionManagement section and invoking the getWagonHintForDeployProtocol(String protocol) to get the wagon
      * hint.
-     *
+     * 
      * @throws Exception
      */
     protected void deployArtifacts( final File projectsDir )
@@ -620,8 +607,7 @@ public abstract class AbstractNexusIntegrationTest
                 if ( model.getDistributionManagement() == null
                     || model.getDistributionManagement().getRepository() == null )
                 {
-                    Assert.fail(
-                        "The test artifact is either missing or has an invalid Distribution Management section." );
+                    Assert.fail( "The test artifact is either missing or has an invalid Distribution Management section." );
                 }
 
                 // get the URL to deploy
@@ -641,7 +627,7 @@ public abstract class AbstractNexusIntegrationTest
     /**
      * Does "protocol to wagon hint" converion: the default is just return the same, but maybe some test wants to
      * override this.
-     *
+     * 
      * @param deployProtocol
      * @return
      */
@@ -653,7 +639,7 @@ public abstract class AbstractNexusIntegrationTest
     /**
      * Deploys with given Wagon (hint is provided), to deployUrl. It is caller matter to adjust those two (ie. deployUrl
      * with file: protocol to be deployed with file wagon would be error). Model is supplied since it is read before.
-     *
+     * 
      * @param wagonHint
      * @param deployUrl
      * @param model
@@ -663,7 +649,7 @@ public abstract class AbstractNexusIntegrationTest
         throws Exception
     {
         log.info( "Deploying project \"" + project.getAbsolutePath() + "\" using Wagon:" + wagonHint + " to URL=\""
-                      + deployUrl + "\"." );
+            + deployUrl + "\"." );
 
         // we already check if the pom.xml was in here.
         File pom = new File( project, "pom.xml" );
@@ -676,8 +662,8 @@ public abstract class AbstractNexusIntegrationTest
 
         final Gav gav =
             new Gav( model.getGroupId(), model.getArtifactId(), model.getVersion(), null,
-                     FileUtils.getExtension( artifactFile.getName() ), null, null, artifactFile.getName(), false, null,
-                     false, null );
+                FileUtils.getExtension( artifactFile.getName() ), null, null, artifactFile.getName(), false, null,
+                false, null );
 
         // the Restlet Client does not support multipart forms:
         // http://restlet.tigris.org/issues/show_bug.cgi?id=71
@@ -702,39 +688,37 @@ public abstract class AbstractNexusIntegrationTest
             if ( artifactSha1.exists() )
             {
                 getDeployUtils().deployWithWagon( wagonHint, deployUrl, artifactSha1,
-                                                  this.getRelitiveArtifactPath( gav ) + ".sha1" );
+                    this.getRelitiveArtifactPath( gav ) + ".sha1" );
             }
             if ( artifactMd5.exists() )
             {
                 getDeployUtils().deployWithWagon( wagonHint, deployUrl, artifactMd5,
-                                                  this.getRelitiveArtifactPath( gav ) + ".md5" );
+                    this.getRelitiveArtifactPath( gav ) + ".md5" );
             }
             if ( artifactAsc.exists() )
             {
                 getDeployUtils().deployWithWagon( wagonHint, deployUrl, artifactAsc,
-                                                  this.getRelitiveArtifactPath( gav ) + ".asc" );
+                    this.getRelitiveArtifactPath( gav ) + ".asc" );
             }
 
             if ( artifactFile.exists() )
             {
                 getDeployUtils().deployWithWagon( wagonHint, deployUrl, artifactFile,
-                                                  this.getRelitiveArtifactPath( gav ) );
+                    this.getRelitiveArtifactPath( gav ) );
             }
 
             if ( pomSha1.exists() )
             {
                 getDeployUtils().deployWithWagon( wagonHint, deployUrl, pomSha1,
-                                                  this.getRelitivePomPath( gav ) + ".sha1" );
+                    this.getRelitivePomPath( gav ) + ".sha1" );
             }
             if ( pomMd5.exists() )
             {
-                getDeployUtils().deployWithWagon( wagonHint, deployUrl, pomMd5,
-                                                  this.getRelitivePomPath( gav ) + ".md5" );
+                getDeployUtils().deployWithWagon( wagonHint, deployUrl, pomMd5, this.getRelitivePomPath( gav ) + ".md5" );
             }
             if ( pomAsc.exists() )
             {
-                getDeployUtils().deployWithWagon( wagonHint, deployUrl, pomAsc,
-                                                  this.getRelitivePomPath( gav ) + ".asc" );
+                getDeployUtils().deployWithWagon( wagonHint, deployUrl, pomAsc, this.getRelitivePomPath( gav ) + ".asc" );
             }
 
             getDeployUtils().deployWithWagon( wagonHint, deployUrl, pom, this.getRelitivePomPath( gav ) );
@@ -841,7 +825,7 @@ public abstract class AbstractNexusIntegrationTest
     /**
      * Returns a File if it exists, null otherwise. Files returned by this method must be located in the
      * "src/test/resourcs/nexusXXX/" folder.
-     *
+     * 
      * @param relativePath path relative to the nexusXXX directory.
      * @return A file specified by the relativePath. or null if it does not exist.
      */
@@ -860,7 +844,7 @@ public abstract class AbstractNexusIntegrationTest
     /**
      * Returns a File if it exists, null otherwise. Files returned by this method must be located in the
      * "src/test/resourcs/nexusXXX/files/" folder.
-     *
+     * 
      * @param relativePath path relative to the files directory.
      * @return A file specified by the relativePath. or null if it does not exist.
      */
@@ -930,24 +914,26 @@ public abstract class AbstractNexusIntegrationTest
         }
     }
 
+    /**
+     * Returns the basedir.
+     * 
+     * @return
+     * @deprecated Use {@link TestContainer#getBasedir()} instead.
+     */
+    @Deprecated
     public static String getBasedir()
     {
-        String basedir = System.getProperty( "basedir" );
-
-        if ( basedir == null )
-        {
-            basedir = new File( "" ).getAbsolutePath();
-        }
-
-        return basedir;
+        return TestContainer.getBasedir();
     }
 
+    @Deprecated
     protected Object lookup( String role )
         throws ComponentLookupException
     {
         return getITPlexusContainer().lookup( role );
     }
 
+    @Deprecated
     protected Object lookup( String role, String hint )
         throws ComponentLookupException
     {
@@ -1009,8 +995,7 @@ public abstract class AbstractNexusIntegrationTest
 
             assertThat(
                 response,
-                allOf( isRedirecting(), respondsWithStatusCode( 301 ),
-                       redirectLocation( notNullValue( String.class ) ) ) );
+                allOf( isRedirecting(), respondsWithStatusCode( 301 ), redirectLocation( notNullValue( String.class ) ) ) );
 
             serviceURI = response.getLocationRef().toString();
         }
@@ -1066,7 +1051,7 @@ public abstract class AbstractNexusIntegrationTest
         throws IOException
     {
         return this.downloadArtifact( gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), gav.getExtension(),
-                                      gav.getClassifier(), targetDirectory );
+            gav.getClassifier(), targetDirectory );
     }
 
     protected File downloadArtifact( String groupId, String artifact, String version, String type, String classifier,
@@ -1074,25 +1059,23 @@ public abstract class AbstractNexusIntegrationTest
         throws IOException
     {
         return this.downloadArtifact( this.getNexusTestRepoUrl(), groupId, artifact, version, type, classifier,
-                                      targetDirectory );
+            targetDirectory );
     }
 
     protected File downloadArtifactFromRepository( String repoId, Gav gav, String targetDirectory )
         throws IOException
     {
         return this.downloadArtifact( AbstractNexusIntegrationTest.nexusBaseUrl + REPOSITORY_RELATIVE_URL + repoId
-                                          + "/", gav.getGroupId(), gav.getArtifactId(), gav.getVersion(),
-                                      gav.getExtension(), gav.getClassifier(),
-                                      targetDirectory );
+            + "/", gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), gav.getExtension(), gav.getClassifier(),
+            targetDirectory );
     }
 
     protected File downloadArtifactFromGroup( String groupId, Gav gav, String targetDirectory )
         throws IOException
     {
         return this.downloadArtifact( AbstractNexusIntegrationTest.nexusBaseUrl + GROUP_REPOSITORY_RELATIVE_URL
-                                          + groupId + "/", gav.getGroupId(), gav.getArtifactId(), gav.getVersion(),
-                                      gav.getExtension(),
-                                      gav.getClassifier(), targetDirectory );
+            + groupId + "/", gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), gav.getExtension(),
+            gav.getClassifier(), targetDirectory );
     }
 
     protected File downloadArtifact( String baseUrl, String groupId, String artifact, String version, String type,
@@ -1195,18 +1178,7 @@ public abstract class AbstractNexusIntegrationTest
         return nexusBaseUrl + GROUP_REPOSITORY_RELATIVE_URL + groupId + "/";
     }
 
-    protected boolean isVerifyNexusConfigBeforeStart()
-    {
-        return verifyNexusConfigBeforeStart;
-    }
-
-    protected void setVerifyNexusConfigBeforeStart( boolean verifyNexusConfigBeforeStart )
-    {
-        this.verifyNexusConfigBeforeStart = verifyNexusConfigBeforeStart;
-    }
-
-    protected boolean printKnownErrorButDoNotFail( Class<? extends AbstractNexusIntegrationTest> clazz,
-                                                   String... tests )
+    protected boolean printKnownErrorButDoNotFail( Class<? extends AbstractNexusIntegrationTest> clazz, String... tests )
     {
         StringBuilder error =
             new StringBuilder( "*********************************************************************************" );
@@ -1238,85 +1210,9 @@ public abstract class AbstractNexusIntegrationTest
 
     // == IT Container management
 
-    private static PlexusContainer itPlexusContainer;
-
     public PlexusContainer getITPlexusContainer()
     {
-        return getITPlexusContainer( getClass() );
-    }
-
-    public synchronized PlexusContainer getITPlexusContainer( Class<?> clazz )
-    {
-        if ( itPlexusContainer == null )
-        {
-            itPlexusContainer = setupContainer( clazz );
-        }
-
-        return itPlexusContainer;
-    }
-
-    public static synchronized void killITPlexusContainer()
-    {
-        if ( itPlexusContainer != null )
-        {
-            itPlexusContainer.dispose();
-
-            itPlexusContainer = null;
-        }
-    }
-
-    protected void customizeContainerConfiguration( ContainerConfiguration configuration )
-    {
-    }
-
-    private PlexusContainer setupContainer( Class<?> baseClass )
-    {
-        // ----------------------------------------------------------------------------
-        // Context Setup
-        // ----------------------------------------------------------------------------
-
-        Map<Object, Object> context = new HashMap<Object, Object>();
-
-        context.put( "basedir", getBasedir() );
-        context.putAll( getTestProperties() );
-
-        boolean hasPlexusHome = context.containsKey( "plexus.home" );
-
-        if ( !hasPlexusHome )
-        {
-            File f = new File( getBasedir(), "target/plexus-home" );
-
-            if ( !f.isDirectory() )
-            {
-                f.mkdir();
-            }
-
-            context.put( "plexus.home", f.getAbsolutePath() );
-        }
-
-        // ----------------------------------------------------------------------------
-        // Configuration
-        // ----------------------------------------------------------------------------
-
-        ContainerConfiguration containerConfiguration =
-            new DefaultContainerConfiguration().setName( "test" ).setContext( context ).setContainerConfiguration(
-                baseClass.getName().replace( '.', '/' ) + ".xml" );
-
-        containerConfiguration.setAutoWiring( true );
-        containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
-
-        customizeContainerConfiguration( containerConfiguration );
-
-        try
-        {
-            return new DefaultPlexusContainer( containerConfiguration );
-        }
-        catch ( PlexusContainerException e )
-        {
-            e.printStackTrace();
-            fail( "Failed to create plexus container." );
-            return null;
-        }
+        return TestContainer.getInstance().getPlexusContainer();
     }
 
     protected void installOptionalPlugin( final String plugin )

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusProxyIntegrationTest.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusProxyIntegrationTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractNexusProxyIntegrationTest
     public void startProxy()
         throws Exception
     {
-        this.proxyServer = (ServletServer) this.lookup( ServletServer.ROLE );
+        this.proxyServer = lookup( ServletServer.class );
         this.proxyServer.start();
     }
 

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/TestContainer.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/TestContainer.java
@@ -18,17 +18,24 @@
  */
 package org.sonatype.nexus.integrationtests;
 
+import static org.testng.Assert.fail;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.sonatype.nexus.test.utils.TestProperties;
+
 public class TestContainer
 {
-
     private static TestContainer SELF = null;
-
-    private TestContext testContext = new TestContext();
-
-    private TestContainer()
-    {
-        super();
-    }
 
     public static TestContainer getInstance()
     {
@@ -42,9 +49,125 @@ public class TestContainer
         return SELF;
     }
 
+    public static String getBasedir()
+    {
+        String basedir = System.getProperty( "basedir" );
+
+        if ( basedir == null )
+        {
+            basedir = new File( "" ).getAbsolutePath();
+        }
+
+        return basedir;
+    }
+
+    // ==
+
+    private final TestContext testContext;
+
+    private PlexusContainer plexusContainer;
+
+    private TestContainer()
+    {
+        testContext = new TestContext();
+    }
+
     public TestContext getTestContext()
     {
         return testContext;
+    }
+
+    public synchronized PlexusContainer getPlexusContainer()
+    {
+        if ( plexusContainer == null )
+        {
+            plexusContainer = setupContainer( getClass() );
+        }
+        return plexusContainer;
+    }
+
+    public void reset()
+    {
+        getTestContext().reset();
+    }
+
+    public <T> T invokeAsAdministrator( final Callable<T> callable )
+        throws Exception
+    {
+        final TestContext ctx = TestContainer.getInstance().getTestContext();
+        final String username = ctx.getUsername();
+        final String password = ctx.getPassword();
+        final boolean secure = ctx.isSecureTest();
+        ctx.useAdminForRequests();
+        ctx.setSecureTest( true );
+
+        try
+        {
+            return callable.call();
+        }
+        finally
+        {
+            ctx.setUsername( username );
+            ctx.setPassword( password );
+            ctx.setSecureTest( secure );
+        }
+    }
+
+    // ==
+
+    protected PlexusContainer setupContainer( Class<?> baseClass )
+    {
+        // ----------------------------------------------------------------------------
+        // Context Setup
+        // ----------------------------------------------------------------------------
+
+        Map<Object, Object> context = new HashMap<Object, Object>();
+
+        context.put( "basedir", getBasedir() );
+        context.putAll( getTestProperties() );
+
+        boolean hasPlexusHome = context.containsKey( "plexus.home" );
+
+        if ( !hasPlexusHome )
+        {
+            File f = new File( getBasedir(), "target/plexus-home" );
+
+            if ( !f.isDirectory() )
+            {
+                f.mkdir();
+            }
+
+            context.put( "plexus.home", f.getAbsolutePath() );
+        }
+
+        // ----------------------------------------------------------------------------
+        // Configuration
+        // ----------------------------------------------------------------------------
+
+        ContainerConfiguration containerConfiguration = new DefaultContainerConfiguration();
+        containerConfiguration.setName( "test" );
+        containerConfiguration.setContext( context );
+        containerConfiguration.setContainerConfiguration( baseClass.getName().replace( '.', '/' ) + ".xml" );
+        containerConfiguration.setAutoWiring( true );
+        containerConfiguration.setClassPathScanning( PlexusConstants.SCANNING_INDEX );
+
+        try
+        {
+            return new DefaultPlexusContainer( containerConfiguration );
+        }
+        catch ( PlexusContainerException e )
+        {
+            e.printStackTrace();
+            fail( "Failed to create plexus container." );
+            return null;
+        }
+    }
+
+    protected Map<String, String> getTestProperties()
+    {
+        HashMap<String, String> variables = new HashMap<String, String>();
+        variables.putAll( TestProperties.getAll() );
+        return variables;
     }
 
 }

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/report/ProgressListener.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/report/ProgressListener.java
@@ -70,7 +70,7 @@ public class ProgressListener
     {
         super.onTestSuccess( tr );
 
-        showResult( tr, "SUCCESS", System.out );
+        showResult( tr, "SUCCESS", System.out  );
     }
 
     private void showResult( ITestResult result, String status, PrintStream printer )
@@ -78,8 +78,10 @@ public class ProgressListener
         checkNotNull( result );
         checkNotNull( result.getTestClass() );
         checkNotNull( printer );
+        long duration = result.getEndMillis() - result.getStartMillis();
 
-        printer.println( "Result: " + result.getTestClass().getName() + "." + result.getName() + "() ===> " + status );
+        printer.println( String.format( "Result: %s.%s() ===> %s (duration %s ms)", result.getTestClass().getName(),
+            result.getName(), status, duration ) );
     }
 
 }

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/Jetty7NexusBooter.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/Jetty7NexusBooter.java
@@ -409,7 +409,8 @@ public class Jetty7NexusBooter
         // But, we have to make it carefully, since we might be re-created during multi-forked ITs but the test-env
         // plugin unzips the nexus bundle only once
         // at the start of the build. So, we have to check and do it only once.
-        tamperJarsForSharedClasspath( basedir, sharedLibs, "lucene-*.jar" );
+        // cstamas: Lucene is no more in core, not needed to do this anymore!
+        // tamperJarsForSharedClasspath( basedir, sharedLibs, "lucene-*.jar" );
 
         // LDAP does not unregister it? Like SISU container does not invoke Disposable.dispose() to make patch for
         // Provider unregistration happen? NO: the cause is if someone creates HTTPS connection while BC is registered,

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/SettingsMessageUtil.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/SettingsMessageUtil.java
@@ -31,6 +31,7 @@ import org.sonatype.plexus.rest.representation.XStreamRepresentation;
 
 import com.google.common.base.Preconditions;
 import com.thoughtworks.xstream.XStream;
+
 public class SettingsMessageUtil
 {
     private static XStream xstream;
@@ -43,55 +44,57 @@ public class SettingsMessageUtil
     public static GlobalConfigurationResource getCurrentSettings()
         throws IOException
     {
-        return getData(new GlobalConfigurationResourceResponse());
+        return getData( new GlobalConfigurationResourceResponse() );
     }
 
-    public static GlobalConfigurationResource getData(final GlobalConfigurationResourceResponse wrapper)
+    public static GlobalConfigurationResource getData( final GlobalConfigurationResourceResponse wrapper )
         throws IOException
     {
-        Preconditions.checkNotNull(wrapper);
+        Preconditions.checkNotNull( wrapper );
         String responseText = RequestFacade.doGetForText( "service/local/global_settings/current" );
-        final XStreamRepresentation rep = new XStreamRepresentation(xstream, responseText, MediaType.APPLICATION_XML);
-        final GlobalConfigurationResourceResponse configResponse = (GlobalConfigurationResourceResponse) rep.getPayload( wrapper );
+        final XStreamRepresentation rep = new XStreamRepresentation( xstream, responseText, MediaType.APPLICATION_XML );
+        final GlobalConfigurationResourceResponse configResponse =
+            (GlobalConfigurationResourceResponse) rep.getPayload( wrapper );
         return configResponse.getData();
     }
 
     public static Status save( final GlobalConfigurationResource globalConfig )
         throws IOException
     {
-        Preconditions.checkNotNull(globalConfig);
-        final GlobalConfigurationResourceResponse configResponse = wrapData(globalConfig);
+        Preconditions.checkNotNull( globalConfig );
+        final GlobalConfigurationResourceResponse configResponse = wrapData( globalConfig );
         XStreamRepresentation representation = new XStreamRepresentation( xstream, "", MediaType.APPLICATION_XML );
         representation.setPayload( configResponse );
-        return RequestFacade.doPutForStatus("service/local/global_settings/current", representation, null);
+        return RequestFacade.doPutForStatus( "service/local/global_settings/current", representation, null );
     }
 
-    public static Status save( final SmtpSettingsResource smtpSettings)
+    public static Status save( final SmtpSettingsResource smtpSettings )
         throws IOException
     {
         String serviceURI = "service/local/check_smtp_settings/";
-        SmtpSettingsResourceRequest configResponse = wrapData(smtpSettings);
+        SmtpSettingsResourceRequest configResponse = wrapData( smtpSettings );
         XStreamRepresentation representation = new XStreamRepresentation( xstream, "", MediaType.APPLICATION_XML );
         representation.setPayload( configResponse );
-        return RequestFacade.doPutForStatus("service/local/check_smtp_settings/", representation, null);
+        return RequestFacade.doPutForStatus( "service/local/check_smtp_settings/", representation, null );
     }
 
     /**
      * Wrap a {@link GlobalConfigurationResource} in a {@link GlobalConfigurationResourceResponse} and return it.
+     * 
      * @param resource the resource to wrap
      * @return a wrapper containing the resource
      */
-    public static GlobalConfigurationResourceResponse wrapData( final GlobalConfigurationResource resource)
+    public static GlobalConfigurationResourceResponse wrapData( final GlobalConfigurationResource resource )
     {
-        Preconditions.checkNotNull(resource);
+        Preconditions.checkNotNull( resource );
         final GlobalConfigurationResourceResponse wrapper = new GlobalConfigurationResourceResponse();
         wrapper.setData( resource );
         return wrapper;
     }
 
-    public static SmtpSettingsResourceRequest wrapData( final SmtpSettingsResource resource)
+    public static SmtpSettingsResourceRequest wrapData( final SmtpSettingsResource resource )
     {
-        Preconditions.checkNotNull(resource);
+        Preconditions.checkNotNull( resource );
         final SmtpSettingsResourceRequest wrapper = new SmtpSettingsResourceRequest();
         wrapper.setData( resource );
         return wrapper;

--- a/nexus/nexus-test-harness/nexus-test-utils/src/main/java/org/sonatype/nexus/integrationtests/TestContext.java
+++ b/nexus/nexus-test-harness/nexus-test-utils/src/main/java/org/sonatype/nexus/integrationtests/TestContext.java
@@ -24,29 +24,44 @@ import java.util.HashMap;
 
 public class TestContext
 {
+    private boolean secureTest;
 
-    private boolean secureTest = false;
+    private String username;
 
-    private String username = "admin";
+    private String password;
 
-    private String password = "admin123";
+    private String adminUsername;
 
-    private String adminUsername = "admin";
+    private String adminPassword;
 
-    private String adminPassword = "admin123";
-
-    private boolean useAdminForRequests = true;
-    
     private String nexusUrl;
 
-    private HashMap<String, Object> map = new HashMap<String, Object>();
+    private final HashMap<String, Object> map;
 
-    public Object getObject( String key )
+    public TestContext()
+    {
+        map = new HashMap<String, Object>();
+        // nexusUrl is set only once, it does not change (for now)
+        nexusUrl = null;
+        reset();
+    }
+
+    public void reset()
+    {
+        secureTest = false;
+        adminUsername = "admin";
+        adminPassword = "admin123";
+        username = adminUsername;
+        password = adminPassword;
+        map.clear();
+    }
+
+    public Object getObject( final String key )
     {
         return map.get( key );
     }
 
-    public boolean getBoolean( String key )
+    public boolean getBoolean( final String key )
     {
         if ( map.containsKey( key ) )
         {
@@ -56,7 +71,7 @@ public class TestContext
         return false;
     }
 
-    public void put( String key, Object value )
+    public void put( final String key, final Object value )
     {
         this.map.put( key, value );
     }
@@ -66,7 +81,7 @@ public class TestContext
         return secureTest;
     }
 
-    public TestContext setSecureTest( boolean secureTest )
+    public TestContext setSecureTest( final boolean secureTest )
     {
         this.secureTest = secureTest;
         return this;
@@ -77,7 +92,7 @@ public class TestContext
         return username;
     }
 
-    public TestContext setUsername( String username )
+    public TestContext setUsername( final String username )
     {
         this.username = username;
         return this;
@@ -88,7 +103,7 @@ public class TestContext
         return password;
     }
 
-    public TestContext setPassword( String password )
+    public TestContext setPassword( final String password )
     {
         this.password = password;
         return this;
@@ -99,7 +114,7 @@ public class TestContext
         return adminUsername;
     }
 
-    public TestContext setAdminUsername( String adminUsername )
+    public TestContext setAdminUsername( final String adminUsername )
     {
         this.adminUsername = adminUsername;
         return this;
@@ -110,7 +125,7 @@ public class TestContext
         return adminPassword;
     }
 
-    public TestContext setAdminPassword( String adminPassword )
+    public TestContext setAdminPassword( final String adminPassword )
     {
         this.adminPassword = adminPassword;
         return this;


### PR DESCRIPTION
The inital problem (log file kept open on windows making it impossible to delete) led me to believe there was a component in IT plexus container that kept the file open.

This led to realization that we "bounce" Plexus per-IT class, and this is not the case anymore. Plexus is brought up once (lazily) and kept the same instance over and over. Moreover, how security was managed in ITs was next to a disaster, and it turned out that many ITs did "interleave" (was relying on side effect!).

After fixing plexus and security, next was to remove the "feature" of ITs that it was bringin' up almost all of Nexus internals within IT (to "validate" configuration [why?], to mangle security configuration [why?] and many more). So, alternative implementations are added that does NOT bring up all of those components, except in few (2 i believe) ITs where they are a must to decipher some of the SMTP related passwords that would come in scrambled if using "low level" model loaded only.

Finally, it turned out that a few ITs (within same group) was responsible for more than 20minutes of runtime, and they were even not doing their job: they were silently timeouting (auto block related ITs).
