### PR TITLE
Update NexusGuiceFilter to use (staged) sisu-guice 3.1.1

### DIFF
--- a/nexus-runtime-platform/pom.xml
+++ b/nexus-runtime-platform/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <sisu-inject.version>2.3.0</sisu-inject.version>
-    <sisu-guice.version>3.1.0</sisu-guice.version>
+    <sisu-guice.version>3.1.1</sisu-guice.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
CI: https://builds.sonatype.org/job/nexus-oss-its-feature/164/

Includes various minor fixes from guice-servlet trunk, most notably:

   http://code.google.com/p/google-guice/source/detail?r=fee2d237bd4d6f89ed510861a25d4f3eafa8f1d1
   http://code.google.com/p/google-guice/source/detail?r=9afcdd8a24ee225e21c461144b524b3fc55c4033
   http://code.google.com/p/google-guice/source/detail?r=e09d8bf14bab27501df1d19462a0542912022f94

Full list: http://code.google.com/p/google-guice/source/list

Also changed the obscure warning about multiple servlet injectors to be logged at a lower level.
