### PR TITLE
NEXUS-4743 - Wait for async events before checking feed

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus3915/Nexus3915ContentValidationFeedIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus3915/Nexus3915ContentValidationFeedIT.java
@@ -80,6 +80,9 @@ public class Nexus3915ContentValidationFeedIT
 
         Assert.assertTrue( msg.contains( "404" ), msg );
 
+        // brokenFiles feed is a asynchronous event, so need to wait async event to finish running
+        getEventInspectorsUtil().waitForCalmPeriod();
+
         SyndFeed feed = FeedUtil.getFeed( "brokenFiles" );
 
         @SuppressWarnings( "unchecked" )


### PR DESCRIPTION
brokenFiles feed is a asynchronous event, so need to wait async event to finish running
