### PR TITLE
Add JMX configuration to logback-nexus.xml

### DIFF
--- a/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
+++ b/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
@@ -14,7 +14,8 @@
 
 -->
 <included>
-
+  <jmxConfigurator/>
+  
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>${appender.pattern}</pattern>


### PR DESCRIPTION
Adds configuration to have logback install its mbeans by default.
