### PR TITLE
NEXUS-4744: fix

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
@@ -20,12 +20,6 @@ package org.sonatype.nexus.proxy.attributes;
 
 import java.io.IOException;
 
-import javax.enterprise.inject.Typed;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
-import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
@@ -34,31 +28,25 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
  * AttributeStorage that actually delegates the work to other instance of AttributeStorage, and having an option of
  * "fallback" to some secondary instance. Usable for scenarios where "transitioning" (smooth upgrade for example) is to
  * be used, the "main" attribute storage would be "upgraded" from "legacy" attribute storage as the attributes are
- * requested over the time from this instance.
+ * requested over the time from this instance. This class is not a component, but is used by AttributesHandler when
+ * "transitioning" is needed.
  * 
  * @author cstamas
  * @since 1.10.0
  */
-@Typed( AttributeStorage.class )
-@Named( "transitioning" )
-@Singleton
 public class TransitioningAttributeStorage
-    extends AbstractLoggingComponent
     implements AttributeStorage
 {
-
     private final AttributeStorage mainAttributeStorage;
 
     private final AttributeStorage fallbackAttributeStorage;
 
-    @Inject
-    public TransitioningAttributeStorage( @Named( "ls" ) final AttributeStorage mainAttributeStorage,
-                                          @Named( "legacy" ) final AttributeStorage fallbackAttributeStorage )
+    public TransitioningAttributeStorage( final AttributeStorage mainAttributeStorage,
+                                          final AttributeStorage fallbackAttributeStorage )
     {
         super();
         this.mainAttributeStorage = mainAttributeStorage;
         this.fallbackAttributeStorage = fallbackAttributeStorage;
-        getLogger().info( "Transitioning AttributeStorage in place." );
     }
 
     @Override
@@ -91,8 +79,7 @@ public class TransitioningAttributeStorage
                         }
                         catch ( IOException e )
                         {
-                            // nag and ignore it
-                            getLogger().debug( "Problem during legacy attribute deletion!", e );
+                            // legacy swallows them, this is needed only to satisfy it's signature
                         }
                     }
                 }
@@ -130,8 +117,7 @@ public class TransitioningAttributeStorage
                 }
                 catch ( IOException e )
                 {
-                    // nag and ignore it
-                    getLogger().debug( "Problem during legacy attribute deletion!", e );
+                    // legacy swallows them, this is needed only to satisfy it's signature
                 }
             }
         }
@@ -162,8 +148,7 @@ public class TransitioningAttributeStorage
             }
             catch ( IOException e )
             {
-                // nag and ignore it
-                getLogger().debug( "Problem during legacy attribute deletion!", e );
+                // legacy swallows them, this is needed only to satisfy it's signature
             }
 
             return mainResult;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractProxyTestEnvironment.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractProxyTestEnvironment.java
@@ -36,7 +36,6 @@ import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.proxy.attributes.AttributesHandler;
-import org.sonatype.nexus.proxy.attributes.DefaultFSAttributeStorage;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
@@ -223,12 +222,6 @@ public abstract class AbstractProxyTestEnvironment
         applicationEventMulticaster.addEventListener( testEventListener );
 
         attributesHandler = lookup( AttributesHandler.class );
-
-        if ( attributesHandler.getAttributeStorage() instanceof DefaultFSAttributeStorage )
-        {
-            ( (DefaultFSAttributeStorage) attributesHandler.getAttributeStorage() ).setWorkingDirectory( getApplicationConfiguration().getWorkingDirectory(
-                "proxy/attributes" ) );
-        }
 
         localRepositoryStorage = lookup( LocalRepositoryStorage.class, "file" );
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonJSONMarshaller.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonJSONMarshaller.java
@@ -51,7 +51,7 @@ public class JacksonJSONMarshaller
     public void marshal( final Attributes item, final OutputStream outputStream )
         throws IOException
     {
-        final Map<String, String> attrs = new HashMap( item.asMap() );
+        final Map<String, String> attrs = new HashMap<String, String>( item.asMap() );
         objectMapper.writeValue( outputStream, attrs );
         outputStream.flush();
     }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
