### PR TITLE
NFC fixes

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/NfcConfigurationModifier.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/NfcConfigurationModifier.java
@@ -1,0 +1,72 @@
+package org.sonatype.nexus.configuration.application;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.Configuration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.util.SystemPropertiesHelper;
+
+@Component( role = ConfigurationModifier.class, hint = "NfcConfigurationModifier" )
+public class NfcConfigurationModifier
+    extends AbstractLoggingComponent
+    implements ConfigurationModifier
+{
+    /**
+     * Flag to control how to interfere with configuration. If system property is not set at all, this
+     * ConfigurationModifier will remain inactive (will not interfere with configuration at all). If is set, and it's
+     * value evaluates to Boolean.TRUE (equals to string "true"), then the enforce will be applied, and NFC will be
+     * forced to not-active on all non-proxy repository and to active on all proxy repositories present in
+     * configuration. If is set, and it's value evaluates to Boolean.FALSE (is set with any other string than "true"),
+     * it will revert to the "default" (all repositories will have NFC enabled). Using these, and bouncing Nexus
+     * instance, you can easily "force" the configuration into a desired state (ie. to restore to old state, just set
+     * the property to "false" and bounce Nexus). The presence of this component has no any other "side effect".
+     */
+    private final String operation = SystemPropertiesHelper.getString(
+        "org.sonatype.nexus.configuration.application.NfcConfigurationModifier.enforce", null );
+
+    @Override
+    public boolean apply( final Configuration configuration )
+    {
+        if ( operation == null )
+        {
+            // neglect all this, just ignore
+            return false;
+        }
+        else if ( Boolean.parseBoolean( operation ) )
+        {
+            doForceNfcSetting( configuration );
+            return true;
+        }
+        else
+        {
+            undoForceNfcSetting( configuration );
+            return true;
+        }
+    }
+
+    protected void doForceNfcSetting( final Configuration configuration )
+    {
+        getLogger().info(
+            "Enforcing proper NFC use: every non-proxy repository present in system will have NFC deactivated (system property override present)." );
+
+        // conservatively shut down NFC on any non-proxy repository
+        for ( CRepository repository : configuration.getRepositories() )
+        {
+            final boolean isProxyRepository =
+                repository.getRemoteStorage() != null && repository.getRemoteStorage().getUrl() != null;
+            repository.setNotFoundCacheActive( isProxyRepository );
+        }
+    }
+
+    protected void undoForceNfcSetting( final Configuration configuration )
+    {
+        getLogger().info(
+            "Undoing NFC overrides: every repository present in system will have NFC activated (system property override present)." );
+
+        // just undo, set true on all repositories in system
+        for ( CRepository repository : configuration.getRepositories() )
+        {
+            repository.setNotFoundCacheActive( true );
+        }
+    }
+}

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/Maven1ProxyRepositoryTemplate.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/Maven1ProxyRepositoryTemplate.java
@@ -69,6 +69,7 @@ public class Maven1ProxyRepositoryTemplate
         repo.externalConfigurationImple = exConf;
 
         repo.setWritePolicy( RepositoryWritePolicy.READ_ONLY.name() );
+        repo.setNotFoundCacheActive( true );
         repo.setNotFoundCacheTTL( 1440 );
         
         if ( exConf.getRepositoryPolicy() != null && exConf.getRepositoryPolicy() == RepositoryPolicy.SNAPSHOT )

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/Maven2ProxyRepositoryTemplate.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/Maven2ProxyRepositoryTemplate.java
@@ -69,6 +69,7 @@ public class Maven2ProxyRepositoryTemplate
         repo.externalConfigurationImple = exConf;
 
         repo.setWritePolicy( RepositoryWritePolicy.READ_ONLY.name() );
+        repo.setNotFoundCacheActive( true );
         repo.setNotFoundCacheTTL( 1440 );
 
         if ( exConf.getRepositoryPolicy() != null && exConf.getRepositoryPolicy() == RepositoryPolicy.SNAPSHOT )

