### PR TITLE
o [NEXUS-4775] log guice circular dependency exception as trace

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
@@ -105,7 +105,17 @@ public class DefaultEventInspectorHost
 
     protected void processEvent( final Event<?> evt )
     {
-        final Set<EventInspector> inspectors = getEventInspectors();
+        Set<EventInspector> inspectors;
+        try
+        {
+            inspectors = getEventInspectors();
+        }
+        catch ( IllegalStateException e )
+        {
+            // NEXUS-4775 guice exception trying to resolve circular dependencies too early
+            getLogger().trace( "Event inspectors are not fully initialized, skipping handling of {}", evt, e );
+            return;
+        }
 
         for ( EventInspector ei : inspectors )
         {


### PR DESCRIPTION
The circular dependency may happen when an event inspector logs
warn/error (which will fire events) in its constructor.
