### PR TITLE
Improve Empty trash task legacy support!

### DIFF
--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -138,6 +138,11 @@
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-charger</artifactId>
     </dependency>
+  <dependency>
+    <groupId>org.sonatype.sisu</groupId>
+    <artifactId>sisu-resource-scanner</artifactId>
+    <version>1.0</version>
+  </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
@@ -44,7 +44,9 @@ import org.sonatype.sisu.resource.scanner.Scanner;
 public class DefaultWastebasket
     implements SmartWastebasket
 {
-    private static final String TRASH_PATH_PREFIX = "/.nexus/trash";
+    static final String TRASH = "trash";
+
+    private static final String TRASH_PATH_PREFIX = "/.nexus/" + TRASH;
 
     static final long ALL = -1L;
 
@@ -160,7 +162,7 @@ public class DefaultWastebasket
                 @Override
                 public void onExitDirectory( File directory )
                 {
-                    if ( !"trash".equals( directory.getName() ) && directory.list().length == 0 )
+                    if ( !TRASH.equals( directory.getName() ) && directory.list().length == 0 )
                     {
                         directory.delete();
                     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasket.java
@@ -44,7 +44,7 @@ public class DefaultWastebasket
 {
     private static final String TRASH_PATH_PREFIX = "/.nexus/trash";
 
-    private static final long ALL = -1L;
+    static final long ALL = -1L;
 
     private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
 
@@ -161,24 +161,8 @@ public class DefaultWastebasket
     {
         ResourceStoreRequest req = new ResourceStoreRequest( getTrashPath( repository, RepositoryItemUid.PATH_ROOT ) );
 
-        if ( age == ALL )
-        {
-            // simple and fast way, no need for walker
-            try
-            {
-                repository.getLocalStorage().shredItem( repository, req );
-            }
-            catch ( ItemNotFoundException e )
-            {
-                // silent
-            }
-            catch ( UnsupportedStorageOperationException e )
-            {
-                // silent?
-            }
-        }
-        else
-        {
+        // NEXUS-4642 shall not delete the directory, since causes a problem if this has been symlinked to another
+        // directory.
             // walker and walk and changes for age
             if ( repository.getLocalStorage().containsItem( repository, req ) )
             {
@@ -193,7 +177,6 @@ public class DefaultWastebasket
 
                 getWalker().walk( ctx );
             }
-        }
     }
 
     @Override

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
@@ -18,8 +18,11 @@
  */
 package org.sonatype.nexus.proxy.wastebasket;
 
+import java.util.Collection;
+
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
+import org.sonatype.nexus.proxy.item.StorageCollectionItem;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
@@ -67,4 +70,15 @@ public class WastebasketWalker
         }
     }
 
+    @Override
+    public void onCollectionExit( WalkerContext ctx, StorageCollectionItem item )
+        throws Exception
+    {
+        // item is now gone, let's check if this is empty and if so delete it as well
+        Collection<StorageItem> items = item.list();
+        if ( items.isEmpty() )
+        {
+            ctx.getRepository().getLocalStorage().shredItem( ctx.getRepository(), item.getResourceStoreRequest() );
+        }
+    }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
@@ -49,7 +49,8 @@ public class WastebasketWalker
         long now = System.currentTimeMillis();
         long limitDate = now - age;
 
-        if ( item instanceof StorageFileItem && item.getModified() < limitDate )
+        if ( item instanceof StorageFileItem && //
+            ( age == DefaultWastebasket.ALL || item.getModified() < limitDate ) )
         {
             try
             {
@@ -74,6 +75,12 @@ public class WastebasketWalker
     public void onCollectionExit( WalkerContext ctx, StorageCollectionItem item )
         throws Exception
     {
+        if ( "trash".equals( item.getName() ) )
+        {
+            // NEXUS-4642 do not delete the trash
+            return;
+        }
+
         // item is now gone, let's check if this is empty and if so delete it as well
         Collection<StorageItem> items = item.list();
         if ( items.isEmpty() )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/wastebasket/WastebasketWalker.java
@@ -75,7 +75,7 @@ public class WastebasketWalker
     public void onCollectionExit( WalkerContext ctx, StorageCollectionItem item )
         throws Exception
     {
-        if ( "trash".equals( item.getName() ) )
+        if ( DefaultWastebasket.TRASH.equals( item.getName() ) )
         {
             // NEXUS-4642 do not delete the trash
             return;

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
@@ -104,11 +104,14 @@ public class DefaultWastebasketTest
         Wastebasket wastebasket = this.lookup( Wastebasket.class );
         wastebasket.purgeAll( 1L );
 
-        // NEXUS-4468 check if directories were deleted
+        // NEXUS-4642 check if directories were deleted
         assertThat( new File( repoLocation, ".nexus/trash" ), FileMatchers.isDirectory() );
         assertThat( new File( repoLocation, ".nexus/trash" ), FileMatchers.isEmpty() );
     }
 
+    /**
+     * NEXUS-4468 Check if nexus is cleaning up legacy trash properly (deleting content w/o deleting the directory)
+     */
     @Test
     public void testPurgeAllLegacyTrash()
         throws Exception
@@ -121,6 +124,7 @@ public class DefaultWastebasketTest
         File basketDir =
             applicationConfiguration.getWorkingDirectory( AbstractRepositoryFolderCleaner.GLOBAL_TRASH_KEY );
 
+        // fill legacy trash
         basketDir.mkdirs();
         File trashContent = new File( "src/test/resources/active-repo/.nexus/trash" );
         FileUtils.copyDirectoryStructure( trashContent, basketDir );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
@@ -82,8 +82,8 @@ public class DefaultWastebasketTest
     }
 
     /**
-     * Tests that that empting the trash does NOT fail for an out-of-service repository.</BR> Verifies fix for:
-     * NEXUS-4554 - Out of service proxy repo appears to cause Empty Trash task to abort as BROKEN
+     * Tests that that empting the trash does NOT fail for an out-of-service repository.<BR>
+     * Verifies fix for: NEXUS-4554 - Out of service proxy repo appears to cause Empty Trash task to abort as BROKEN
      * 
      * @throws Exception
      */

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/wastebasket/DefaultWastebasketTest.java
@@ -105,7 +105,8 @@ public class DefaultWastebasketTest
         wastebasket.purgeAll( 1L );
 
         // NEXUS-4468 check if directories were deleted
-        assertThat( new File( repoLocation, ".nexus/trash" ), not( FileMatchers.isDirectory() ) );
+        assertThat( new File( repoLocation, ".nexus/trash" ), FileMatchers.isDirectory() );
+        assertThat( new File( repoLocation, ".nexus/trash" ), FileMatchers.isEmpty() );
     }
 
 }

--- a/nexus/nexus-test/nexus-test-common/src/main/java/net/time4tea/rsync/matcher/FileMatchers.java
+++ b/nexus/nexus-test/nexus-test-common/src/main/java/net/time4tea/rsync/matcher/FileMatchers.java
@@ -1,0 +1,223 @@
+/*
+ * © time4tea technology ltd 2007 - Freely redistributable as long as source is acknowledged (CC BY 3.0)
+ */
+package net.time4tea.rsync.matcher;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * James Richardson has written Hamcrest matchers to select files. Wiki page, including code:
+ * http://www.time4tea.net/wiki/display/MAIN/Testing+Files+with+Hamcrest
+ */
+public class FileMatchers
+{
+
+    public static Matcher<File> isDirectory()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return item.isDirectory();
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that " );
+                description.appendValue( fileTested );
+                description.appendText( "is a directory" );
+            }
+        };
+    }
+
+    public static Matcher<File> exists()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return item.exists();
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that file " );
+                description.appendValue( fileTested );
+                description.appendText( " exists" );
+            }
+        };
+    }
+
+    public static Matcher<File> isFile()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return item.isFile();
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that " );
+                description.appendValue( fileTested );
+                description.appendText( "is a file" );
+            }
+        };
+    }
+
+    public static Matcher<File> readable()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return item.canRead();
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that file " );
+                description.appendValue( fileTested );
+                description.appendText( "is readable" );
+            }
+        };
+    }
+
+    public static Matcher<File> writable()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return item.canWrite();
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that file " );
+                description.appendValue( fileTested );
+                description.appendText( "is writable" );
+            }
+        };
+    }
+
+    public static Matcher<File> sized( long size )
+    {
+        return sized( Matchers.equalTo( size ) );
+    }
+
+    public static Matcher<File> sized( final Matcher<Long> size )
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            long length;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                length = item.length();
+                return size.matches( length );
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that file " );
+                description.appendValue( fileTested );
+                description.appendText( " is sized " );
+                description.appendDescriptionOf( size );
+                description.appendText( ", not " + length );
+            }
+        };
+    }
+
+    public static Matcher<File> named( final Matcher<String> name )
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            File fileTested;
+
+            public boolean matchesSafely( File item )
+            {
+                fileTested = item;
+                return name.matches( item.getName() );
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " that file " );
+                description.appendValue( fileTested );
+                description.appendText( " is named" );
+                description.appendDescriptionOf( name );
+                description.appendText( " not " );
+                description.appendValue( fileTested.getName() );
+            }
+        };
+    }
+
+    public static Matcher<File> withCanonicalPath( final Matcher<String> path )
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            public boolean matchesSafely( File item )
+            {
+                try
+                {
+                    return path.matches( item.getCanonicalPath() );
+                }
+                catch ( IOException e )
+                {
+                    return false;
+                }
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( "with canonical path '" );
+                description.appendDescriptionOf( path );
+                description.appendText( "'" );
+            }
+        };
+    }
+
+    public static Matcher<File> withAbsolutePath( final Matcher<String> path )
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            public boolean matchesSafely( File item )
+            {
+                return path.matches( item.getAbsolutePath() );
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( "with absolute path '" );
+                description.appendDescriptionOf( path );
+                description.appendText( "'" );
+            }
+        };
+    }
+}

