### PR TITLE
Group member change detection

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
@@ -156,6 +156,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the set of enums describing the changes happened against group repository.
      * 
      * @return
+     * @since 2.0
      */
     public Set<MemberChange> getMemberChangeSet()
     {
@@ -166,6 +167,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the list of member repository IDs as it was set before the configuration change.
      * 
      * @return
+     * @since 2.0
      */
     public List<String> getOldRepositoryMemberIds()
     {
@@ -176,6 +178,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the list of member repository IDs as it was set after the configuration change.
      * 
      * @return
+     * @since 2.0
      */
     public List<String> getNewRepositoryMemberIds()
     {
@@ -186,6 +189,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the list of repository IDs that were removed from the group by the configuration change.
      * 
      * @return
+     * @since 2.0
      */
     public List<String> getRemovedRepositoryIds()
     {
@@ -196,6 +200,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the list of repository IDs that were added to the group by the configuration change.
      * 
      * @return
+     * @since 2.0
      */
     public List<String> getAddedRepositoryIds()
     {
@@ -206,6 +211,7 @@ public class RepositoryGroupMembersChangedEvent
      * Returns the list of repository IDs that were reordered within the group by the configuration change.
      * 
      * @return
+     * @since 2.0
      */
     public List<String> getReorderedRepositoryIds()
     {

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
@@ -28,28 +28,64 @@ import java.util.Set;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
 
 /**
- * Fired when a group repository members changed and is applied (not rollbacked).
+ * Fired when a group repository members changed and change is commited to configuration (is not rolled back).
  * 
  * @author cstamas
  */
 public class RepositoryGroupMembersChangedEvent
     extends RepositoryEvent
 {
+    /**
+     * Enum describing the changes that might happen against a group members list. Every enum describes one of the
+     * possible type of the change, but they might happen all together too.
+     * 
+     * @author cstamas
+     * @since 2.0
+     */
     public enum MemberChange
     {
-        MEMBER_ADDED, MEMBER_REMOVED, MEMBER_REORDERED;
+        /**
+         * Member(s) added to group.
+         */
+        MEMBER_ADDED,
+        /**
+         * Member(s) removed from group.
+         */
+        MEMBER_REMOVED,
+        /**
+         * Member(s) reordered within a group.
+         */
+        MEMBER_REORDERED;
     }
 
+    /**
+     * List of member IDs that were set before this member change.
+     */
     private final List<String> oldRepositoryMemberIds;
 
+    /**
+     * List of member IDs that is set after this member change.
+     */
     private final List<String> newRepositoryMemberIds;
 
+    /**
+     * List of member IDs that were removed from the group.
+     */
     private final List<String> removedRepositoryIds;
 
+    /**
+     * List of member IDs that were added ti the group.
+     */
     private final List<String> addedRepositoryIds;
 
+    /**
+     * List of member IDs that were reordered within the group.
+     */
     private final List<String> reorderedRepositoryIds;
 
+    /**
+     * Set of change enums, describing the changes in short and consise way that happened against the given group.
+     */
     private final Set<MemberChange> memberChangeSet;
 
     public RepositoryGroupMembersChangedEvent( final GroupRepository repository, final List<String> currentMemberIds,
@@ -106,36 +142,71 @@ public class RepositoryGroupMembersChangedEvent
         }
     }
 
+    /**
+     * Returns the group repository instance being reconfigured.
+     * 
+     * @return
+     */
     public GroupRepository getGroupRepository()
     {
         return (GroupRepository) getEventSender();
     }
 
+    /**
+     * Returns the set of enums describing the changes happened against group repository.
+     * 
+     * @return
+     */
     public Set<MemberChange> getMemberChangeSet()
     {
         return memberChangeSet;
     }
 
+    /**
+     * Returns the list of member repository IDs as it was set before the configuration change.
+     * 
+     * @return
+     */
     public List<String> getOldRepositoryMemberIds()
     {
         return Collections.unmodifiableList( oldRepositoryMemberIds );
     }
 
+    /**
+     * Returns the list of member repository IDs as it was set after the configuration change.
+     * 
+     * @return
+     */
     public List<String> getNewRepositoryMemberIds()
     {
         return Collections.unmodifiableList( newRepositoryMemberIds );
     }
 
+    /**
+     * Returns the list of repository IDs that were removed from the group by the configuration change.
+     * 
+     * @return
+     */
     public List<String> getRemovedRepositoryIds()
     {
         return Collections.unmodifiableList( removedRepositoryIds );
     }
 
+    /**
+     * Returns the list of repository IDs that were added to the group by the configuration change.
+     * 
+     * @return
+     */
     public List<String> getAddedRepositoryIds()
     {
         return Collections.unmodifiableList( addedRepositoryIds );
     }
 
+    /**
+     * Returns the list of repository IDs that were reordered within the group by the configuration change.
+     * 
+     * @return
+     */
     public List<String> getReorderedRepositoryIds()
     {
         return Collections.unmodifiableList( reorderedRepositoryIds );

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
@@ -18,6 +18,13 @@
  */
 package org.sonatype.nexus.proxy.events;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
 import org.sonatype.nexus.proxy.repository.GroupRepository;
 
 /**
@@ -28,13 +35,109 @@ import org.sonatype.nexus.proxy.repository.GroupRepository;
 public class RepositoryGroupMembersChangedEvent
     extends RepositoryEvent
 {
-    public RepositoryGroupMembersChangedEvent( final GroupRepository repository )
+    public enum MemberChange
+    {
+        MEMBER_ADDED, MEMBER_REMOVED, MEMBER_REORDERED;
+    }
+
+    private final List<String> oldRepositoryMemberIds;
+
+    private final List<String> newRepositoryMemberIds;
+
+    private final List<String> removedRepositoryIds;
+
+    private final List<String> addedRepositoryIds;
+
+    private final List<String> reorderedRepositoryIds;
+
+    private final Set<MemberChange> memberChangeSet;
+
+    public RepositoryGroupMembersChangedEvent( final GroupRepository repository, final List<String> currentMemberIds,
+                                               final List<String> newMemberIds )
     {
         super( repository );
+        // we need to copy these to "detach" them for sure from config
+        this.oldRepositoryMemberIds = new ArrayList<String>( currentMemberIds );
+        this.newRepositoryMemberIds = new ArrayList<String>( newMemberIds );
+
+        // simple calculations
+        this.removedRepositoryIds = new ArrayList<String>( oldRepositoryMemberIds );
+        removedRepositoryIds.removeAll( newRepositoryMemberIds );
+        this.addedRepositoryIds = new ArrayList<String>( newRepositoryMemberIds );
+        addedRepositoryIds.removeAll( oldRepositoryMemberIds );
+        this.reorderedRepositoryIds = new ArrayList<String>();
+
+        // ordering detection
+        final List<String> currentTrimmed = new ArrayList<String>( oldRepositoryMemberIds );
+        currentTrimmed.removeAll( removedRepositoryIds );
+        currentTrimmed.removeAll( addedRepositoryIds );
+        final List<String> newTrimmed = new ArrayList<String>( newRepositoryMemberIds );
+        newTrimmed.removeAll( removedRepositoryIds );
+        newTrimmed.removeAll( addedRepositoryIds );
+
+        if ( !currentTrimmed.equals( newTrimmed ) && currentTrimmed.size() > 0 )
+        {
+            Iterator<String> i1 = currentTrimmed.iterator();
+            Iterator<String> i2 = newTrimmed.iterator();
+
+            while ( i1.hasNext() )
+            {
+                final String oldEl = i1.next();
+                final String newEl = i2.next();
+                if ( !oldEl.equals( newEl ) )
+                {
+                    reorderedRepositoryIds.add( newEl );
+                }
+            }
+        }
+
+        this.memberChangeSet = EnumSet.noneOf( MemberChange.class );
+        if ( !reorderedRepositoryIds.isEmpty() )
+        {
+            memberChangeSet.add( MemberChange.MEMBER_REORDERED );
+        }
+        if ( !removedRepositoryIds.isEmpty() )
+        {
+            memberChangeSet.add( MemberChange.MEMBER_REMOVED );
+        }
+        if ( !addedRepositoryIds.isEmpty() )
+        {
+            memberChangeSet.add( MemberChange.MEMBER_ADDED );
+        }
     }
 
     public GroupRepository getGroupRepository()
     {
         return (GroupRepository) getEventSender();
+    }
+
+    public Set<MemberChange> getMemberChangeSet()
+    {
+        return memberChangeSet;
+    }
+
+    public List<String> getOldRepositoryMemberIds()
+    {
+        return Collections.unmodifiableList( oldRepositoryMemberIds );
+    }
+
+    public List<String> getNewRepositoryMemberIds()
+    {
+        return Collections.unmodifiableList( newRepositoryMemberIds );
+    }
+
+    public List<String> getRemovedRepositoryIds()
+    {
+        return Collections.unmodifiableList( removedRepositoryIds );
+    }
+
+    public List<String> getAddedRepositoryIds()
+    {
+        return Collections.unmodifiableList( addedRepositoryIds );
+    }
+
+    public List<String> getReorderedRepositoryIds()
+    {
+        return Collections.unmodifiableList( reorderedRepositoryIds );
     }
 }

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEventTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEventTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2008-2011 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions
+ *
+ * This program is free software: you can redistribute it and/or modify it only under the terms of the GNU Affero General
+ * Public License Version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License Version 3
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License Version 3 along with this program.  If not, see
+ * http://www.gnu.org/licenses.
+ *
+ * Sonatype Nexus (TM) Open Source Version is available from Sonatype, Inc. Sonatype and Sonatype Nexus are trademarks of
+ * Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation. M2Eclipse is a trademark of the Eclipse Foundation.
+ * All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.events;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonatype.nexus.proxy.events.RepositoryGroupMembersChangedEvent.MemberChange;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+
+public class RepositoryGroupMembersChangedEventTest
+{
+    protected RepositoryGroupMembersChangedEvent createEvent( final List<String> currentMemberIds,
+                                                              final List<String> newMemberIds )
+    {
+        final RepositoryGroupMembersChangedEvent evt =
+            new RepositoryGroupMembersChangedEvent( Mockito.mock( GroupRepository.class ), currentMemberIds,
+                newMemberIds );
+
+        assertThat( evt.getOldRepositoryMemberIds(), contains( currentMemberIds.toArray() ) );
+        assertThat( evt.getNewRepositoryMemberIds(), contains( newMemberIds.toArray() ) );
+
+        return evt;
+    }
+
+    @Test
+    public void testNoChange()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a", "b", "c" );
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 0 ) );
+        assertThat( evt.getAddedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getRemovedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testSimpleAddition()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a", "b", "c", "d" );
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_ADDED ) );
+        assertThat( evt.getAddedRepositoryIds(), contains( "d" ) );
+        assertThat( evt.getRemovedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testSimpleAdditionMore()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a", "b", "c", "d", "e" );
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_ADDED ) );
+        assertThat( evt.getAddedRepositoryIds(), contains( "d", "e" ) );
+        assertThat( evt.getRemovedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testSimpleRemoval()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a", "b" );
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_REMOVED ) );
+        assertThat( evt.getAddedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getRemovedRepositoryIds(), contains( "c" ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testSimpleRemovalMore()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a" );
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_REMOVED ) );
+        assertThat( evt.getAddedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getRemovedRepositoryIds(), contains( "b", "c" ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testSimpleOrderChange()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "a", "c", "b" );
+        // we swapped places of "b" and "c"
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_REORDERED ) );
+        assertThat( evt.getAddedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getRemovedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getReorderedRepositoryIds(), contains( "c", "b" ) );
+    }
+
+    @Test
+    public void testSimpleOrderChangeMore()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "c", "a", "b" );
+        // we swapped places of all members
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 1 ) );
+        assertThat( evt.getMemberChangeSet(), contains( MemberChange.MEMBER_REORDERED ) );
+        assertThat( evt.getAddedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getRemovedRepositoryIds().size(), equalTo( 0 ) );
+        assertThat( evt.getReorderedRepositoryIds(), contains( "c", "a", "b" ) );
+    }
+
+    @Test
+    public void testMultiChange1()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c" );
+        final List<String> newMembers = Arrays.asList( "d", "e", "a" );
+        // we removed "b", "c", added "d", "e", and ordering of "a" did not change (it is only one remnant from old
+        // list)
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 2 ) );
+        assertThat( evt.getMemberChangeSet(),
+            containsInAnyOrder( MemberChange.MEMBER_ADDED, MemberChange.MEMBER_REMOVED ) );
+        assertThat( evt.getAddedRepositoryIds(), contains( "d", "e" ) );
+        assertThat( evt.getRemovedRepositoryIds(), contains( "b", "c" ) );
+        assertThat( evt.getReorderedRepositoryIds().size(), equalTo( 0 ) );
+    }
+
+    @Test
+    public void testMultiChange2()
+    {
+        final List<String> oldMembers = Arrays.asList( "a", "b", "c", "d" );
+        final List<String> newMembers = Arrays.asList( "f", "e", "c", "a" );
+        // we removed "b" and "d", added "f", "e", and reordered "ac" to "ca"
+        final RepositoryGroupMembersChangedEvent evt = createEvent( oldMembers, newMembers );
+        assertThat( evt.getMemberChangeSet().size(), equalTo( 3 ) );
+        assertThat( evt.getMemberChangeSet(),
+            containsInAnyOrder( MemberChange.MEMBER_ADDED, MemberChange.MEMBER_REMOVED, MemberChange.MEMBER_REORDERED ) );
+        assertThat( evt.getAddedRepositoryIds(), contains( "f", "e" ) );
+        assertThat( evt.getRemovedRepositoryIds(), contains( "b", "d" ) );
+        assertThat( evt.getReorderedRepositoryIds(), contains( "c", "a" ) );
+    }
+
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -101,6 +101,10 @@ public abstract class AbstractGroupRepository
                     true ).getMemberRepositoryIds().size() || !getExternalConfiguration( false ).getMemberRepositoryIds().containsAll(
                     getExternalConfiguration( true ).getMemberRepositoryIds() ) );
 
+        // we have to "remember" these before commit happens in super.onEvent
+        final List<String> currentMemberIds = getExternalConfiguration( false ).getMemberRepositoryIds();
+        final List<String> newMemberIds = getExternalConfiguration( true ).getMemberRepositoryIds();
+
         super.onEvent( evt );
 
         // act automatically on repo removal. Remove it from myself if member.
@@ -116,7 +120,8 @@ public abstract class AbstractGroupRepository
         else if ( evt instanceof ConfigurationPrepareForSaveEvent && membersChanged )
         {
             // fire another event
-            getApplicationEventMulticaster().notifyEventListeners( new RepositoryGroupMembersChangedEvent( this ) );
+            getApplicationEventMulticaster().notifyEventListeners(
+                new RepositoryGroupMembersChangedEvent( this, currentMemberIds, newMemberIds ) );
         }
     }
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -101,9 +101,19 @@ public abstract class AbstractGroupRepository
                     true ).getMemberRepositoryIds().size() || !getExternalConfiguration( false ).getMemberRepositoryIds().containsAll(
                     getExternalConfiguration( true ).getMemberRepositoryIds() ) );
 
+        List<String> currentMemberIds = Collections.emptyList();
+        List<String> newMemberIds = Collections.emptyList();
         // we have to "remember" these before commit happens in super.onEvent
-        final List<String> currentMemberIds = getExternalConfiguration( false ).getMemberRepositoryIds();
-        final List<String> newMemberIds = getExternalConfiguration( true ).getMemberRepositoryIds();
+        // but ONLY if we are dirty and we do have "member changes" (see membersChanged above)
+        // this same boolean drives the firing of the event too, for which we are actually collecting these lists
+        // if no event to be fired, these lines should also not execute, since they are "dirtying" the config
+        // if membersChange is true, config is already dirty, and we DO KNOW there is member change to happen
+        // and we will fire the event too
+        if ( membersChanged )
+        {
+            currentMemberIds = getExternalConfiguration( false ).getMemberRepositoryIds();
+            newMemberIds = getExternalConfiguration( true ).getMemberRepositoryIds();
+        }
 
         super.onEvent( evt );
 


### PR DESCRIPTION
Added change "awareness" for RepositoryGroupMembersChangedEvent.

It is now able to report what repository IDs were added, removed and/or reordered
in a group.
