### PR TITLE
NXCM-3545 (pre-req) : expose checksum policy to non-core plugins

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
@@ -348,7 +348,10 @@ public abstract class AbstractRepositoryPlexusResource
         else
         {
             resource.setRepoPolicy( RepositoryPolicy.MIXED.name() );
-            resource.setChecksumPolicy( ChecksumPolicy.IGNORE.name() );
+            if ( StringUtils.isEmpty( resource.getChecksumPolicy() ) )
+            {
+                resource.setChecksumPolicy( ChecksumPolicy.IGNORE.name() );
+            }
             resource.setDownloadRemoteIndexes( false );
         }
 
@@ -398,6 +401,7 @@ public abstract class AbstractRepositoryPlexusResource
             {
                 Method artifactMethod = repository.getClass().getMethod( "getArtifactMaxAge", new Class<?>[0] );
                 Method metadataMethod = repository.getClass().getMethod( "getMetadataMaxAge", new Class<?>[0] );
+                Method checksumMethod = repository.getClass().getMethod( "getChecksumPolicy", new Class<?>[0] );
 
                 if ( artifactMethod != null )
                 {
@@ -406,6 +410,10 @@ public abstract class AbstractRepositoryPlexusResource
                 if ( metadataMethod != null )
                 {
                     resource.setMetadataMaxAge( (Integer) metadataMethod.invoke( repository, new Object[0] ) );
+                }
+                if ( checksumMethod != null )
+                {
+                    resource.setChecksumPolicy( checksumMethod.invoke( repository, new Object[0] ).toString() );
                 }
             }
             catch ( Exception e )

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
@@ -295,7 +295,7 @@ public class RepositoryListPlexusResource
     {
         M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( (Xpp3Dom) target.getExternalConfiguration() );
 
-        if ( model.getProvider().equals( "maven2" ) || model.getProvider().equals( "maven1" ) )
+        if ( StringUtils.isNotEmpty( model.getChecksumPolicy() ) )
         {
             exConf.setChecksumPolicy( EnumUtil.valueOf( model.getChecksumPolicy(), ChecksumPolicy.class ) );
         }

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
@@ -295,7 +295,8 @@ public class RepositoryListPlexusResource
     {
         M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( (Xpp3Dom) target.getExternalConfiguration() );
 
-        if ( StringUtils.isNotEmpty( model.getChecksumPolicy() ) )
+        if ( model.getProvider().equals( "maven2" ) || model.getProvider().equals( "maven1" ) ||
+             StringUtils.isNotEmpty( model.getChecksumPolicy() ) )
         {
             exConf.setChecksumPolicy( EnumUtil.valueOf( model.getChecksumPolicy(), ChecksumPolicy.class ) );
         }

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
@@ -307,6 +307,8 @@ public class RepositoryPlexusResource
                                     repository.getClass().getMethod( "setArtifactMaxAge", int.class );
                                 Method metadataMethod =
                                     repository.getClass().getMethod( "setMetadataMaxAge", int.class );
+                                Method checksumMethod =
+                                    repository.getClass().getMethod( "setChecksumPolicy", ChecksumPolicy.class );
 
                                 RepositoryProxyResource proxyModel = (RepositoryProxyResource) model;
 
@@ -317,6 +319,10 @@ public class RepositoryPlexusResource
                                 if ( metadataMethod != null )
                                 {
                                     metadataMethod.invoke( repository, proxyModel.getMetadataMaxAge() );
+                                }
+                                if ( checksumMethod != null )
+                                {
+                                    checksumMethod.invoke( repository, ChecksumPolicy.valueOf( proxyModel.getChecksumPolicy() ) );
                                 }
                             }
                             catch ( Exception e )


### PR DESCRIPTION
The Nexus UI lets you set the checksum policy for new repository types contributed by non-core plugins, but internally the new setting is not passed on to the repository instance and any external configuration setting is always reset back to "ignore".

This change exposes the checksum policy if the repository type supports it, following the same reflection approach used to expose the artifact and metadata max age settings. FYI, this is a pre-req for NXCM-3545.
