### PR TITLE
Making TransitioningAttributeStorage "non-eager", throttling et al.

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
@@ -33,6 +33,8 @@ public class DefaultWalkerContext
 
     private final ResourceStoreRequest request;
 
+    private final WalkerThrottleController throttleController;
+
     private Map<String, Object> context;
 
     private List<WalkerProcessor> processors;
@@ -65,18 +67,31 @@ public class DefaultWalkerContext
         this.collectionsOnly = collectionsOnly;
 
         this.running = true;
+
+        if ( request.getRequestContext().containsKey( WalkerThrottleController.CONTEXT_KEY, false ) )
+        {
+            this.throttleController =
+                (WalkerThrottleController) request.getRequestContext().get( WalkerThrottleController.CONTEXT_KEY, false );
+        }
+        else
+        {
+            this.throttleController = WalkerThrottleController.NO_THROTTLING;
+        }
     }
 
+    @Override
     public boolean isLocalOnly()
     {
         return request.isRequestLocalOnly();
     }
 
+    @Override
     public boolean isCollectionsOnly()
     {
         return collectionsOnly;
     }
 
+    @Override
     public Map<String, Object> getContext()
     {
         if ( context == null )
@@ -86,6 +101,7 @@ public class DefaultWalkerContext
         return context;
     }
 
+    @Override
     public List<WalkerProcessor> getProcessors()
     {
         if ( processors == null )
@@ -96,26 +112,31 @@ public class DefaultWalkerContext
         return processors;
     }
 
+    @Override
     public void setProcessors( List<WalkerProcessor> processors )
     {
         this.processors = processors;
     }
 
+    @Override
     public WalkerFilter getFilter()
     {
         return walkerFilter;
     }
 
+    @Override
     public Repository getRepository()
     {
         return resourceStore;
     }
 
+    @Override
     public ResourceStoreRequest getResourceStoreRequest()
     {
         return request;
     }
 
+    @Override
     public boolean isStopped()
     {
         try
@@ -135,11 +156,13 @@ public class DefaultWalkerContext
         return !running;
     }
 
+    @Override
     public Throwable getStopCause()
     {
         return stopCause;
     }
 
+    @Override
     public void stop( Throwable cause )
     {
         running = false;
@@ -147,4 +170,9 @@ public class DefaultWalkerContext
         stopCause = cause;
     }
 
+    @Override
+    public WalkerThrottleController getThrottleController()
+    {
+        return this.throttleController;
+    }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
@@ -101,4 +101,11 @@ public interface WalkerContext
      * @return
      */
     Repository getRepository();
+
+    /**
+     * Returns the "throttle control" of this context.
+     * 
+     * @return
+     */
+    WalkerThrottleController getThrottleController();
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerProcessor.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerProcessor.java
@@ -24,7 +24,7 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 public interface WalkerProcessor
 {
     boolean isActive();
-
+    
     void beforeWalk( WalkerContext context )
         throws Exception;
 

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -1,0 +1,53 @@
+package org.sonatype.nexus.proxy.walker;
+
+/**
+ * Interface to controle throttling (if desired) in executing of Walks.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public interface WalkerThrottleController
+{
+    /**
+     * Key used in RequestContext to pass it into Walker.
+     */
+    String CONTEXT_KEY = WalkerThrottleController.class.getName();
+
+    /**
+     * WalkerThrottleController that does not emply walk throttling.
+     */
+    WalkerThrottleController NO_THROTTLING = new WalkerThrottleController()
+    {
+        @Override
+        public boolean isThrottled()
+        {
+            return false;
+        }
+
+        @Override
+        public long throttleTime( long processItemSpentMillis )
+        {
+            return -1;
+        }
+    };
+
+    /**
+     * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean
+     * intentionally slowing down the "walk" by inserting some amount (see {@link #throttleTime(long)} method) of
+     * Thread.sleep() invocations.
+     * 
+     * @return
+     */
+    boolean isThrottled();
+
+    /**
+     * Returns the next desired sleep time this context wants to have applied. It might be in some relation to the time
+     * spent in processItem() methods of registered WalkerProcessors, but does not have to be.
+     * 
+     * @param processItemSpentMillis time in millis WalkerProcessors spent in their
+     *            {@link WalkerProcessor#processItem(WalkerContext, org.sonatype.nexus.proxy.item.StorageItem)} method.
+     * @return any value bigger than zero means "sleep as many millis to throttle". Any values less or equal to zero are
+     *         neglected (will not invoke sleep).
+     */
+    long throttleTime( long processItemSpentMillis );
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -25,11 +25,36 @@ public interface WalkerThrottleController
         }
 
         @Override
