### PR TITLE
o [NXCM-3688] Add config option for decoding html entities to TextField

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.form.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.form.js
@@ -983,22 +983,59 @@ Ext.override(Ext.form.TextField, {
    * <tt>true</tt> to decode html entities in the value given to
    * Ext.form.ByteDisplayField.setValue and Ext.form.ByteDisplayField.setRawValue
    * before setting the actual value.
+   * <p/>
+   * This is needed for displaying the 'literal' value in the text field when it was received by the server,
+   * for example in the repository name. The REST layer will encode to html entities, which will be correct
+   * for html rendering, but text fields without this configuration will display '&quot;test&quot;' instead
+   * of the originally sent '"test"'.
    */
   htmlDecode : false,
 
+  /**
+   * @cfg {Boolean} htmlConvert
+   * <tt>true</tt> to decode html entities in the value given to
+   * Ext.form.TextField.set(Raw)Value
+   * before setting the actual value, and encode html entities again
+   * in the call to Ext.form.TextField.get(Raw)Value.
+   * <p/>
+   * This is needed for displaying the 'literal' value in the text field when it was received by the server
+   * (see htmlDecode configuration doc), and display to the user correctly before round-tripping to the server again
+   * (e.g. in a grid field).
+   * <p/>
+   * when this config is set, the value has to be html-decoded again before sending it to the server, because the REST layer
+   * will encode the string again.
+   */
+  htmlConvert : false,
+
   setRawValue : function(value) {
-    if ( this.htmlDecode )
+    if ( this.htmlDecode || this.htmlConvert )
     {
       value = Ext.util.Format.htmlDecode(value);
     }
     Ext.form.TextField.superclass.setRawValue.call(this, value);
   },
   setValue : function(value) {
-    if ( this.htmlDecode )
+    if ( this.htmlDecode || this.htmlConvert )
     {
       value = Ext.util.Format.htmlDecode(value);
     }
     Ext.form.TextField.superclass.setValue.call(this, value);
+  },
+  getRawValue : function() {
+    var value = Ext.form.TextField.superclass.getRawValue.call(this);
+    if ( this.htmlConvert )
+    {
+      value = Ext.util.Format.htmlEncode(value);
+    }
+    return value;
+  },
+  getValue : function() {
+    var value = Ext.form.TextField.superclass.getValue.call(this);
+    if ( this.htmlConvert )
+    {
+      value = Ext.util.Format.htmlEncode(value);
+    }
+    return value;
   }
 });
 

--- a/nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.form.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/extensions/Ext.form.js
@@ -976,3 +976,30 @@ Ext.form.ByteDisplayField = Ext.extend(Ext.form.DisplayField, {
     });
 
 Ext.reg('byteDisplayField', Ext.form.ByteDisplayField);
+
+Ext.override(Ext.form.TextField, {
+  /**
+   * @cfg {Boolean} htmlDecode
+   * <tt>true</tt> to decode html entities in the value given to
+   * Ext.form.ByteDisplayField.setValue and Ext.form.ByteDisplayField.setRawValue
+   * before setting the actual value.
+   */
+  htmlDecode : false,
+
+  setRawValue : function(value) {
+    if ( this.htmlDecode )
+    {
+      value = Ext.util.Format.htmlDecode(value);
+    }
+    Ext.form.TextField.superclass.setRawValue.call(this, value);
+  },
+  setValue : function(value) {
+    if ( this.htmlDecode )
+    {
+      value = Ext.util.Format.htmlDecode(value);
+    }
+    Ext.form.TextField.superclass.setValue.call(this, value);
+  }
+});
+
+

--- a/nexus/nexus-webapp/src/main/webapp/js/formFieldGenerator.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/formFieldGenerator.js
@@ -53,6 +53,7 @@ FormFieldGenerator = function(panelId, fieldSetName, fieldNamePrefix, typeStore,
             {
               items[j] = {
                 xtype : 'textfield',
+                htmlDecode : true,
                 fieldLabel : curRec.label,
                 itemCls : curRec.required ? 'required-field' : '',
                 helpText : curRec.helpText,
@@ -81,6 +82,7 @@ FormFieldGenerator = function(panelId, fieldSetName, fieldNamePrefix, typeStore,
             {
               items[j] = {
                 xtype : 'textarea',
+                htmlDecode : true,
                 fieldLabel : curRec.label,
                 itemCls : curRec.required ? 'required-field' : '',
                 helpText : curRec.helpText,

--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.RepoEditPanel.js
@@ -432,6 +432,7 @@ Sonatype.repoServer.HostedRepositoryEditor = function(config) {
               helpText : ht.name,
               name : 'name',
               width : 200,
+              htmlDecode : true,
               allowBlank : false
             }, {
               xtype : 'textfield',


### PR DESCRIPTION
Characters mapping to html entities are escaped server-side on incoming REST requests. The value received from server would render as expected, but the text field setting the value would contain the html escaped string instead of the 'literal' value, and would also send the html string on the next save - just to be processed again by the REST layer.

This change adds a config option to decode html entities for text field values, and applies this option to the repository name field.