@@ -53,7 +53,7 @@ public class JacksonXMLMarshaller
     public void marshal( final Attributes item, final OutputStream outputStream )
         throws IOException
     {
-        final Map<String, String> attrs = new HashMap( item.asMap() );
+        final Map<String, String> attrs = new HashMap<String, String>( item.asMap() );
         objectMapper.writeValue( outputStream, attrs );
         outputStream.flush();
     }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorageTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/LegacyFSAttributeStorageTest.java
@@ -32,7 +32,6 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 
 /**
  * AttributeStorage implementation driven by XStream.
@@ -55,12 +54,11 @@ public class LegacyFSAttributeStorageTest
 
         proxyAttributesDirectory = getTestFile( "target/test-classes/nexus4660" );
 
-        ApplicationEventMulticaster applicationEventMulticaster = Mockito.mock( ApplicationEventMulticaster.class );
         ApplicationConfiguration applicationConfiguration = Mockito.mock( ApplicationConfiguration.class );
         Mockito.when( applicationConfiguration.getWorkingDirectory( "proxy/attributes", false ) ).thenReturn(
             proxyAttributesDirectory );
 
-        attributeStorage = new LegacyFSAttributeStorage( applicationEventMulticaster, applicationConfiguration );
+        attributeStorage = new LegacyFSAttributeStorage( applicationConfiguration );
 
         attributeStorage.initializeWorkingDirectory();
     }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/AttributeStoragePerformanceTestSupport.java
@@ -132,7 +132,7 @@ public abstract class AttributeStoragePerformanceTestSupport
         // set the AttributeStorage on the Attribute Handler
         attributeStorage = getAttributeStorage();
         DefaultAttributesHandler attributesHandler =
-            new DefaultAttributesHandler( applicationConfiguration, attributeStorage, itemInspectorList,
+            new DefaultAttributesHandler( applicationConfiguration, attributeStorage, null, itemInspectorList,
                 fileItemInspectorList );
         // this test assumes attributes are ALWAYS written
         attributesHandler.setLastRequestedResolution( 0 );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/DefaultFSAttributeStoragePerformanceLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/DefaultFSAttributeStoragePerformanceLRTest.java
@@ -18,14 +18,11 @@
  */
 package org.sonatype.nexus.proxy.attributes.perf;
 
-import static org.mockito.Mockito.mock;
-
 import org.junit.runner.RunWith;
 import org.sonatype.nexus.proxy.attributes.AttributeStorage;
 import org.sonatype.nexus.proxy.attributes.DefaultFSAttributeStorage;
 import org.sonatype.nexus.proxy.attributes.XStreamMarshaller;
 import org.sonatype.nexus.proxy.attributes.perf.internal.OrderedRunner;
-import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 
 import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