-        public long throttleTime( long processItemSpentMillis )
+        public long throttleTime( final ThrottleInfo info )
         {
             return -1;
         }
     };
+
+    public interface ThrottleInfo
+    {
+        /**
+         * The total time spent in processItem() method. This time is "contained" in the {@link #getTotalTimeWalking()}.
+         * 
+         * @return
+         */
+        long getTotalProcessItemSpentMillis();
+
+        /**
+         * The total invocation count of processItem() method ("How many items were processed so far?").
+         * 
+         * @return
+         */
+        long getTotalProcessItemInvocationCount();
+
+        /**
+         * The total time (in milliseconds) since walking begun. The returned time always reflects the truly actual
+         * spent time in walking, counting time even spent with throttle calculations ("gross time" spent).
+         * 
+         * @return
+         */
+        long getTotalTimeWalking();
+    }
 
     /**
      * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean
@@ -44,10 +69,9 @@ public interface WalkerThrottleController
      * Returns the next desired sleep time this context wants to have applied. It might be in some relation to the time
      * spent in processItem() methods of registered WalkerProcessors, but does not have to be.
      * 
-     * @param processItemSpentMillis time in millis WalkerProcessors spent in their
-     *            {@link WalkerProcessor#processItem(WalkerContext, org.sonatype.nexus.proxy.item.StorageItem)} method.
+     * @param info The info object holding some (probably) used informations to calculate next desired sleep time.
      * @return any value bigger than zero means "sleep as many millis to throttle". Any values less or equal to zero are
      *         neglected (will not invoke sleep).
      */
