### PR TITLE
NEXUS-4786: Scheduled task logging fix

### DIFF
--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/DefaultFeedRecorder.java
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/DefaultFeedRecorder.java
@@ -469,7 +469,7 @@ public class DefaultFeedRecorder
 
         addToTimeline( prc );
 
-        getLogger().info( prc.getMessage() );
+        getLogger().debug( prc.getMessage() );
 
         return prc;
     }
@@ -480,7 +480,7 @@ public class DefaultFeedRecorder
 
         addToTimeline( prc );
 
-        getLogger().info( prc.getMessage() );
+        getLogger().debug( prc.getMessage() );
     }
 
     public void systemProcessCanceled( SystemProcess prc, String cancelMessage )
@@ -489,7 +489,7 @@ public class DefaultFeedRecorder
 
         addToTimeline( prc );
 
-        getLogger().info( prc.getMessage() );
+        getLogger().debug( prc.getMessage() );
     }
 
     public void systemProcessBroken( SystemProcess prc, Throwable e )
@@ -498,7 +498,7 @@ public class DefaultFeedRecorder
 
         addToTimeline( prc );
 
-        getLogger().info( prc.getMessage(), e );
+        getLogger().debug( prc.getMessage(), e );
     }
 
     protected void addToTimeline( SystemEvent se )


### PR DESCRIPTION
This is actually a followup of the "move timeline into plugin" change.
Before, while Timeline was in core, ScheduledTasks relied on it, and was coupled
to it to perform "task related logging" (report when task started, stopped, etc).
Today, Timeline plugin is demoted into a plugin, and is hence optional, this
change actually fixes the problem of potentially missing task related loglines,
but also corrects the misleading loglines coming from Feed recorder.

Changes:
- DefaultFeedRecorder task related logging demoted to DEBUG level (IMO, should be totally removed)
- AbstractNexusTask improved for small "bookkeepeing" about run duration and proper logging about it's
  execution status

This change actually "fixes" the problem forgot to be solved in the actual move of the Timeline into a plugin.
