### PR TITLE
Bump versions of nexus-launcher dependencies

### DIFF
--- a/nexus/nexus-launcher/pom.xml
+++ b/nexus/nexus-launcher/pom.xml
@@ -77,12 +77,12 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-bundle-launcher</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-jsw-utils</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>

--- a/nexus/nexus-launcher/pom.xml
+++ b/nexus/nexus-launcher/pom.xml
@@ -77,21 +77,16 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-bundle-launcher</artifactId>
-      <version>1.0</version>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-jsw-utils</artifactId>
-      <version>1.0</version>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.ning</groupId>
-      <artifactId>async-http-client</artifactId>
-      <version>1.4.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Bump version of sisu-bundle-launcher to be able to use latest aether for ITs and sisu-jsw-utils to make ITs runnable also on windows

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
