### PR TITLE
Reconfigure logging when nexus is initialized as there can be plugins th...

### DIFF
--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/src/main/java/org/sonatype/nexus/plugin/migration/artifactory/ArtifactoryFileLocationPlexusResource.java
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/src/main/java/org/sonatype/nexus/plugin/migration/artifactory/ArtifactoryFileLocationPlexusResource.java
@@ -63,7 +63,6 @@ import org.sonatype.security.usermanagement.User;
 @Component( role = PlexusResource.class, hint = "artifactoryFileLocation" )
 public class ArtifactoryFileLocationPlexusResource
     extends AbstractArtifactoryMigrationPlexusResource
-    implements Initializable
 {
 
     @Requirement
@@ -71,9 +70,6 @@ public class ArtifactoryFileLocationPlexusResource
 
     @Requirement
     private RepositoryRegistry repositoryRegistry;
-
-    @Requirement
-    private LogManager logManager;
 
     public ArtifactoryFileLocationPlexusResource()
     {
@@ -362,12 +358,6 @@ public class ArtifactoryFileLocationPlexusResource
             }
         }
         return null;
-    }
-
-    public void initialize()
-        throws InitializationException
-    {
-        logManager.configure();
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/src/main/java/org/sonatype/nexus/plugin/migration/artifactory/DefaultArtifactoryMigrator.java
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/src/main/java/org/sonatype/nexus/plugin/migration/artifactory/DefaultArtifactoryMigrator.java
@@ -90,7 +90,7 @@ import org.sonatype.scheduling.ScheduledTask;
 @Component( role = ArtifactoryMigrator.class )
 public class DefaultArtifactoryMigrator
     extends AbstractLogEnabled
-    implements ArtifactoryMigrator, Initializable
+    implements ArtifactoryMigrator
 {
     private static final String MAVEN2 = "maven2";
 
@@ -119,9 +119,6 @@ public class DefaultArtifactoryMigrator
 
     @Requirement
     private Nexus nexus;
-
-    @Requirement
-    private LogManager logManager;
 
     @Requirement
     private RepositoryRegistry repositoryRegistry;
@@ -1036,12 +1033,6 @@ public class DefaultArtifactoryMigrator
         zipUnArchiver.extract();
 
         return artifactoryBackup;
-    }
-
-    public void initialize()
-        throws InitializationException
-    {
-        logManager.configure();
     }
 
 }

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackReconfigureEventInspector.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackReconfigureEventInspector.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.log.internal;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.sonatype.nexus.log.LogManager;
+import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusInitializedEvent;
+import org.sonatype.plexus.appevents.Event;
+
+@Component( role = EventInspector.class, hint = "LogbackReconfigureEventInspector" )
+public class LogbackReconfigureEventInspector
+    extends AbstractEventInspector
+{
+
+    @Requirement
+    private LogManager logManager;
+
+    public boolean accepts( Event<?> evt )
+    {
+        return evt instanceof NexusInitializedEvent;
+    }
+
+    public void inspect( Event<?> evt )
+    {
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
+
+        logManager.configure();
+    }
+}


### PR DESCRIPTION
...at can contribute configurations that are not initially visible

It did work before for migration plugin as migration plugin was doing its own reconfiguration call when initialized

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