--- a/nexus/nexus-test/nexus-test-common/src/main/java/net/time4tea/rsync/matcher/FileMatchers.java
+++ b/nexus/nexus-test/nexus-test-common/src/main/java/net/time4tea/rsync/matcher/FileMatchers.java
@@ -220,4 +220,24 @@ public class FileMatchers
             }
         };
     }
+
+    public static Matcher<? super File> isEmpty()
+    {
+        return new TypeSafeMatcher<File>()
+        {
+            String[] files;
+
+            public boolean matchesSafely( File item )
+            {
+                files = item.list();
+                return files.length == 0;
+            }
+
+            public void describeTo( Description description )
+            {
+                description.appendText( " files found " );
+                description.appendValue( files );
+            }
+        };
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
               <exclude>**/.idea/**</exclude>
               <!-- The classes in guava package are copied over from com.google.common.eventbus in order to make then extensible (they are package protected) -->
               <exclude>**/org/sonatype/nexus/eventbus/internal/guava/**</exclude>
+              <!-- FileMatcher from time4tea -->
+              <exclude>**/net/time4tea/rsync/matcher/**</exclude>
             </excludes>
             <mapping>
               <vm>XML_STYLE</vm>


### PR DESCRIPTION
Basically I made 4 changes to EmptyTrash based on NEXUS-4642 and NEXUS-4468:
- trash root level now is holly and no longer deleted  (applied to new and legacy trash)
- using scanner when ALL trash should be purged (applied to new and legacy trash)
- legacy trash now is clean up when age is set (before it only ran with ALL was set)
- new EmptyTrashTask now removes empty directories.
