### PR TITLE
UT logging cleanup.

### DIFF
--- a/nexus/nexus-api/pom.xml
+++ b/nexus/nexus-api/pom.xml
@@ -107,10 +107,6 @@
       <artifactId>nexus-test-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/nexus/nexus-app/pom.xml
+++ b/nexus/nexus-app/pom.xml
@@ -116,11 +116,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-jetty-testsuite</artifactId>
       <scope>test</scope>

--- a/nexus/nexus-clients/nexus-rest-client-java/pom.xml
+++ b/nexus/nexus-clients/nexus-rest-client-java/pom.xml
@@ -74,10 +74,6 @@
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-test-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/pom.xml
@@ -37,8 +37,8 @@
       <artifactId>junit-dep</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
     </dependency>
     <dependency>
       <groupId> org.jdom</groupId>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-core-client/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-core-client/pom.xml
@@ -45,8 +45,8 @@
       <artifactId>junit-dep</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
     </dependency>
     <dependency>
       <groupId> org.jdom</groupId>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-m2-settings-client/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-m2-settings-client/pom.xml
@@ -45,8 +45,8 @@
       <artifactId>junit-dep</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
     </dependency>
     <dependency>
       <groupId> org.jdom</groupId>

--- a/nexus/nexus-configuration-model/pom.xml
+++ b/nexus/nexus-configuration-model/pom.xml
@@ -56,10 +56,6 @@
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-test-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/nexus/nexus-configuration/pom.xml
+++ b/nexus/nexus-configuration/pom.xml
@@ -100,10 +100,6 @@
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-test-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
@@ -106,10 +106,6 @@
       <artifactId>nexus-test-common</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/pom.xml
@@ -171,11 +171,6 @@
       <artifactId>nexus-test-common</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.sonatype.http-testing-harness</groupId>

--- a/nexus/nexus-core-plugins/nexus-rrb-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-rrb-plugin/pom.xml
@@ -126,11 +126,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-jetty-testsuite</artifactId>
       <scope>test</scope>

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -180,10 +180,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-web</artifactId>
       <scope>test</scope>

--- a/nexus/nexus-web-utils/pom.xml
+++ b/nexus/nexus-web-utils/pom.xml
@@ -96,6 +96,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -619,13 +619,6 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
-        <type>jar</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
         <type>jar</type>


### PR DESCRIPTION
As nexus-test-common started bringing in logback, which is a SLF4J backend,
logging in UTs were borked as slf4j-simple was added too with test scope
and SLF4J complains about multiple backends present on classpath.

nexus-test-common brings in logback as transitive dep coming from litmus.

Now, the slf4j-simple is removed, only one module is left using it (that
rightfully does not use nexus-test-common): nexus-web-utils module.
