### PR TITLE
Nxcm 3642 fire expirecaches event on cache alteration

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
@@ -22,26 +22,22 @@ package org.sonatype.nexus.proxy.events;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * The event fired when NFC has been requested to expire/clear.
+ * The event fired when NFC has been cleared.
  *
  * @since 2.0
  */
 public class RepositoryEventNfcCleared
-    extends RepositoryEventExpireCaches
+    extends RepositoryMaintenanceEvent
 {
-    private final boolean altered;
+    private final String path;
 
-    public RepositoryEventNfcCleared(final Repository repository, final String path, final boolean altered)
+    public RepositoryEventNfcCleared(final Repository repository, final String path)
     {
-        super( repository, path );
-        this.altered = altered;
+        super( repository );
+        this.path = path;
     }
 
-    /**
-     * Flag to indicate if the NFC was actually altered.
-     * Presence of event only indicates that a request to clear/expire NFC was performed.
-     */
-    public boolean isAltered() {
-        return altered;
+    public String getPath() {
+        return path;
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
@@ -23,8 +23,6 @@ import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
  * The event fired when NFC has been requested to expire/clear.
- * 
- * @author cstamas
  */
 public class RepositoryEventNfcCleared
     extends RepositoryEventExpireCaches

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+
+package org.sonatype.nexus.proxy.events;
+
+import org.sonatype.nexus.proxy.repository.Repository;
+
+/**
+ * The event fired when NFC has been requested to expire/clear.
+ * 
+ * @author cstamas
+ */
+public class RepositoryEventNfcCleared
+    extends RepositoryEventExpireCaches
+{
+    private final boolean altered;
+
+    public RepositoryEventNfcCleared(final Repository repository, final String path, final boolean altered)
+    {
+        super( repository, path );
+        this.altered = altered;
+    }
+
+    /**
+     * Flag to indicate if the NFC was actually altered.
+     * Presence of event only indicates that a request to clear/expire NFC was performed.
+     */
+    public boolean isAltered() {
+        return altered;
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryEventNfcCleared.java
@@ -23,6 +23,8 @@ import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
  * The event fired when NFC has been requested to expire/clear.
+ *
+ * @since 2.0
  */
 public class RepositoryEventNfcCleared
     extends RepositoryEventExpireCaches

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCachePathCache.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCachePathCache.java
@@ -109,14 +109,16 @@ public class EhCachePathCache
 
         String keyToRemove = makeKeyFromPath( path );
 
+        boolean removed = false;
         for ( String key : keys )
         {
             if ( key.startsWith( keyToRemove ) )
             {
-                getEHCache().remove( key );
+                boolean tmp = getEHCache().remove( key );
+                removed = removed || tmp;
             }
         }
-        return true;
+        return removed;
     }
 
     public void doPurge()

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -52,6 +52,7 @@ import org.sonatype.nexus.proxy.cache.PathCache;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryEventExpireCaches;
 import org.sonatype.nexus.proxy.events.RepositoryEventLocalStatusChanged;
+import org.sonatype.nexus.proxy.events.RepositoryEventNfcCleared;
 import org.sonatype.nexus.proxy.events.RepositoryEventRecreateAttributes;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventDelete;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
@@ -502,11 +503,8 @@ public abstract class AbstractRepository
             }
         }
 
-        // Only fire an event if the cache was altered
-        if (cacheAltered) {
-            getApplicationEventMulticaster().notifyEventListeners(
-                new RepositoryEventExpireCaches( this, request.getRequestPath() ) );
-        }
+        getApplicationEventMulticaster().notifyEventListeners(
+            new RepositoryEventNfcCleared( this, request.getRequestPath(), cacheAltered ) );
     }
 
     public Collection<String> evictUnusedItems( ResourceStoreRequest request, final long timestamp )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -52,7 +52,6 @@ import org.sonatype.nexus.proxy.cache.PathCache;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryEventExpireCaches;
 import org.sonatype.nexus.proxy.events.RepositoryEventLocalStatusChanged;
-import org.sonatype.nexus.proxy.events.RepositoryEventNfcCleared;
 import org.sonatype.nexus.proxy.events.RepositoryEventRecreateAttributes;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventDelete;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
@@ -503,8 +502,11 @@ public abstract class AbstractRepository
             }
         }
 