--- a/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
@@ -123,7 +123,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -147,7 +147,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -171,7 +171,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -195,6 +195,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.ShadowRepository</providerRole>
       <providerHint>m2-m1-shadow</providerHint>
       <localStatus>IN_SERVICE</localStatus>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>15</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -211,7 +212,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.GroupRepository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>15</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade146to1100.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade146to1100.java
@@ -98,17 +98,27 @@ public class Upgrade146to1100
         };
 
         org.sonatype.nexus.configuration.model.Configuration newc = versionConverter.upgradeConfiguration( oldc );
-        
+
         // this should go into much "older" upgrader, this was a mistake!
-        if (newc.getErrorReporting() == null) {
+        if ( newc.getErrorReporting() == null )
+        {
             CErrorReporting errorReporting = new CErrorReporting();
             errorReporting.setEnabled( false );
             newc.setErrorReporting( errorReporting );
         }
-        if (newc.getNotification() == null) {
+        if ( newc.getNotification() == null )
+        {
             CNotification notification = new CNotification();
             notification.setEnabled( false );
             newc.setNotification( notification );
+        }
+
+        // conservatively shut down NFC on any non-proxy repository
+        for ( CRepository repository : newc.getRepositories() )
+        {
+            final boolean isProxyRepository =
+                repository.getRemoteStorage() != null && repository.getRemoteStorage().getUrl() != null;
+            repository.setNotFoundCacheActive( isProxyRepository );
         }
 
         newc.setVersion( org.sonatype.nexus.configuration.model.Configuration.MODEL_VERSION );

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/DefaultCRepository.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/DefaultCRepository.java
@@ -28,7 +28,7 @@ public class DefaultCRepository
         // providerHint
         setPathPrefix( null );
         setLocalStatus( LocalStatus.IN_SERVICE.toString() );
-        setNotFoundCacheActive( true );
+        setNotFoundCacheActive( false );
         setNotFoundCacheTTL( 15 );
         setUserManaged( true );
         setExposed( true );

--- a/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
+++ b/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
@@ -123,7 +123,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -147,7 +147,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -171,7 +171,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>1440</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -195,6 +195,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.ShadowRepository</providerRole>
       <providerHint>m2-m1-shadow</providerHint>
       <localStatus>IN_SERVICE</localStatus>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>15</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>
@@ -211,7 +212,7 @@
       <providerRole>org.sonatype.nexus.proxy.repository.GroupRepository</providerRole>
       <providerHint>maven2</providerHint>
       <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
+      <notFoundCacheActive>false</notFoundCacheActive>
       <notFoundCacheTTL>15</notFoundCacheTTL>
       <userManaged>true</userManaged>
       <exposed>true</exposed>

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
@@ -247,6 +247,8 @@ public class RepositoryListPlexusResource
                 appModel.getLocalStorage().setUrl( repoResource.getOverrideLocalStorageUrl() );
 
                 appModel.getLocalStorage().setProvider( "file" );
+                
+                appModel.setNotFoundCacheActive( true );
             }
             else
             {

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
@@ -247,8 +247,6 @@ public class RepositoryListPlexusResource
                 appModel.getLocalStorage().setUrl( repoResource.getOverrideLocalStorageUrl() );
 
                 appModel.getLocalStorage().setProvider( "file" );
-                
-                appModel.setNotFoundCacheActive( true );
             }
             else
             {
@@ -258,6 +256,8 @@ public class RepositoryListPlexusResource
             RepositoryResourceRemoteStorage remoteStorage = repoResource.getRemoteStorage();
             if ( remoteStorage != null )
             {
+                appModel.setNotFoundCacheActive( true );
+                
                 appModel.setRemoteStorage( new CRemoteStorage() );
 
                 appModel.getRemoteStorage().setUrl( remoteStorage.getRemoteStorageUrl() );


### PR DESCRIPTION
As it turns out, NFC is used by ALL repository types (used as populated).

Even groups, even if in their case the actual _content_ of NFC is neglected, they still use it!
Before this change, the size of NFC in case of a non serviceable request to public group would raise
with 1+groupMemberSize. After this change, size of NFC would raise with the count of affected proxy
repositories only (1 in this case, Central only).

The testing of these changes were applied to RSO with good results, hosted reposes did not make disks evaporate.
