### PR TITLE
Fix invalid UTF-8 sequence (replace long-dash with dash)

### DIFF
--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
@@ -359,7 +359,7 @@ public class LogbackLogManager
             out.println( "<?xml version='1.0' encoding='UTF-8'?>" );
             out.println();
             out.println( "<!--" );
-            out.println( "    DO NOT EDIT – This file aggregates log configuration from Nexus and its plugins, and is automatically generated." );
+            out.println( "    DO NOT EDIT - This file aggregates log configuration from Nexus and its plugins, and is automatically generated." );
             out.println( "-->" );
             out.println();
             out.println( "<configuration scan='true'>" );

--- a/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-events.xml
+++ b/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-events.xml
@@ -21,7 +21,7 @@
 -->
 
 <!--
-    DO NOT EDIT – This log appender is used by Nexus to populate the "Error and warning events" system feed.
+    DO NOT EDIT - This log appender is used by Nexus to populate the "Error and warning events" system feed.
 -->
 
 <included>


### PR DESCRIPTION
https://github.com/sonatype/nexus/commit/800b02bc28cdd85e06eff6d6f28170611f7c524b broke logging by introducing an invalid UTF-8 character (long-dash instead of a simple dash) into the logfiles:

 jvm 1    | ch.qos.logback.core.joran.spi.JoranException: I/O error occurred while parsing xml file
jvm 1    |  at ch.qos.logback.core.joran.event.SaxEventRecorder.handleError(SaxEventRecorder.java:74)
jvm 1    |  at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:62)
jvm 1    |  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:132)
jvm 1    |  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:96)
jvm 1    |  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:73)
jvm 1    |  at org.sonatype.nexus.log.internal.LogbackLogManager.reconfigure(LogbackLogManager.java:399)
jvm 1    |  at org.sonatype.nexus.log.internal.LogbackLogManager.configure(LogbackLogManager.java:250)
jvm 1    |  at org.sonatype.nexus.web.LogConfigListener.configureLogManager(LogConfigListener.java:103)
jvm 1    |  at org.sonatype.nexus.web.LogConfigListener.contextInitialized(LogConfigListener.java:50)
jvm 1    |  at org.eclipse.jetty.server.handler.ContextHandler.startContext(ContextHandler.java:643)
jvm 1    |  at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:233)
jvm 1    |  at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1213)
jvm 1    |  at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:589)
jvm 1    |  at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:454)
jvm 1    |  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:59)
jvm 1    |  at org.eclipse.jetty.server.handler.HandlerCollection.doStart(HandlerCollection.java:224)
jvm 1    |  at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:167)
jvm 1    |  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:59)
jvm 1    |  at org.eclipse.jetty.server.handler.HandlerWrapper.doStart(HandlerWrapper.java:89)
jvm 1    |  at org.eclipse.jetty.server.Server.doStart(Server.java:261)
jvm 1    |  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:59)
jvm 1    |  at org.sonatype.plexus.jetty.Jetty7$JettyWrapperThread.run(Jetty7.java:142)
jvm 1    | Caused by: com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException: Invalid byte 2 of 2-byte UTF-8 sequence.
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.invalidByte(UTF8Reader.java:684)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.read(UTF8Reader.java:369)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1742)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.scanData(XMLEntityScanner.java:1242)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLScanner.scanComment(XMLScanner.java:756)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanComment(XMLDocumentFragmentScannerImpl.java:1040)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$PrologDriver.next(XMLDocumentScannerImpl.java:946)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:648)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:140)
jvm 1    |  at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:511)
jvm 1    |  at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:808)
jvm 1    |  at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:737)
jvm 1    |  at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:119)
jvm 1    |  at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1205)
jvm 1    |  at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:522)
jvm 1    |  at javax.xml.parsers.SAXParser.parse(SAXParser.java:395)
jvm 1    |  at ch.qos.logback.core.joran.event.SaxEventRecorder.recordEvents(SaxEventRecorder.java:59)
jvm 1    |  ... 20 more