-        getApplicationEventMulticaster().notifyEventListeners(
-            new RepositoryEventNfcCleared( this, request.getRequestPath(), cacheAltered ) );
+        // Only fire an event if the cache was altered
+        if (cacheAltered) {
+            getApplicationEventMulticaster().notifyEventListeners(
+                new RepositoryEventExpireCaches( this, request.getRequestPath() ) );
+        }
     }
 
     public Collection<String> evictUnusedItems( ResourceStoreRequest request, final long timestamp )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -460,6 +460,9 @@ public abstract class AbstractRepository
 
         // 2nd, remove the items from NFC
         expireNotFoundCaches( request );
+
+        getApplicationEventMulticaster().notifyEventListeners(
+            new RepositoryEventExpireCaches(this, request.getRequestPath()) );
     }
 
     public void expireNotFoundCaches( ResourceStoreRequest request )
@@ -503,8 +506,10 @@ public abstract class AbstractRepository
             }
         }
 
-        getApplicationEventMulticaster().notifyEventListeners(
-            new RepositoryEventNfcCleared( this, request.getRequestPath(), cacheAltered ) );
+        if (cacheAltered) {
+            getApplicationEventMulticaster().notifyEventListeners(
+                new RepositoryEventNfcCleared( this, request.getRequestPath() ) );
+        }
     }
 
     public Collection<String> evictUnusedItems( ResourceStoreRequest request, final long timestamp )

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManagerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManagerTest.java
@@ -50,18 +50,60 @@ public class EhCacheCacheManagerTest
         c.put( "/com/sonatype", Boolean.TRUE );
         c.put( "/com/sonatype/nexus", Boolean.TRUE );
 
-        c.removeWithParents( "/com/sonatype" );
+        boolean removed = c.removeWithParents( "/com/sonatype" );
 
+        assertEquals(true, removed);
         assertTrue( c.contains( "/com/sonatype/nexus" ) );
         assertFalse( c.contains( "/com/sonatype" ) );
         assertFalse( c.contains( "/com" ) );
 
-        c.removeWithParents( "/com/sonatype/nexus" );
+        removed = c.removeWithParents( "/com/sonatype/nexus" );
 
+        assertEquals(true, removed);
         assertFalse( c.contains( "/com/sonatype/nexus" ) );
         assertFalse( c.contains( "/com/sonatype" ) );
         assertFalse( c.contains( "/com" ) );
 
+        removed = c.removeWithParents( "/com/sonatype/nexus" );
+        assertEquals(false, removed);
+    }
+    
+    @Test
+    public void testRemoveWithChildren()
+        throws Exception
+    {
+        CacheManager cm = lookup( CacheManager.class );
+
+        PathCache c = cm.getPathCache( "test" );
+
+        c.put( "/com", Boolean.TRUE );
+        c.put( "/com/sonatype", Boolean.TRUE );
+        c.put( "/com/sonatype/nexus", Boolean.TRUE );
+        c.put( "/org", Boolean.TRUE );
+        c.put( "/org/sonatype", Boolean.TRUE );
+        c.put( "/org/sonatype/nexus", Boolean.TRUE );
+        
+        boolean removed = c.removeWithChildren( "/com" );
+
+        assertTrue( removed ); // this should have removed stuff
+        assertFalse( c.contains( "/com/sonatype/nexus" ) );
+        assertFalse( c.contains( "/com/sonatype" ) );
+        assertFalse( c.contains( "/com" ) );
+        assertTrue( c.contains( "/org/sonatype/nexus" ) );
+        assertTrue( c.contains( "/org/sonatype" ) );
+        assertTrue( c.contains( "/org" ) );
+
+        removed = c.removeWithChildren( "/com" );
+
+        assertFalse( removed ); // this should have removed nothing
+
+        removed = c.removeWithChildren( "/" );
+
+        assertTrue( removed ); // this should have removed everything
+
+        assertFalse( c.contains( "/org/sonatype/nexus" ) );
+        assertFalse( c.contains( "/org/sonatype" ) );
+        assertFalse( c.contains( "/org" ) );
     }
 
     @Test


### PR DESCRIPTION
Potential fix for https://issues.sonatype.org/browse/NXCM-3642 and general optimization for how/when RepositoryEventExpireCaches fired.

This change will only fire this event if the cache was altered.

A few changes to the EhCache impl to expose meaningful results for removeWithChildren() invocation.