@@ -47,10 +44,8 @@ public class DefaultFSAttributeStoragePerformanceLRTest
 
     public AttributeStorage getAttributeStorage()
     {
-        ApplicationEventMulticaster applicationEventMulticaster = mock( ApplicationEventMulticaster.class );
-
         DefaultFSAttributeStorage attributeStorage =
-            new DefaultFSAttributeStorage( applicationEventMulticaster, applicationConfiguration,
+            new DefaultFSAttributeStorage( applicationConfiguration,
                 new XStreamMarshaller() );
         attributeStorage.initializeWorkingDirectory();
         return attributeStorage;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/JacksonJSONFSAttributeStoragePerformanceLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/JacksonJSONFSAttributeStoragePerformanceLRTest.java
@@ -18,14 +18,11 @@
  */
 package org.sonatype.nexus.proxy.attributes.perf;
 
-import static org.mockito.Mockito.mock;
-
 import org.junit.runner.RunWith;
 import org.sonatype.nexus.proxy.attributes.AttributeStorage;
 import org.sonatype.nexus.proxy.attributes.DefaultFSAttributeStorage;
 import org.sonatype.nexus.proxy.attributes.JacksonJSONMarshaller;
 import org.sonatype.nexus.proxy.attributes.perf.internal.OrderedRunner;
-import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 
 import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
@@ -47,10 +44,8 @@ public class JacksonJSONFSAttributeStoragePerformanceLRTest
     
     public AttributeStorage getAttributeStorage()
     {
-        ApplicationEventMulticaster applicationEventMulticaster = mock( ApplicationEventMulticaster.class );
-
         DefaultFSAttributeStorage attributeStorage =
-            new DefaultFSAttributeStorage( applicationEventMulticaster, applicationConfiguration,
+            new DefaultFSAttributeStorage( applicationConfiguration,
                 new JacksonJSONMarshaller() );
         attributeStorage.initializeWorkingDirectory();
         return attributeStorage;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/JacksonXMLFSAttributeStoragePerformanceLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/perf/JacksonXMLFSAttributeStoragePerformanceLRTest.java
@@ -18,14 +18,11 @@
  */
 package org.sonatype.nexus.proxy.attributes.perf;
 
-import static org.mockito.Mockito.mock;
-
 import org.junit.runner.RunWith;
 import org.sonatype.nexus.proxy.attributes.AttributeStorage;
 import org.sonatype.nexus.proxy.attributes.DefaultFSAttributeStorage;
 import org.sonatype.nexus.proxy.attributes.JacksonXMLMarshaller;
 import org.sonatype.nexus.proxy.attributes.perf.internal.OrderedRunner;
-import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 
 import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
@@ -46,10 +43,8 @@ public class JacksonXMLFSAttributeStoragePerformanceLRTest
 
     public AttributeStorage getAttributeStorage()
     {
-        ApplicationEventMulticaster applicationEventMulticaster = mock( ApplicationEventMulticaster.class );
-
         DefaultFSAttributeStorage attributeStorage =
-            new DefaultFSAttributeStorage( applicationEventMulticaster, applicationConfiguration,
+            new DefaultFSAttributeStorage( applicationConfiguration,
                 new JacksonXMLMarshaller() );
         attributeStorage.initializeWorkingDirectory();
         return attributeStorage;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/perf/DefaultFSLocalRepositoryStoragePerformanceLRTest.java
@@ -53,7 +53,6 @@ import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.storage.local.fs.DefaultFSLocalRepositoryStorage;
 import org.sonatype.nexus.proxy.storage.local.fs.DefaultFSPeer;
 import org.sonatype.nexus.proxy.wastebasket.Wastebasket;
-import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
@@ -114,7 +113,7 @@ public class DefaultFSLocalRepositoryStoragePerformanceLRTest
 
         // set the AttributeStorage on the Attribute Handler
         DefaultAttributesHandler attributesHandler =
-            new DefaultAttributesHandler( applicationConfiguration, getAttributeStorage(), itemInspectorList,
+            new DefaultAttributesHandler( applicationConfiguration, getAttributeStorage(), null, itemInspectorList,
                 fileItemInspectorList );
 
         // Need to use the MockRepository
@@ -141,10 +140,8 @@ public class DefaultFSLocalRepositoryStoragePerformanceLRTest
     private AttributeStorage getAttributeStorage()
     {
         // Mock out the events
-        ApplicationEventMulticaster applicationEventMulticaster = mock( ApplicationEventMulticaster.class );
-
         DefaultFSAttributeStorage attributeStorage =
-            new DefaultFSAttributeStorage( applicationEventMulticaster, applicationConfiguration,
+            new DefaultFSAttributeStorage( applicationConfiguration,
                 new XStreamMarshaller() );
         attributeStorage.initializeWorkingDirectory();
 


### PR DESCRIPTION
The original NPE was not due to load, but due to config event and how workingFolder was
handled. As it turns out, having AttributeStorage components listen for config events
(and doing whatever they did) was totally nonsense, since there are no means that
a config event (related to nexus.xml changes) would change the nexus-work folder!
Doing the latter is possible only by bouncing Nexus. Hence, scrubbed.

Moreover, the way how Nexus decides is "transitioning" (for attributes) needed or not is
much smarter now with meaningful log messages. Before, we would waste CPU cycles (if not
actual IO) just to invoke methods on "legacy" storage that would simply return doing nothing.
Now, we detect the need for "transitioning", and on new instances we even don't install
any of those components, thus, not wasting any cycles on them.
