### PR TITLE
Make RecreateMavenMetadata a bit smarter...

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryItemEvent.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * The event fired in case of some content changes in Nexus related to an item/file.
@@ -69,6 +70,13 @@ public abstract class RepositoryItemEvent
     public StorageItem getItem()
     {
         return item;
+    }
+    
+    // ==
+    
+    public String toString()
+    {
+        return String.format( "%s(sender=%s, %s)", getClass().getSimpleName(), RepositoryStringUtils.getHumanizedNameString( getRepository() ), getItem().getRepositoryItemUid().toString() );
     }
 
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/AbstractMetadataHelper.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/AbstractMetadataHelper.java
@@ -105,7 +105,7 @@ abstract public class AbstractMetadataHelper
     public void processFile( String path )
         throws IOException
     {
-        // remove rotten checksum
+        // remove checksums that does not have corresponding "main" file (those without .sha1 ext)
         if ( isObsoleteChecksum( path ) )
         {
             remove( path );


### PR DESCRIPTION
As detected by SP, Recreate Maven Metadata task (more precisely the org.sonatype.nexus.proxy.maven.metadata.DefaultMetadataHelper class used by task) always recreates Maven2 checksum files, even if they are containing good checksums. This was due to a poor design to drive the decision.

This fix improves the decision making (is basing the decision on "correctness" of SHA1 and assumes if SHA1 is wrong, MD5 will be wrong too, and other way around), and will recreate those files only when needed.
