### PR TITLE
Nexus 4681 fix it

### DIFF
--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/SleepRepositoryTask.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/SleepRepositoryTask.java
@@ -23,7 +23,6 @@ import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.nexus.scheduling.AbstractNexusRepositoriesTask;
 import org.sonatype.scheduling.SchedulerTask;
 
-
 @Component( role = SchedulerTask.class, hint = "SleepRepositoryTask", instantiationStrategy = "per-lookup" )
 public class SleepRepositoryTask
     extends AbstractNexusRepositoriesTask<Object>
@@ -36,10 +35,20 @@ public class SleepRepositoryTask
         getLogger().debug( getMessage() );
 
         final int time = getTime();
-        Thread.sleep( time * 1000 / 2 );
+        sleep( time );
         getRepositoryRegistry().getRepository( getRepositoryId() );
-        Thread.sleep( time * 1000 / 2 );
+        sleep( time );
         return null;
+    }
+
+    protected void sleep( final int time )
+        throws InterruptedException
+    {
+        for ( int i = 0; i < time; i++ )
+        {
+            Thread.sleep( 1000 / 2 );
+            checkInterruption();
+        }
     }
 
     private int getTime()

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
@@ -36,10 +36,17 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 
+/**
+ * Check for tasks mutual exclusion (like two reindex tasks for same repository will run serialized, one will "win" and
+ * run, one will "loose" and wait for winner to finish).
+ */
 public class Nexus4066TaskMutualExclusionIT
     extends AbstractNexusIntegrationTest
 {
 
+    /*
+     * When last argument is false mean task should run in parallel. When it is true task should run serialized.
+     */
     @DataProvider( name = "data", parallel = false )
     public Object[][] createData()
     {

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
@@ -21,13 +21,20 @@ package org.sonatype.nexus.integrationtests.nexus4066;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
 import org.sonatype.nexus.rest.model.ScheduledServiceListResource;
 import org.sonatype.nexus.test.utils.TaskScheduleUtil;
 import org.sonatype.scheduling.TaskState;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
 
 public class Nexus4066TaskMutualExclusionIT
     extends AbstractNexusIntegrationTest
@@ -56,11 +63,28 @@ public class Nexus4066TaskMutualExclusionIT
         };
     }
 
+    private List<ScheduledServiceListResource> tasks;
+
     @BeforeMethod
     public void w8()
         throws Exception
     {
+        tasks = Lists.newArrayList();
+
         TaskScheduleUtil.waitForAllTasksToStop();
+    }
+
+    @AfterMethod
+    public void killTasks()
+        throws IOException
+    {
+        // first I wanna cancel any blocked task, then I cancel the blocker
+        Collections.reverse( tasks );
+
+        for ( ScheduledServiceListResource task : tasks )
+        {
+            TaskScheduleUtil.cancel( task.getId() );
+        }
     }
 
     @Test( dataProvider = "data" )
@@ -94,11 +118,15 @@ public class Nexus4066TaskMutualExclusionIT
         final String taskName = "SleepRepositoryTask_" + repo + "_" + System.nanoTime();
         TaskScheduleUtil.runTask( taskName, "SleepRepositoryTask", 0,
             TaskScheduleUtil.newProperty( "repositoryId", repo ),
-            TaskScheduleUtil.newProperty( "time", String.valueOf( 5 ) ) );
+            TaskScheduleUtil.newProperty( "time", String.valueOf( 50 ) ) );
 
         Thread.sleep( 2000 );
 
-        return TaskScheduleUtil.getTask( taskName );
+        ScheduledServiceListResource task = TaskScheduleUtil.getTask( taskName );
+
+        tasks.add( task );
+
+        return task;
     }
 
 }

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -183,7 +183,7 @@
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
-    <plexus-task-scheduler.version>1.4.2</plexus-task-scheduler.version>
+    <plexus-task-scheduler.version>1.4.3-SNAPSHOT</plexus-task-scheduler.version>
     <plexus-velocity.version>1.1.7</plexus-velocity.version>
     <restlet.version>1.1.6-SONATYPE-5348-V4</restlet.version>
     <shiro.version>1.1.0</shiro.version>


### PR DESCRIPTION
Change this test to create longer tasks that will run for 50 secs to prevent something going south if nexus delays something.

To prevent this test taking to much time to run I made the sleeperTask cancel aware.

Also, depends on changes to task scheduler, that originally was setting a canceled task as never ran. So make sure to visit https://github.com/sonatype/sisu-task-scheduler/pull/1