-    long throttleTime( long processItemSpentMillis );
+    long throttleTime( ThrottleInfo info );
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+public interface AttributeUpgrader
+{
+    boolean isLegacyAttributesDirectoryPresent();
+
+    boolean isUpgradeNeeded();
+
+    boolean isUpgradeRunning();
+    
+    boolean isUpgradeFinished();
+
+    int getCurrentUps();
+
+    int getLimiterUps();
+
+    void setLimiterUps( int limit );
+
+    void upgrade();
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
@@ -12,34 +12,16 @@
  */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
-import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
 import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
-import org.sonatype.nexus.proxy.item.RepositoryItemUid;
-import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
-import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
-import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
-import org.sonatype.nexus.util.SystemPropertiesHelper;
 import org.sonatype.plexus.appevents.Event;
 
 /**
- * EventInspector that handles upgrade of "legacy attribute storage". It does it by detecting it's presence, and firing
- * the rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did
- * happen, to not kick in on any subsequent reboot.
+ * EventInspector that fires upgrade call to upgrader component, does it blindly.
  * 
  * @since 1.10.0
  */
@@ -48,23 +30,8 @@ public class AttributesUpgradeEventInspector
     extends AbstractEventInspector
     implements EventInspector, AsynchronousEventInspector
 {
-    /**
-     * The "switch" for performing upgrade (by bg thread), default is true (upgrade will happen).
-     */
-    private final boolean UPGRADE = SystemPropertiesHelper.getBoolean( getClass().getName() + ".upgrade", true );
-
-    /**
-     * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
-     * Default is to NOT use throttling.
-     */
-    private final long UPGRADE_THROTTLE_MILLIS = SystemPropertiesHelper.getLong( getClass().getName()
-        + ".throttleMillis", -1 );
-
     @Requirement
-    private ApplicationConfiguration applicationConfiguration;
-
-    @Requirement
-    private RepositoryRegistry repositoryRegistry;
+    private AttributeUpgrader attributeUpgrader;
 
     @Override
     public boolean accepts( Event<?> evt )
@@ -75,169 +42,9 @@ public class AttributesUpgradeEventInspector
     @Override
     public void inspect( Event<?> evt )
     {
-        final File legacyAttributesDirectory = applicationConfiguration.getWorkingDirectory( "proxy/attributes", false );
-
-        if ( !legacyAttributesDirectory.isDirectory() )
+        if ( accepts( evt ) )
         {
-            // file not found or not a directory, stay put to not create noise in logs (new or tidied up nexus
-            // instance)
-        }
-        else
-        {
-            if ( isUpgradeDone( legacyAttributesDirectory, null ) )
-            {
-                // nag the user to remove the directory
-                getLogger().info(
-                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
-                        + legacyAttributesDirectory.getAbsolutePath() + "\" folder." );
-            }
-            else
-            {
-                if ( UPGRADE )
-                {
-                    new UpgraderThread( legacyAttributesDirectory, repositoryRegistry, UPGRADE_THROTTLE_MILLIS ).start();
-                }
-                else
-                {
-                    getLogger().info(
-                        "Legacy attribute directory present, but upgrade prevented by system property. Not upgrading it." );
-                }
-            }
-        }
-    }
-
-    // ==
-
-    private static final String MARKER_FILENAME = "README.txt";
-
-    private static final String MARKER_TEXT =
-        "Migration of legacy attributes finished.\nPlease delete, remove or rename this directory!";
-
-    protected static boolean isUpgradeDone( final File attributesDirectory, final String repoId )
-    {
-        try
-        {
-            if ( StringUtils.isBlank( repoId ) )
-            {
-                return StringUtils.equals( MARKER_TEXT,
-                    FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
-            }
-            else
-            {
-                return StringUtils.equals( MARKER_TEXT,
-                    FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
-            }
-        }
-        catch ( IOException e )
-        {
-            return false;
-        }
-    }
-
-    protected static void markUpgradeDone( final File attributesDirectory, final String repoId )
-    {
-        try
-        {
-            if ( StringUtils.isBlank( repoId ) )
-            {
-                FileUtils.fileWrite( new File( attributesDirectory, MARKER_FILENAME ), MARKER_TEXT );
-            }
-            else
-            {
-                final File target = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
-                // this step is needed if new repo added while upgrade not done: it will NOT have legacy attributes
-                // as other reposes, that were present in old/upgraded instance
-                target.getParentFile().mkdirs();
-                FileUtils.fileWrite( target, MARKER_TEXT );
-            }
-        }
-        catch ( IOException e )
-        {
-            // hum?
-        }
-    }
-
-    // ==
-
-    protected static class UpgraderThread
-        extends Thread
-    {
-        private Logger logger = LoggerFactory.getLogger( getClass() );
-
-        private final File legacyAttributesDirectory;
-
-        private final RepositoryRegistry repositoryRegistry;
-
-        private final long throttleMillis;
-
-        public UpgraderThread( final File legacyAttributesDirectory, final RepositoryRegistry repositoryRegistry,
-                               long throttleMillis )
-        {
-            this.legacyAttributesDirectory = legacyAttributesDirectory;
-            this.repositoryRegistry = repositoryRegistry;
-            this.throttleMillis = throttleMillis;
-            // to have it clearly in thread dumps
-            setName( "LegacyAttributesUpgrader" );
-            // to not prevent sudden reboots (by user, if upgrading, and rebooting)
-            setDaemon( true );
-            // to not interfere much with other stuff
-            setPriority( Thread.MIN_PRIORITY );
-        }
-
-        @Override
-        public void run()
-        {
-            if ( !isUpgradeDone( legacyAttributesDirectory, null ) )
-            {
-                logger.info( "Legacy attribute directory present, and upgrade needed. Upgrading it in background thread." );
-                if ( throttleMillis > 0 )
-                {
-                    logger.info(
-                        "Legacy attribute upgrade is throttled by {} millis (system property override present).",
-                        throttleMillis );
-                }
-                List<Repository> reposes = repositoryRegistry.getRepositories();
-                for ( Repository repo : reposes )
-                {
-                    if ( !isUpgradeDone( legacyAttributesDirectory, repo.getId() ) )
-                    {
-                        logger.info( "Upgrading legacy attributes of repository {}.",
-                            RepositoryStringUtils.getHumanizedNameString( repo ) );
-                        ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
-                        if ( throttleMillis > 0 )
-                        {
-                            req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY,
-                                new WalkerThrottleController()
-                                {
-                                    @Override
-                                    public boolean isThrottled()
-                                    {
-                                        return true;
-                                    }
-
-                                    @Override
-                                    public long throttleTime( long processItemSpentMillis )
-                                    {
-                                        if ( processItemSpentMillis < throttleMillis )
-                                        {
-                                            return throttleMillis;
-                                        }
-                                        else
-                                        {
-                                            return -1;
-                                        }
-                                    }
-                                } );
-                        }
-                        repo.recreateAttributes( req, null );
-                        markUpgradeDone( legacyAttributesDirectory, repo.getId() );
-                    }
-                }
-                markUpgradeDone( legacyAttributesDirectory, null );
-                logger.info(
-                    "Legacy attribute directory upgrade finished. Please delete, move or rename the \"{}\" folder.",
-                    legacyAttributesDirectory.getAbsolutePath() );
-            }
+            attributeUpgrader.upgrade();
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -1,0 +1,204 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.util.SystemPropertiesHelper;
+
+/**
+ * Component that handles upgrade of "legacy attribute storage". It does it by detecting it's presence, and firing the
+ * rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did happen,
+ * to not kick in on any subsequent reboot.
+ * 
+ * @since 1.10.0
+ */
+@Component( role = AttributeUpgrader.class )
+public class DefaultAttributeUpgrader
+    extends AbstractLoggingComponent
+    implements AttributeUpgrader
+{
+    /**
+     * The "switch" for performing upgrade (by bg thread), default is true (upgrade will happen).
+     */
+    private final boolean UPGRADE = SystemPropertiesHelper.getBoolean( getClass().getName() + ".upgrade", true );
+
+    /**
+     * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
+     * Default is to 100 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
+     * Central repository is currently 300k of artifacts, this would mean in "nexus world" 6x300k items (pom, jar,
+     * maven-metadata and sha1/md5 hashes for those) if all of Central would be proxied by Nexus, which is not
+     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 100 UPS
+     * would take exactly 2.5 hour to upgrade it. Note: this is only the value used for unnattended upgrade! This is the
+     * starting value, that is still possible to "tune" (increase, decrease) over JMX!
+     */
+    private final int UPGRADE_THROTTLE_UPS = SystemPropertiesHelper.getInteger( getClass().getName() + ".throttleUps",
+        50 );
+
+    @Requirement
+    private ApplicationConfiguration applicationConfiguration;
+
+    @Requirement
+    private RepositoryRegistry repositoryRegistry;
+
+    private volatile UpgraderThread upgraderThread;
+
+    protected File getLegacyAttributesDirectory()
+    {
+        return applicationConfiguration.getWorkingDirectory( "proxy/attributes", false );
+    }
+
+    @Override
+    public boolean isLegacyAttributesDirectoryPresent()
+    {
+        return getLegacyAttributesDirectory().isDirectory();
+    }
+
+    @Override
+    public boolean isUpgradeNeeded()
+    {
+        return isLegacyAttributesDirectoryPresent() && !isUpgradeFinished();
+    }
+
+    @Override
+    public boolean isUpgradeRunning()
+    {
+        return upgraderThread != null && upgraderThread.isAlive();
+    }
+
+    @Override
+    public boolean isUpgradeFinished()
+    {
+        return isUpgradeDone( getLegacyAttributesDirectory(), null );
+    }
+
+    @Override
+    public int getCurrentUps()
+    {
+        if ( isUpgradeRunning() )
+        {
+            return upgraderThread.getActualUps();
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
+    @Override
+    public int getLimiterUps()
+    {
+        if ( isUpgradeRunning() )
+        {
+            return upgraderThread.getLimiterUps();
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
+    @Override
+    public void setLimiterUps( int limit )
+    {
+        if ( isUpgradeRunning() )
+        {
+            upgraderThread.setLimiterUps( limit );
+        }
+    }
+
+    @Override
+    public synchronized void upgrade()
+    {
+        if ( !isLegacyAttributesDirectoryPresent() )
+        {
+            // file not found or not a directory, stay put to not create noise in logs (new or tidied up nexus
+            // instance)
+            getLogger().debug( "Legacy attribute directory not present, no need for attribute upgrade." );
+        }
+        else
+        {
+            if ( isUpgradeDone( getLegacyAttributesDirectory(), null ) )
+            {
+                // nag the user to remove the directory
+                getLogger().info(
+                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
+                        + getLegacyAttributesDirectory().getAbsolutePath() + "\" folder." );
+            }
+            else
+            {
+                if ( UPGRADE )
+                {
+                    getLogger().info(
+                        "Legacy attribute directory present, and upgrade is needed. Starting background upgrade." );
+                    this.upgraderThread =
+                        new UpgraderThread( getLegacyAttributesDirectory(), repositoryRegistry, UPGRADE_THROTTLE_UPS );
+                    this.upgraderThread.start();
+                }
+                else
+                {
+                    // nag the user about explicit no-upgrade switch
+                    getLogger().info(
+                        "Legacy attribute directory present, but upgrade prevented by system property. Not upgrading it." );
+                }
+            }
+        }
+    }
+
+    // ==
+
+    private static final String MARKER_FILENAME = "README.txt";
+
+    private static final String MARKER_TEXT =
+        "Migration of legacy attributes finished.\nPlease delete, remove or rename this directory!";
+
+    protected static boolean isUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
+            }
+            else
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
+            }
+        }
+        catch ( IOException e )
+        {
+            return false;
+        }
+    }
+
+    protected static void markUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                FileUtils.fileWrite( new File( attributesDirectory, MARKER_FILENAME ), MARKER_TEXT );
+            }
+            else
+            {
+                final File target = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
+                // this step is needed if new repo added while upgrade not done: it will NOT have legacy attributes
+                // as other reposes, that were present in old/upgraded instance
+                target.getParentFile().mkdirs();
+                FileUtils.fileWrite( target, MARKER_TEXT );
+            }
+        }
+        catch ( IOException e )
+        {
+            // hum?
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -1,0 +1,175 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import java.io.File;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
+import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
+import org.sonatype.nexus.util.FibonacciNumberSequence;
+
+public class UpgraderThread
+    extends Thread
+    implements WalkerThrottleController
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private final File legacyAttributesDirectory;
+
+    private final RepositoryRegistry repositoryRegistry;
+
+    private int actualUps;
+
+    private int limiterUps;
+
+    private FibonacciNumberSequence currentSleepTime;
+
+    private long lastAdjustment;
+
+    public UpgraderThread( final File legacyAttributesDirectory, final RepositoryRegistry repositoryRegistry,
+                           final int limiterUps )
+    {
+        this.legacyAttributesDirectory = legacyAttributesDirectory;
+        this.repositoryRegistry = repositoryRegistry;
+        this.limiterUps = limiterUps;
+        // start with sleep time of 100ms
+        this.currentSleepTime = new FibonacciNumberSequence( 100 );
+        this.lastAdjustment = 0;
+        // to have it clearly in thread dumps
+        setName( "LegacyAttributesUpgrader" );
+        // to not prevent sudden reboots (by user, if upgrading, and rebooting)
+        setDaemon( true );
+        // to not interfere much with other stuff (CPU wise)
+        setPriority( Thread.MIN_PRIORITY );
+    }
+
+    public int getActualUps()
+    {
+        return actualUps;
+    }
+
+    public int getLimiterUps()
+    {
+        return limiterUps;
+    }
+
+    public void setLimiterUps( int limiterUps )
+    {
+        this.limiterUps = limiterUps;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            Thread.sleep( 5000 );
+        }
+        catch ( InterruptedException e )
+        {
+            return;
+        }
+        this.lastAdjustment = System.currentTimeMillis();
+
+        if ( !DefaultAttributeUpgrader.isUpgradeDone( legacyAttributesDirectory, null ) )
+        {
+            List<Repository> reposes = repositoryRegistry.getRepositories();
+            for ( Repository repo : reposes )
+            {
+                if ( !repo.getRepositoryKind().isFacetAvailable( GroupRepository.class ) )
+                {
+                    if ( !DefaultAttributeUpgrader.isUpgradeDone( legacyAttributesDirectory, repo.getId() ) )
+                    {
+                        logger.info( "Upgrading legacy attributes of repository {}.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                        ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
+                        req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY, this );
+                        repo.recreateAttributes( req, null );
+                        DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, repo.getId() );
+                        logger.info( "Upgrade of legacy attributes of repository {} done.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                    }
+                    else
+                    {
+                        logger.info( "Skipping legacy attributes of repository {}, already marked as upgraded.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                    }
+                }
+            }
+            DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, null );
+            logger.info(
+                "Legacy attribute directory upgrade finished. Please delete, move or rename the \"{}\" folder.",
+                legacyAttributesDirectory.getAbsolutePath() );
+        }
+    }
+
+    // == WalkerThrottleController
+
+    @Override
+    public boolean isThrottled()
+    {
+        return limiterUps > 0;
+    }
+
+    @Override
+    public long throttleTime( final ThrottleInfo info )
+    {
+        if ( adjustmentNeeded() )
+        {
+            actualUps = (int) ( info.getTotalProcessItemInvocationCount() / ( info.getTotalTimeWalking() / 1000 ) );
+
+            if ( actualUps > limiterUps )
+            {
+                // hold down the horses, increase sleepTime
+                if ( currentSleepTime.peek() <= 0 )
+                {
+                    currentSleepTime.reset();
+                }
+                else
+                {
+                    currentSleepTime.next();
+                }
+            }
+            else
+            {
+                // lessen the sleep time
+                if ( currentSleepTime.peek() > 0 )
+                {
+                    currentSleepTime.prev();
+                }
+            }
+
+            logger.info( "Actual speed {} UPS (limited to {} UPS), current sleepTime {}ms.", new Object[] { actualUps,
+                limiterUps, currentSleepTime.peek() } );
+        }
+
+        return currentSleepTime.peek();
+    }
+
+    /**
+     * To prevent "oscillation" we do adjustments only once in 5 seconds (or override if needed).
+     * 
+     * @return
+     */
+    protected boolean adjustmentNeeded()
+    {
+        // adjust every 5 second for now
+        if ( ( System.currentTimeMillis() - lastAdjustment ) > 5000 )
+        {
+            this.lastAdjustment = System.currentTimeMillis();
+
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
@@ -1,0 +1,62 @@
+package org.sonatype.nexus.proxy.walker;
+
+import org.sonatype.nexus.proxy.walker.WalkerThrottleController.ThrottleInfo;
+
+/**
+ * A simple single-threaded ThrottleInfo used in Walker implementation.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public class DefaultThrottleInfo
+    implements ThrottleInfo
+{
+    private final long walkStarted;
+
+    private long totalProcessItemSpentMillis;
+
+    private long totalProcessItemInvocationCount;
+
+    private long lastProcessItemEnterTime;
+
+    public DefaultThrottleInfo()
+    {
+        this.walkStarted = now();
+        this.totalProcessItemSpentMillis = 0;
+        this.totalProcessItemInvocationCount = 0;
+    }
+
+    protected long now()
+    {
+        return System.currentTimeMillis();
+    }
+
+    public void enterProcessItem()
+    {
+        this.lastProcessItemEnterTime = now();
+    }
+
+    public void exitProcessItem()
+    {
+        totalProcessItemSpentMillis += now() - lastProcessItemEnterTime;
+        totalProcessItemInvocationCount++;
+    }
+
+    @Override
+    public long getTotalProcessItemSpentMillis()
+    {
+        return totalProcessItemSpentMillis;
+    }
+
+    @Override
+    public long getTotalProcessItemInvocationCount()
+    {
+        return totalProcessItemInvocationCount;
+    }
+
+    @Override
+    public long getTotalTimeWalking()
+    {
+        return now() - walkStarted;
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -303,6 +303,8 @@ public class DefaultWalker
     {
         try
         {
+            final long processItemEnter = System.currentTimeMillis();
+
             for ( WalkerProcessor processor : context.getProcessors() )
             {
                 if ( processor.isActive() )
@@ -313,6 +315,17 @@ public class DefaultWalker
                     {
                         break;
                     }
+                }
+            }
+
+            if ( !context.isStopped() && context.getThrottleController().isThrottled() )
+            {
+                final long throttleTime =
+                    context.getThrottleController().throttleTime( System.currentTimeMillis() - processItemEnter );
+
+                if ( throttleTime > 0 )
+                {
+                    Thread.sleep( throttleTime );
                 }
             }
         }

--- a/nexus/nexus-utils/pom.xml
+++ b/nexus/nexus-utils/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>junit-dep</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/FibonacciNumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/FibonacciNumberSequence.java
@@ -23,7 +23,9 @@ package org.sonatype.nexus.util;
 public class FibonacciNumberSequence
     implements NumberSequence
 {
-    private final long start;
+    private final long startA;
+
+    private final long startB;
 
     private long a;
 
@@ -36,20 +38,36 @@ public class FibonacciNumberSequence
 
     public FibonacciNumberSequence( long start )
     {
-        this.start = start;
+        this( start, start );
+    }
 
+    public FibonacciNumberSequence( long startA, long startB )
+    {
+        this.startA = startA;
+        this.startB = startB;
         reset();
     }
 
     public long next()
     {
         long res = a;
-        
+
         a = b;
 
         b = res + b;
 
         return res;
+    }
+
+    public long prev()
+    {
+        long tmp = b;
+
+        b = a;
+
+        a = tmp - b;
+
+        return a;
     }
 
     public long peek()
@@ -59,9 +77,8 @@ public class FibonacciNumberSequence
 
     public void reset()
     {
-        a = start;
-
-        b = start;
+        a = startA;
+        b = startB;
     }
 
 }

--- a/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
+++ b/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.util;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,6 +75,33 @@ public class NumberSequenceTest
         for ( int f : fibonacciNumbers )
         {
             Assert.assertEquals( f, fs.next() );
+        }
+    }
+
+    @Test
+    public void testFibonacciSequenceBackAndForth()
+    {
+        int[] fibonacciNumbers = new int[] { 10, 10, 20, 30, 50, 80, 130, 210, 340, 550, 890, 1440, 2330 };
+
+        FibonacciNumberSequence fs = new FibonacciNumberSequence( 10 );
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.next() );
+        }
+
+        fs.reset();
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.next() );
+        }
+
+        ArrayUtils.reverse( fibonacciNumbers );
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.prev() );
         }
     }
 }


### PR DESCRIPTION
Attribute upgrade from now on happens only on attribute STORE operation,
while attribute READ operation just _reads_ them (from new or falls back to old
storage).

Just for review, not for vote yet. This change alone would not be sufficient for sure, coz some tests expect the "old" behavior.
