### PR TITLE
Attribute related fixes

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.walker;
 
 /**

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
@@ -1,0 +1,35 @@
+package org.sonatype.nexus.proxy.walker;
+
+/**
+ * Handy abstract class to create new throttle controllers. Just override method you need.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public abstract class AbstractWalkerThrottleController
+    implements WalkerThrottleController
+{
+    @Override
+    public void walkStarted( final WalkerContext context )
+    {
+        // nop
+    }
+
+    @Override
+    public void walkEnded( final WalkerContext context )
+    {
+        // nop
+    }
+
+    @Override
+    public boolean isThrottled()
+    {
+        return false;
+    }
+
+    @Override
+    public long throttleTime( final ThrottleInfo info )
+    {
+        return -1;
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AbstractWalkerThrottleController.java
@@ -16,7 +16,7 @@ public abstract class AbstractWalkerThrottleController
     }
 
     @Override
-    public void walkEnded( final WalkerContext context )
+    public void walkEnded( final WalkerContext context, final ThrottleInfo info )
     {
         // nop
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AdaptiveRenicingWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AdaptiveRenicingWalkerThrottleController.java
@@ -1,0 +1,49 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.walker;
+
+/**
+ * Adapting controller, also known as "Mike's controller". This controller is meant to detect speed changes (assumed by
+ * load on system), and it will react to those speed changes by lowering the throttle ("stepping aside", or lessening
+ * the load imposed by this walk), and giving more room to other processes.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public class AdaptiveRenicingWalkerThrottleController
+    extends AbstractWalkerThrottleController
+{
+    @Override
+    public void walkStarted( final WalkerContext context )
+    {
+        // nop
+    }
+
+    @Override
+    public void walkEnded( final WalkerContext context )
+    {
+        // nop
+    }
+
+    @Override
+    public boolean isThrottled()
+    {
+        return true;
+    }
+
+    @Override
+    public long throttleTime( final ThrottleInfo info )
+    {
+        return -1;
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AdaptiveRenicingWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/AdaptiveRenicingWalkerThrottleController.java
@@ -30,7 +30,7 @@ public class AdaptiveRenicingWalkerThrottleController
     }
 
     @Override
-    public void walkEnded( final WalkerContext context )
+    public void walkEnded( final WalkerContext context, final ThrottleInfo info )
     {
         // nop
     }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
@@ -33,6 +33,8 @@ public class DefaultWalkerContext
 
     private final ResourceStoreRequest request;
 
+    private final WalkerThrottleController throttleController;
+
     private Map<String, Object> context;
 
     private List<WalkerProcessor> processors;
@@ -65,18 +67,31 @@ public class DefaultWalkerContext
         this.collectionsOnly = collectionsOnly;
 
         this.running = true;
+
+        if ( request.getRequestContext().containsKey( WalkerThrottleController.CONTEXT_KEY, false ) )
+        {
+            this.throttleController =
+                (WalkerThrottleController) request.getRequestContext().get( WalkerThrottleController.CONTEXT_KEY, false );
+        }
+        else
+        {
+            this.throttleController = WalkerThrottleController.NO_THROTTLING;
+        }
     }
 
+    @Override
     public boolean isLocalOnly()
     {
         return request.isRequestLocalOnly();
     }
 
+    @Override
     public boolean isCollectionsOnly()
     {
         return collectionsOnly;
     }
 
+    @Override
     public Map<String, Object> getContext()
     {
         if ( context == null )
@@ -86,6 +101,7 @@ public class DefaultWalkerContext
         return context;
     }
 
+    @Override
     public List<WalkerProcessor> getProcessors()
     {
         if ( processors == null )
@@ -96,26 +112,31 @@ public class DefaultWalkerContext
         return processors;
     }
 
+    @Override
     public void setProcessors( List<WalkerProcessor> processors )
     {
         this.processors = processors;
     }
 
+    @Override
     public WalkerFilter getFilter()
     {
         return walkerFilter;
     }
 
+    @Override
     public Repository getRepository()
     {
         return resourceStore;
     }
 
+    @Override
     public ResourceStoreRequest getResourceStoreRequest()
     {
         return request;
     }
 
+    @Override
     public boolean isStopped()
     {
         try
@@ -135,11 +156,13 @@ public class DefaultWalkerContext
         return !running;
     }
 
+    @Override
     public Throwable getStopCause()
     {
         return stopCause;
     }
 
+    @Override
     public void stop( Throwable cause )
     {
         running = false;
@@ -147,4 +170,9 @@ public class DefaultWalkerContext
         stopCause = cause;
     }
 
+    @Override
+    public WalkerThrottleController getThrottleController()
+    {
+        return this.throttleController;
+    }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleController.java
@@ -1,0 +1,256 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.walker;
+
+import java.util.concurrent.TimeUnit;
+
+import org.sonatype.nexus.util.NumberSequence;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Fixed rate WalkerThrottleController ensures that a walk will not advance FASTER than the limit TPS set. Note: this
+ * controller is "dumb", if for any reason (ie. complex operations in processItem() method, system under load or simply
+ * slow hardware it runs on) the limit TPS is not even reached, this controller will NOT interfere (slow down the walk)
+ * but the application will still probably bashing the underlying OS/System resources or will fight with other threads
+ * for CPU!
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public class FixedRateWalkerThrottleController
+    extends AbstractWalkerThrottleController
+{
+    /**
+     * Callback interface to be used with this throttle controller.
+     * 
+     * @author cstamas
+     */
+    public static interface FixedRateWalkerThrottleControllerCallback
+    {
+        /**
+         * Invoked for ever "adjustment slice" after all the relevant values are updated.
+         * 
+         * @param controller
+         */
+        void onAdjustment( final FixedRateWalkerThrottleController controller );
+    }
+
+    /**
+     * The stepping source of sleep times. The choice of number sequence defines the "steepness" how speed adjustments
+     * are made.
+     */
+    private final NumberSequence currentSleepTime;
+
+    /**
+     * The callback, if any.
+     */
+    private final FixedRateWalkerThrottleControllerCallback callback;
+
+    /**
+     * The average TPS of overall run.
+     */
+    private int globalAverageTps;
+
+    /**
+     * The absolute maximum TPS achieved by walk from start, for statistical purposes (ie. to show off that your Nexus
+     * can do more than your colleague's one, same for company maintained forges). :D
+     */
+    private int globalMaximumTps;
+
+    /**
+     * The variable limit (ceiling) of TPS. How strictly this controller will enforce it, depends on other variables
+     * (ie. how much time will be spent in "overspeed" depends on adjustment frequency too and other).
+     */
+    private int limiterTps;
+
+    /**
+     * Internally maintained timestamp (in milliseconds) when last adjustment was made.
+     */
+    private long lastAdjustmentTimestamp;
+
+    /**
+     * Internally maintained slice size (in milliseconds), milliseconds betwen two subsequent adjustments.
+     */
+    private long lastAdjustmentSliceSize;
+
+    /**
+     * Internally maintained processItem invocation count when last adjustment was made.
+     */
+    private long lastAdjustmentProcessItemInvocationCount;
+
+    /**
+     * The TPS measured in last adjustment "slice".
+     */
+    private int lastAdjustmentTps;
+
+    /**
+     * How often (in milliseconds) should adjustment to throttling be made. To small value might cause unneded overhead
+     * and "oscillation", to big value might cause that throttling becomes not effective (ie. walk will spend too much
+     * time in "overspeed" before adjustment kicks in).
+     */
+    private long adjustmentFrequency;
+
+    /**
+     * Creates a new instance of fixed rate throttle controller with some defaults (adjustment slice size is 2 seconds).
+     * 
+     * @param limiterTps
+     * @param numberSequence
+     */
+    public FixedRateWalkerThrottleController( final int limiterTps, final NumberSequence numberSequence )
+    {
+        this( limiterTps, numberSequence, null );
+    }
+
+    /**
+     * Creates a new instance of fixed rate throttle controller with some defaults (adjustment slice size is 2 seconds).
+     * 
+     * @param limiterTps
+     * @param numberSequence
+     */
+    public FixedRateWalkerThrottleController( final int limiterTps, final NumberSequence numberSequence,
+                                              final FixedRateWalkerThrottleControllerCallback callback )
+    {
+        this.limiterTps = limiterTps;
+        this.currentSleepTime = numberSequence;
+        this.callback = callback;
+        this.adjustmentFrequency = TimeUnit.SECONDS.toMillis( 2 );
+    }
+
+    public int getGlobalAverageTps()
+    {
+        return globalAverageTps;
+    }
+
+    public int getGlobalMaximumTps()
+    {
+        return globalMaximumTps;
+    }
+
+    public int getLastAdjustmentTps()
+    {
+        return lastAdjustmentTps;
+    }
+
+    public long getCurrentSleepTime()
+    {
+        return currentSleepTime.peek();
+    }
+
+    public int getLimiterTps()
+    {
+        return limiterTps;
+    }
+
+    public void setLimiterTps( final int limiterTps )
+    {
+        this.limiterTps = limiterTps;
+    }
+
+    public long getAdjustmentFrequency()
+    {
+        return adjustmentFrequency;
+    }
+
+    public void setAdjustmentFrequency( final long adjustmentFrequency )
+    {
+        Preconditions.checkArgument( adjustmentFrequency > 0 );
+        this.adjustmentFrequency = adjustmentFrequency;
+    }
+
+    // == WalkerThrottleController iface
+    @Override
+    public void walkStarted( final WalkerContext context )
+    {
+        globalAverageTps = 0;
+        globalMaximumTps = 0;
+        lastAdjustmentTps = 0;
+        lastAdjustmentTimestamp = System.currentTimeMillis();
+        lastAdjustmentProcessItemInvocationCount = 0;
+    }
+
+    @Override
+    public void walkEnded( final WalkerContext context )
+    {
+        // nop
+    }
+
+    @Override
+    public boolean isThrottled()
+    {
+        return limiterTps > 0;
+    }
+
+    @Override
+    public long throttleTime( final ThrottleInfo info )
+    {
+        if ( adjustmentNeeded() )
+        {
+            // global average TPS since walk started
+            globalAverageTps =
+                (int) ( info.getTotalProcessItemInvocationCount() / ( info.getTotalTimeWalking() / 1000 ) );
+            // local TPS achieved in current "adjustment" slice
+            lastAdjustmentTps =
+                (int) ( ( info.getTotalProcessItemInvocationCount() - lastAdjustmentProcessItemInvocationCount ) / ( lastAdjustmentSliceSize / 1000 ) );
+            lastAdjustmentProcessItemInvocationCount = info.getTotalProcessItemInvocationCount();
+            // the maximum TPS since the walk started
+            globalMaximumTps = Math.max( lastAdjustmentTps, globalMaximumTps );
+
+            if ( lastAdjustmentTps > limiterTps )
+            {
+                // hold down the horses, increase sleepTime
+                if ( currentSleepTime.peek() <= 0 )
+                {
+                    currentSleepTime.reset();
+                }
+                else
+                {
+                    currentSleepTime.next();
+                }
+            }
+            else
+            {
+                // lessen the sleep time
+                if ( currentSleepTime.peek() > 0 )
+                {
+                    currentSleepTime.prev();
+                }
+            }
+
+            if ( callback != null )
+            {
+                callback.onAdjustment( this );
+            }
+        }
+
+        return currentSleepTime.peek();
+    }
+
+    // ==
+
+    protected boolean adjustmentNeeded( )
+    {
+        final long now = System.currentTimeMillis();
+        lastAdjustmentSliceSize = now - lastAdjustmentTimestamp;
+        // adjust every 5 second for now
+        if ( ( lastAdjustmentSliceSize ) > adjustmentFrequency )
+        {
+            this.lastAdjustmentTimestamp = now;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
@@ -101,4 +101,11 @@ public interface WalkerContext
      * @return
      */
     Repository getRepository();
+
+    /**
+     * Returns the "throttle control" of this context.
+     * 
+     * @return
+     */
+    WalkerThrottleController getThrottleController();
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerProcessor.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerProcessor.java
@@ -24,7 +24,7 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 public interface WalkerProcessor
 {
     boolean isActive();
-
+    
     void beforeWalk( WalkerContext context )
         throws Exception;
 

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -1,0 +1,53 @@
+package org.sonatype.nexus.proxy.walker;
+
+/**
+ * Interface to controle throttling (if desired) in executing of Walks.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public interface WalkerThrottleController
+{
+    /**
+     * Key used in RequestContext to pass it into Walker.
+     */
+    String CONTEXT_KEY = WalkerThrottleController.class.getName();
+
+    /**
+     * WalkerThrottleController that does not emply walk throttling.
+     */
+    WalkerThrottleController NO_THROTTLING = new WalkerThrottleController()
+    {
+        @Override
+        public boolean isThrottled()
+        {
+            return false;
+        }
+
+        @Override
+        public long throttleTime( long processItemSpentMillis )
+        {
+            return -1;
+        }
+    };
+
+    /**
+     * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean
+     * intentionally slowing down the "walk" by inserting some amount (see {@link #throttleTime(long)} method) of
+     * Thread.sleep() invocations.
+     * 
+     * @return
+     */
+    boolean isThrottled();
+
+    /**
+     * Returns the next desired sleep time this context wants to have applied. It might be in some relation to the time
+     * spent in processItem() methods of registered WalkerProcessors, but does not have to be.
+     * 
+     * @param processItemSpentMillis time in millis WalkerProcessors spent in their
+     *            {@link WalkerProcessor#processItem(WalkerContext, org.sonatype.nexus.proxy.item.StorageItem)} method.
+     * @return any value bigger than zero means "sleep as many millis to throttle". Any values less or equal to zero are
+     *         neglected (will not invoke sleep).
+     */
+    long throttleTime( long processItemSpentMillis );
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -26,21 +26,11 @@ public interface WalkerThrottleController
     String CONTEXT_KEY = WalkerThrottleController.class.getName();
 
     /**
-     * WalkerThrottleController that does not emply walk throttling.
+     * WalkerThrottleController that does not do walk throttling. Used when no user supplied throttle control found in
+     * walker context.
      */
-    WalkerThrottleController NO_THROTTLING = new WalkerThrottleController()
+    WalkerThrottleController NO_THROTTLING = new AbstractWalkerThrottleController()
     {
-        @Override
-        public boolean isThrottled()
-        {
-            return false;
-        }
-
-        @Override
-        public long throttleTime( final ThrottleInfo info )
-        {
-            return -1;
-        }
     };
 
     /**
@@ -72,6 +62,20 @@ public interface WalkerThrottleController
          */
         long getTotalTimeWalking();
     }
+
+    /**
+     * Invoked at walk start.
+     * 
+     * @param context
+     */
+    void walkStarted( WalkerContext context );
+
+    /**
+     * Invoked at walk end.
+     * 
+     * @param context
+     */
+    void walkEnded( WalkerContext context );
 
     /**
      * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -1,7 +1,19 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.walker;
 
 /**
- * Interface to controle throttling (if desired) in executing of Walks.
+ * Interface to control throttling (if desired) of Walk executed within context that this controller resides.
  * 
  * @author cstamas
  * @since 2.0
@@ -31,6 +43,11 @@ public interface WalkerThrottleController
         }
     };
 
+    /**
+     * Carries some "stats" about walk, that makes possible to perform some calculation about it's speed.
+     * 
+     * @author cstamas
+     */
     public interface ThrottleInfo
     {
         /**

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -74,8 +74,9 @@ public interface WalkerThrottleController
      * Invoked at walk end.
      * 
      * @param context
+     * @param info
      */
-    void walkEnded( WalkerContext context );
+    void walkEnded( WalkerContext context, ThrottleInfo info );
 
     /**
      * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerThrottleController.java
@@ -25,11 +25,36 @@ public interface WalkerThrottleController
         }
 
         @Override
-        public long throttleTime( long processItemSpentMillis )
+        public long throttleTime( final ThrottleInfo info )
         {
             return -1;
         }
     };
+
+    public interface ThrottleInfo
+    {
+        /**
+         * The total time spent in processItem() method. This time is "contained" in the {@link #getTotalTimeWalking()}.
+         * 
+         * @return
+         */
+        long getTotalProcessItemSpentMillis();
+
+        /**
+         * The total invocation count of processItem() method ("How many items were processed so far?").
+         * 
+         * @return
+         */
+        long getTotalProcessItemInvocationCount();
+
+        /**
+         * The total time (in milliseconds) since walking begun. The returned time always reflects the truly actual
+         * spent time in walking, counting time even spent with throttle calculations ("gross time" spent).
+         * 
+         * @return
+         */
+        long getTotalTimeWalking();
+    }
 
     /**
      * Returns true if the controllers wants to use "throttled walker" execution. Throttling in this case would mean
@@ -44,10 +69,9 @@ public interface WalkerThrottleController
      * Returns the next desired sleep time this context wants to have applied. It might be in some relation to the time
      * spent in processItem() methods of registered WalkerProcessors, but does not have to be.
      * 
-     * @param processItemSpentMillis time in millis WalkerProcessors spent in their
-     *            {@link WalkerProcessor#processItem(WalkerContext, org.sonatype.nexus.proxy.item.StorageItem)} method.
+     * @param info The info object holding some (probably) used informations to calculate next desired sleep time.
      * @return any value bigger than zero means "sleep as many millis to throttle". Any values less or equal to zero are
      *         neglected (will not invoke sleep).
      */
-    long throttleTime( long processItemSpentMillis );
+    long throttleTime( ThrottleInfo info );
 }

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.walker;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
@@ -1,0 +1,140 @@
+package org.sonatype.nexus.proxy.walker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonatype.nexus.proxy.walker.WalkerThrottleController.ThrottleInfo;
+import org.sonatype.nexus.util.ConstantNumberSequence;
+import org.sonatype.nexus.util.FibonacciNumberSequence;
+import org.sonatype.nexus.util.NumberSequence;
+
+/**
+ * Test for fixed rate walker throttle controller.
+ * 
+ * @author cstamas
+ */
+public class FixedRateWalkerThrottleControllerTest
+{
+    protected FixedRateWalkerThrottleController fixedRateWalkerThrottleController;
+
+    @Test
+    public void testDoesItHelpAtAll()
+    {
+        // set unrealistic TPS and we do "almost nothing" (1 nano) in processItem method
+        final int measuredTpsUnreal = performAndMeasureActualTps( 100000000, new ConstantNumberSequence( 1 ) );
+        // set 500 TPS and we do "little" (1 nano) in processItem method
+        final int measuredTps500 = performAndMeasureActualTps( 500, new ConstantNumberSequence( 1 ) );
+        // set 200 TPS and we do "little" (1 nano) in processItem method
+        final int measuredTps200 = performAndMeasureActualTps( 200, new ConstantNumberSequence( 1 ) );
+
+        assertThat( "TPS500 should less than Unreal one", measuredTps500, lessThan( measuredTpsUnreal ) );
+        assertThat( "TPS200 should less than TPS500 one", measuredTps200, lessThan( measuredTps500 ) );
+    }
+
+    // ==
+
+    protected int performAndMeasureActualTps( final int wantedTps, final NumberSequence loadChange )
+    {
+        fixedRateWalkerThrottleController =
+            new FixedRateWalkerThrottleController( wantedTps, new FibonacciNumberSequence( 1 ) );
+        fixedRateWalkerThrottleController.setSliceSize( 1 );
+
+        final TestThrottleInfo info = new TestThrottleInfo();
+
+        final WalkerContext context = Mockito.mock( WalkerContext.class );
+
+        final int iterationCount = 10000;
+
+        final long startTime = System.currentTimeMillis();
+        fixedRateWalkerThrottleController.walkStarted( context );
+        for ( int i = 0; i < iterationCount; i++ )
+        {
+            info.simulateInvocation( loadChange.next() );
+            long sleepTime = fixedRateWalkerThrottleController.throttleTime( info );
+            sleep( sleepTime ); // sleep as much as throttle controller says to sleep
+        }
+        fixedRateWalkerThrottleController.walkEnded( context, info );
+
+        final int measuredTps =
+            fixedRateWalkerThrottleController.calculateCPS( iterationCount, System.currentTimeMillis() - startTime );
+
+        System.out.println( "Measured=" + measuredTps );
+        System.out.println( "GlobalAvg=" + fixedRateWalkerThrottleController.getGlobalAverageTps() );
+        System.out.println( "GlobalMax=" + fixedRateWalkerThrottleController.getGlobalMaximumTps() );
+
+        return measuredTps;
+    }
+
+    // ==
+
+    protected static void sleep( long millis )
+    {
+        try
+        {
+            Thread.sleep( millis );
+        }
+        catch ( InterruptedException e )
+        {
+            // need to kill test too
+            throw new RuntimeException( e );
+        }
+    }
+
+    protected static void sleepNanos( long nanos )
+    {
+        try
+        {
+            Thread.sleep( 0, (int) nanos );
+        }
+        catch ( InterruptedException e )
+        {
+            // need to kill test too
+            throw new RuntimeException( e );
+        }
+    }
+
+    protected static class TestThrottleInfo
+        implements ThrottleInfo
+    {
+        private final long started;
+
+        private long totalProcessItemSpentMillis;
+
+        private long totalProcessItemInvocationCount;
+
+        public TestThrottleInfo()
+        {
+            this.started = System.currentTimeMillis();
+            this.totalProcessItemSpentMillis = 0;
+            this.totalProcessItemInvocationCount = 0;
+        }
+
+        public void simulateInvocation( final long spentTimeInProcessItem )
+        {
+            // we need to sleep to keep getTotalTimeWalking() and totalProcessItemSpentMillis aligned
+            sleepNanos( spentTimeInProcessItem );
+            totalProcessItemSpentMillis = totalProcessItemSpentMillis + ( spentTimeInProcessItem * 1000 );
+            totalProcessItemInvocationCount++;
+        }
+
+        @Override
+        public long getTotalProcessItemSpentMillis()
+        {
+            return totalProcessItemSpentMillis;
+        }
+
+        @Override
+        public long getTotalProcessItemInvocationCount()
+        {
+            return totalProcessItemInvocationCount;
+        }
+
+        @Override
+        public long getTotalTimeWalking()
+        {
+            return System.currentTimeMillis() - started;
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/TransitioningAttributeStorage.java
@@ -31,6 +31,11 @@ import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
 public class TransitioningAttributeStorage
     implements AttributeStorage
 {
+    /**
+     * All attributes "leaving" fallback storage are marked (by presence) of this key.
+     */
+    public static final String FALLBACK_MARKER_KEY = LegacyFSAttributeStorage.class.getName();
+
     private final AttributeStorage mainAttributeStorage;
 
     private final AttributeStorage fallbackAttributeStorage;
@@ -58,6 +63,11 @@ public class TransitioningAttributeStorage
             if ( result == null && fallbackAttributeStorage != null )
             {
                 result = fallbackAttributeStorage.getAttributes( uid );
+                if ( result != null )
+                {
+                    // mark it as legacy
+                    result.put( FALLBACK_MARKER_KEY, Boolean.TRUE.toString() );
+                }
             }
 
             return result;
@@ -78,6 +88,12 @@ public class TransitioningAttributeStorage
 
         try
         {
+            if ( fallbackAttributeStorage != null )
+            {
+                // shave the legacy marker if any
+                item.remove( FALLBACK_MARKER_KEY );
+            }
+
             mainAttributeStorage.putAttributes( uid, item );
 
             if ( fallbackAttributeStorage != null )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+public interface AttributeUpgrader
+{
+    boolean isLegacyAttributesDirectoryPresent();
+
+    boolean isUpgradeNeeded();
+
+    boolean isUpgradeRunning();
+    
+    boolean isUpgradeFinished();
+
+    int getCurrentUps();
+
+    int getLimiterUps();
+
+    void setLimiterUps( int limit );
+
+    void upgrade();
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgrader.java
@@ -1,20 +1,81 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
+/**
+ * Component responsible for "upgrading" of the legacy attributes to new attributes on upgraded systems.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
 public interface AttributeUpgrader
 {
+    /**
+     * Returns true if folder holding legacy attributes is present.
+     * 
+     * @return
+     */
     boolean isLegacyAttributesDirectoryPresent();
 
+    /**
+     * Returns true if {@link #isLegacyAttributesDirectoryPresent()} returns true, and those folders are not marked as
+     * "done".
+     * 
+     * @return
+     */
     boolean isUpgradeNeeded();
 
+    /**
+     * Returns true if the UpgraderThread is started, and is alive.
+     * 
+     * @return
+     */
     boolean isUpgradeRunning();
-    
+
+    /**
+     * Returns true if {@link #isUpgradeRunning()} returns false, and {@link #isLegacyAttributesDirectoryPresent()}
+     * returns true, and those folders are marked as "done".
+     * 
+     * @return
+     */
     boolean isUpgradeFinished();
 
+    /**
+     * Returns the UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it
+     * returns -1.
+     * 
+     * @return
+     */
     int getCurrentUps();
 
+    /**
+     * Returns the max UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it
+     * returns -1.
+     * 
+     * @return
+     */
     int getLimiterUps();
 
+    /**
+     * Sets the max UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it is
+     * neglected.
+     * 
+     * @return
+     */
     void setLimiterUps( int limit );
 
+    /**
+     * Starts the upgrade thread if needed.
+     */
     void upgrade();
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderMBean.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderMBean.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
 /**

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderMBean.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderMBean.java
@@ -1,29 +1,17 @@
-/**
- * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2007-2012 Sonatype, Inc.
- * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
- *
- * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
- * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
- *
- * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
- * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
- * Eclipse Foundation. All other trademarks are the property of their respective owners.
- */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
 /**
- * Component responsible for "upgrading" of the legacy attributes to new attributes on upgraded systems.
+ * JMX interface for managing and monitoring Attribute Upgrade.
  * 
  * @author cstamas
  * @since 2.0
  */
-public interface AttributeUpgrader
+public interface AttributeUpgraderMBean
 {
     /**
      * Returns true if folder holding legacy attributes is present.
      * 
-     * @return
+     * @return {@code true} if legacy attributes directory is present in Nexus workdir.
      */
     boolean isLegacyAttributesDirectoryPresent();
 
@@ -31,22 +19,24 @@ public interface AttributeUpgrader
      * Returns true if {@link #isLegacyAttributesDirectoryPresent()} returns true, and those folders are not marked as
      * "done".
      * 
-     * @return
+     * @return {@code true} if {@link #isLegacyAttributesDirectoryPresent()} returns true, and those folders are not
+     *         marked as "done".
      */
     boolean isUpgradeNeeded();
 
     /**
      * Returns true if the UpgraderThread is started, and is alive.
      * 
-     * @return
+     * @return {@code true} if the UpgraderThread is started, and is alive, hence, upgrade is underway.
      */
     boolean isUpgradeRunning();
 
     /**
-     * Returns true if {@link #isUpgradeRunning()} returns false, and {@link #isLegacyAttributesDirectoryPresent()}
-     * returns true, and those folders are marked as "done".
+     * Returns true if {@link #isUpgradeRunning()} returns false, and {@link #isUpgradeNeeded()()} returns {@code false}
+     * .
      * 
-     * @return
+     * @return {@code true} if {@link #isUpgradeRunning()} returns false, and {@link #isUpgradeNeeded()()} returns
+     *         {@code false}
      */
     boolean isUpgradeFinished();
 
@@ -54,7 +44,7 @@ public interface AttributeUpgrader
      * Returns the UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it
      * returns -1.
      * 
-     * @return
+     * @return if upgrade is underway, the current amount of performed upgrade operations per second, -1 otherwise.
      */
     int getCurrentUps();
 
@@ -69,7 +59,8 @@ public interface AttributeUpgrader
      * Returns the max UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it
      * returns the value of parameter (ie. "this would be it if it would running").
      * 
-     * @return
+     * @return the max UPS of currently executing upgrade (if {@link #isUpgradeRunning()} returns true). Otherwise, it
+     *         returns the value of parameter (ie. "this would be it if it would running").
      */
     int getLimiterUps();
 
@@ -81,13 +72,8 @@ public interface AttributeUpgrader
 
     /**
      * Starts the attributes upgrade if needed (will perform the needed checks and might not start it if decided as not
-     * needed). Calls into {@link #upgradeAttributes(false)}.
+     * needed).
      */
     void upgradeAttributes();
 
-    /**
-     * Starts the attributes upgrade if needed, but overrides user set preferences (will perform the needed checks and
-     * might not start it if decided as not needed).
-     */
-    void upgradeAttributes( boolean force );
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderThread.java
@@ -52,7 +52,7 @@ public class AttributeUpgraderThread
         this.repositoryRegistry = repositoryRegistry;
         // set throttle controller
         this.throttleController =
-            new FixedRateWalkerThrottleController( limiterTps, new FibonacciNumberSequence( 5 ), this );
+            new FixedRateWalkerThrottleController( limiterTps, new FibonacciNumberSequence( 0, 5 ), this );
         // to have it clearly in thread dumps
         setName( "LegacyAttributesUpgrader" );
         // to not prevent sudden reboots (by user, if upgrading, and rebooting)

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributeUpgraderThread.java
@@ -33,6 +33,12 @@ import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
 import org.sonatype.nexus.proxy.walker.FixedRateWalkerThrottleController.FixedRateWalkerThrottleControllerCallback;
 import org.sonatype.nexus.util.FibonacciNumberSequence;
 
+/**
+ * The background thread doing the actual attribute upgrades (moving them from legacy to LS attribute storage).
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
 public class AttributeUpgraderThread
     extends Thread
     implements FixedRateWalkerThrottleControllerCallback

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
@@ -12,34 +12,16 @@
  */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
-import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
 import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
-import org.sonatype.nexus.proxy.item.RepositoryItemUid;
-import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
-import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
-import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
-import org.sonatype.nexus.util.SystemPropertiesHelper;
 import org.sonatype.plexus.appevents.Event;
 
 /**
- * EventInspector that handles upgrade of "legacy attribute storage". It does it by detecting it's presence, and firing
- * the rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did
- * happen, to not kick in on any subsequent reboot.
+ * EventInspector that fires upgrade call to upgrader component, does it blindly.
  * 
  * @since 1.10.0
  */
@@ -48,23 +30,8 @@ public class AttributesUpgradeEventInspector
     extends AbstractEventInspector
     implements EventInspector, AsynchronousEventInspector
 {
-    /**
-     * The "switch" for performing upgrade (by bg thread), default is true (upgrade will happen).
-     */
-    private final boolean UPGRADE = SystemPropertiesHelper.getBoolean( getClass().getName() + ".upgrade", true );
-
-    /**
-     * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
-     * Default is to NOT use throttling.
-     */
-    private final long UPGRADE_THROTTLE_MILLIS = SystemPropertiesHelper.getLong( getClass().getName()
-        + ".throttleMillis", -1 );
-
     @Requirement
-    private ApplicationConfiguration applicationConfiguration;
-
-    @Requirement
-    private RepositoryRegistry repositoryRegistry;
+    private AttributeUpgrader attributeUpgrader;
 
     @Override
     public boolean accepts( Event<?> evt )
@@ -75,169 +42,9 @@ public class AttributesUpgradeEventInspector
     @Override
     public void inspect( Event<?> evt )
     {
-        final File legacyAttributesDirectory = applicationConfiguration.getWorkingDirectory( "proxy/attributes", false );
-
-        if ( !legacyAttributesDirectory.isDirectory() )
+        if ( accepts( evt ) )
         {
-            // file not found or not a directory, stay put to not create noise in logs (new or tidied up nexus
-            // instance)
-        }
-        else
-        {
-            if ( isUpgradeDone( legacyAttributesDirectory, null ) )
-            {
-                // nag the user to remove the directory
-                getLogger().info(
-                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
-                        + legacyAttributesDirectory.getAbsolutePath() + "\" folder." );
-            }
-            else
-            {
-                if ( UPGRADE )
-                {
-                    new UpgraderThread( legacyAttributesDirectory, repositoryRegistry, UPGRADE_THROTTLE_MILLIS ).start();
-                }
-                else
-                {
-                    getLogger().info(
-                        "Legacy attribute directory present, but upgrade prevented by system property. Not upgrading it." );
-                }
-            }
-        }
-    }
-
-    // ==
-
-    private static final String MARKER_FILENAME = "README.txt";
-
-    private static final String MARKER_TEXT =
-        "Migration of legacy attributes finished.\nPlease delete, remove or rename this directory!";
-
-    protected static boolean isUpgradeDone( final File attributesDirectory, final String repoId )
-    {
-        try
-        {
-            if ( StringUtils.isBlank( repoId ) )
-            {
-                return StringUtils.equals( MARKER_TEXT,
-                    FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
-            }
-            else
-            {
-                return StringUtils.equals( MARKER_TEXT,
-                    FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
-            }
-        }
-        catch ( IOException e )
-        {
-            return false;
-        }
-    }
-
-    protected static void markUpgradeDone( final File attributesDirectory, final String repoId )
-    {
-        try
-        {
-            if ( StringUtils.isBlank( repoId ) )
-            {
-                FileUtils.fileWrite( new File( attributesDirectory, MARKER_FILENAME ), MARKER_TEXT );
-            }
-            else
-            {
-                final File target = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
-                // this step is needed if new repo added while upgrade not done: it will NOT have legacy attributes
-                // as other reposes, that were present in old/upgraded instance
-                target.getParentFile().mkdirs();
-                FileUtils.fileWrite( target, MARKER_TEXT );
-            }
-        }
-        catch ( IOException e )
-        {
-            // hum?
-        }
-    }
-
-    // ==
-
-    protected static class UpgraderThread
-        extends Thread
-    {
-        private Logger logger = LoggerFactory.getLogger( getClass() );
-
-        private final File legacyAttributesDirectory;
-
-        private final RepositoryRegistry repositoryRegistry;
-
-        private final long throttleMillis;
-
-        public UpgraderThread( final File legacyAttributesDirectory, final RepositoryRegistry repositoryRegistry,
-                               long throttleMillis )
-        {
-            this.legacyAttributesDirectory = legacyAttributesDirectory;
-            this.repositoryRegistry = repositoryRegistry;
-            this.throttleMillis = throttleMillis;
-            // to have it clearly in thread dumps
-            setName( "LegacyAttributesUpgrader" );
-            // to not prevent sudden reboots (by user, if upgrading, and rebooting)
-            setDaemon( true );
-            // to not interfere much with other stuff
-            setPriority( Thread.MIN_PRIORITY );
-        }
-
-        @Override
-        public void run()
-        {
-            if ( !isUpgradeDone( legacyAttributesDirectory, null ) )
-            {
-                logger.info( "Legacy attribute directory present, and upgrade needed. Upgrading it in background thread." );
-                if ( throttleMillis > 0 )
-                {
-                    logger.info(
-                        "Legacy attribute upgrade is throttled by {} millis (system property override present).",
-                        throttleMillis );
-                }
-                List<Repository> reposes = repositoryRegistry.getRepositories();
-                for ( Repository repo : reposes )
-                {
-                    if ( !isUpgradeDone( legacyAttributesDirectory, repo.getId() ) )
-                    {
-                        logger.info( "Upgrading legacy attributes of repository {}.",
-                            RepositoryStringUtils.getHumanizedNameString( repo ) );
-                        ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
-                        if ( throttleMillis > 0 )
-                        {
-                            req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY,
-                                new WalkerThrottleController()
-                                {
-                                    @Override
-                                    public boolean isThrottled()
-                                    {
-                                        return true;
-                                    }
-
-                                    @Override
-                                    public long throttleTime( long processItemSpentMillis )
-                                    {
-                                        if ( processItemSpentMillis < throttleMillis )
-                                        {
-                                            return throttleMillis;
-                                        }
-                                        else
-                                        {
-                                            return -1;
-                                        }
-                                    }
-                                } );
-                        }
-                        repo.recreateAttributes( req, null );
-                        markUpgradeDone( legacyAttributesDirectory, repo.getId() );
-                    }
-                }
-                markUpgradeDone( legacyAttributesDirectory, null );
-                logger.info(
-                    "Legacy attribute directory upgrade finished. Please delete, move or rename the \"{}\" folder.",
-                    legacyAttributesDirectory.getAbsolutePath() );
-            }
+            attributeUpgrader.upgrade();
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/AttributesUpgradeEventInspector.java
@@ -44,7 +44,7 @@ public class AttributesUpgradeEventInspector
     {
         if ( accepts( evt ) )
         {
-            attributeUpgrader.upgrade();
+            attributeUpgrader.upgradeAttributes();
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -1,0 +1,204 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.util.SystemPropertiesHelper;
+
+/**
+ * Component that handles upgrade of "legacy attribute storage". It does it by detecting it's presence, and firing the
+ * rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did happen,
+ * to not kick in on any subsequent reboot.
+ * 
+ * @since 1.10.0
+ */
+@Component( role = AttributeUpgrader.class )
+public class DefaultAttributeUpgrader
+    extends AbstractLoggingComponent
+    implements AttributeUpgrader
+{
+    /**
+     * The "switch" for performing upgrade (by bg thread), default is true (upgrade will happen).
+     */
+    private final boolean UPGRADE = SystemPropertiesHelper.getBoolean( getClass().getName() + ".upgrade", true );
+
+    /**
+     * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
+     * Default is to 100 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
+     * Central repository is currently 300k of artifacts, this would mean in "nexus world" 6x300k items (pom, jar,
+     * maven-metadata and sha1/md5 hashes for those) if all of Central would be proxied by Nexus, which is not
+     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 100 UPS
+     * would take exactly 2.5 hour to upgrade it. Note: this is only the value used for unnattended upgrade! This is the
+     * starting value, that is still possible to "tune" (increase, decrease) over JMX!
+     */
+    private final int UPGRADE_THROTTLE_UPS = SystemPropertiesHelper.getInteger( getClass().getName() + ".throttleUps",
+        50 );
+
+    @Requirement
+    private ApplicationConfiguration applicationConfiguration;
+
+    @Requirement
+    private RepositoryRegistry repositoryRegistry;
+
+    private volatile UpgraderThread upgraderThread;
+
+    protected File getLegacyAttributesDirectory()
+    {
+        return applicationConfiguration.getWorkingDirectory( "proxy/attributes", false );
+    }
+
+    @Override
+    public boolean isLegacyAttributesDirectoryPresent()
+    {
+        return getLegacyAttributesDirectory().isDirectory();
+    }
+
+    @Override
+    public boolean isUpgradeNeeded()
+    {
+        return isLegacyAttributesDirectoryPresent() && !isUpgradeFinished();
+    }
+
+    @Override
+    public boolean isUpgradeRunning()
+    {
+        return upgraderThread != null && upgraderThread.isAlive();
+    }
+
+    @Override
+    public boolean isUpgradeFinished()
+    {
+        return isUpgradeDone( getLegacyAttributesDirectory(), null );
+    }
+
+    @Override
+    public int getCurrentUps()
+    {
+        if ( isUpgradeRunning() )
+        {
+            return upgraderThread.getActualUps();
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
+    @Override
+    public int getLimiterUps()
+    {
+        if ( isUpgradeRunning() )
+        {
+            return upgraderThread.getLimiterUps();
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
+    @Override
+    public void setLimiterUps( int limit )
+    {
+        if ( isUpgradeRunning() )
+        {
+            upgraderThread.setLimiterUps( limit );
+        }
+    }
+
+    @Override
+    public synchronized void upgrade()
+    {
+        if ( !isLegacyAttributesDirectoryPresent() )
+        {
+            // file not found or not a directory, stay put to not create noise in logs (new or tidied up nexus
+            // instance)
+            getLogger().debug( "Legacy attribute directory not present, no need for attribute upgrade." );
+        }
+        else
+        {
+            if ( isUpgradeDone( getLegacyAttributesDirectory(), null ) )
+            {
+                // nag the user to remove the directory
+                getLogger().info(
+                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
+                        + getLegacyAttributesDirectory().getAbsolutePath() + "\" folder." );
+            }
+            else
+            {
+                if ( UPGRADE )
+                {
+                    getLogger().info(
+                        "Legacy attribute directory present, and upgrade is needed. Starting background upgrade." );
+                    this.upgraderThread =
+                        new UpgraderThread( getLegacyAttributesDirectory(), repositoryRegistry, UPGRADE_THROTTLE_UPS );
+                    this.upgraderThread.start();
+                }
+                else
+                {
+                    // nag the user about explicit no-upgrade switch
+                    getLogger().info(
+                        "Legacy attribute directory present, but upgrade prevented by system property. Not upgrading it." );
+                }
+            }
+        }
+    }
+
+    // ==
+
+    private static final String MARKER_FILENAME = "README.txt";
+
+    private static final String MARKER_TEXT =
+        "Migration of legacy attributes finished.\nPlease delete, remove or rename this directory!";
+
+    protected static boolean isUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
+            }
+            else
+            {
+                return StringUtils.equals( MARKER_TEXT,
+                    FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
+            }
+        }
+        catch ( IOException e )
+        {
+            return false;
+        }
+    }
+
+    protected static void markUpgradeDone( final File attributesDirectory, final String repoId )
+    {
+        try
+        {
+            if ( StringUtils.isBlank( repoId ) )
+            {
+                FileUtils.fileWrite( new File( attributesDirectory, MARKER_FILENAME ), MARKER_TEXT );
+            }
+            else
+            {
+                final File target = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
+                // this step is needed if new repo added while upgrade not done: it will NOT have legacy attributes
+                // as other reposes, that were present in old/upgraded instance
+                target.getParentFile().mkdirs();
+                FileUtils.fileWrite( target, MARKER_TEXT );
+            }
+        }
+        catch ( IOException e )
+        {
+            // hum?
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
 import java.io.File;
@@ -128,8 +140,8 @@ public class DefaultAttributeUpgrader
             {
                 // nag the user to remove the directory
                 getLogger().info(
-                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \""
-                        + getLegacyAttributesDirectory().getAbsolutePath() + "\" folder." );
+                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \"{}\" folder.",
+                    getLegacyAttributesDirectory().getAbsolutePath() );
             }
             else
             {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -43,15 +43,15 @@ public class DefaultAttributeUpgrader
 
     /**
      * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
-     * Default is to 100 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
+     * Default is to 200 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
      * Central repository is currently 300k of artifacts, this would mean in "nexus world" 6x300k items (pom, jar,
      * maven-metadata and sha1/md5 hashes for those) if all of Central would be proxied by Nexus, which is not
-     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 100 UPS
-     * would take exactly 2.5 hour to upgrade it. Note: this is only the value used for unnattended upgrade! This is the
+     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 200 UPS
+     * would take exactly 1.25 hour to upgrade it. Note: this is only the value used for unattended upgrade! This is the
      * starting value, that is still possible to "tune" (increase, decrease) over JMX!
      */
     private final int UPGRADE_THROTTLE_UPS = SystemPropertiesHelper.getInteger( getClass().getName() + ".throttleUps",
-        50 );
+        200 );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -49,17 +49,17 @@ public class DefaultAttributeUpgrader
 
     /**
      * The "switch" to enable "upgrade throttling" if needed (is critical to lessen IO bound problem with attributes).
-     * Default is to 200 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
+     * Default is to 100 UPS to for use throttling. The "measure" is "UPS": item Upgrades Per Second. Reasoning is:
      * Central repository is currently 300k of artifacts, this would mean in "nexus world" 6x300k items (pom, jar,
      * maven-metadata and sha1/md5 hashes for those) if all of Central would be proxied by Nexus, which is not
-     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 200 UPS
-     * would take exactly 1.25 hour to upgrade it. Note: this is only the value used for unattended upgrade! This is
-     * only the initial value, that is still possible to "tune" (increase, decrease) over JMX! Possible values: -1 means
-     * no throttling, will bash up to the Hardware limits, any other positive integer would mean a limit of UPS to not
+     * plausible, so assume 50% of Central is present in cache (still is OVER-estimation!). Crawling 900k at 100 UPS
+     * would take exactly 2.5 hour to upgrade it. Note: this is only the value used for unattended upgrade! This is only
+     * the initial value, that is still possible to "tune" (increase, decrease) over JMX! Possible values: -1 means no
+     * throttling, will bash up to the Hardware limits, any other positive integer would mean a limit of UPS to not
      * reach over.
      */
     private final int UPGRADE_THROTTLE_UPS = SystemPropertiesHelper.getInteger( getClass().getName() + ".throttleUps",
-        200 );
+        100 );
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -33,7 +33,7 @@ import org.sonatype.nexus.util.SystemPropertiesHelper;
  * rebuild attributes background task if needed. Finally, it leaves "marker" file to mark the fact upgrade did happen,
  * to not kick in on any subsequent reboot.
  * 
- * @since 1.10.0
+ * @since 2.0
  */
 @Component( role = AttributeUpgrader.class )
 public class DefaultAttributeUpgrader
@@ -222,7 +222,7 @@ public class DefaultAttributeUpgrader
             {
                 // nag the user to remove the directory
                 getLogger().info(
-                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \"{}\" folder.",
+                    "Legacy attribute directory present, but is marked already as upgraded. Please delete, move or rename the \"{}\" directory.",
                     getLegacyAttributesDirectory().getAbsolutePath() );
             }
             else

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -71,7 +71,7 @@ public class DefaultAttributeUpgrader
 
     private int upgradeThrottleUps;
 
-    private volatile UpgraderThread upgraderThread;
+    private volatile AttributeUpgraderThread upgraderThread;
 
     public DefaultAttributeUpgrader()
     {
@@ -230,7 +230,7 @@ public class DefaultAttributeUpgrader
                             "Legacy attribute directory present, and upgrade is needed. Starting background upgrade." );
                     }
                     this.upgraderThread =
-                        new UpgraderThread( getLegacyAttributesDirectory(), repositoryRegistry, upgradeThrottleUps );
+                        new AttributeUpgraderThread( getLegacyAttributesDirectory(), repositoryRegistry, upgradeThrottleUps );
                     this.upgraderThread.start();
                 }
                 else

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
@@ -14,6 +14,12 @@ package org.sonatype.nexus.proxy.attributes.upgrade;
 
 import javax.management.StandardMBean;
 
+/**
+ * Simple exposure of AttributeUpgrader to JMX.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
 public class DefaultAttributeUpgraderMBean
     extends StandardMBean
     implements AttributeUpgraderMBean

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
 import javax.management.StandardMBean;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgraderMBean.java
@@ -1,0 +1,70 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import javax.management.StandardMBean;
+
+public class DefaultAttributeUpgraderMBean
+    extends StandardMBean
+    implements AttributeUpgraderMBean
+{
+    private final AttributeUpgrader attributeUpgrader;
+
+    protected DefaultAttributeUpgraderMBean( final AttributeUpgrader attributeUpgrader )
+    {
+        super( AttributeUpgraderMBean.class, false );
+        this.attributeUpgrader = attributeUpgrader;
+    }
+
+    @Override
+    public boolean isLegacyAttributesDirectoryPresent()
+    {
+        return attributeUpgrader.isLegacyAttributesDirectoryPresent();
+    }
+
+    @Override
+    public boolean isUpgradeNeeded()
+    {
+        return attributeUpgrader.isUpgradeNeeded();
+    }
+
+    @Override
+    public boolean isUpgradeRunning()
+    {
+        return attributeUpgrader.isUpgradeRunning();
+    }
+
+    @Override
+    public boolean isUpgradeFinished()
+    {
+        return attributeUpgrader.isUpgradeFinished();
+    }
+
+    @Override
+    public int getCurrentUps()
+    {
+        return attributeUpgrader.getCurrentUps();
+    }
+
+    @Override
+    public int getMaximumUps()
+    {
+        return attributeUpgrader.getMaximumUps();
+    }
+
+    @Override
+    public int getLimiterUps()
+    {
+        return attributeUpgrader.getLimiterUps();
+    }
+
+    @Override
+    public void setLimiterUps( int limit )
+    {
+        attributeUpgrader.setLimiterUps( limit );
+    }
+
+    @Override
+    public void upgradeAttributes()
+    {
+        attributeUpgrader.upgradeAttributes( true );
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -1,0 +1,175 @@
+package org.sonatype.nexus.proxy.attributes.upgrade;
+
+import java.io.File;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
+import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
+import org.sonatype.nexus.util.FibonacciNumberSequence;
+
+public class UpgraderThread
+    extends Thread
+    implements WalkerThrottleController
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private final File legacyAttributesDirectory;
+
+    private final RepositoryRegistry repositoryRegistry;
+
+    private int actualUps;
+
+    private int limiterUps;
+
+    private FibonacciNumberSequence currentSleepTime;
+
+    private long lastAdjustment;
+
+    public UpgraderThread( final File legacyAttributesDirectory, final RepositoryRegistry repositoryRegistry,
+                           final int limiterUps )
+    {
+        this.legacyAttributesDirectory = legacyAttributesDirectory;
+        this.repositoryRegistry = repositoryRegistry;
+        this.limiterUps = limiterUps;
+        // start with sleep time of 100ms
+        this.currentSleepTime = new FibonacciNumberSequence( 100 );
+        this.lastAdjustment = 0;
+        // to have it clearly in thread dumps
+        setName( "LegacyAttributesUpgrader" );
+        // to not prevent sudden reboots (by user, if upgrading, and rebooting)
+        setDaemon( true );
+        // to not interfere much with other stuff (CPU wise)
+        setPriority( Thread.MIN_PRIORITY );
+    }
+
+    public int getActualUps()
+    {
+        return actualUps;
+    }
+
+    public int getLimiterUps()
+    {
+        return limiterUps;
+    }
+
+    public void setLimiterUps( int limiterUps )
+    {
+        this.limiterUps = limiterUps;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            Thread.sleep( 5000 );
+        }
+        catch ( InterruptedException e )
+        {
+            return;
+        }
+        this.lastAdjustment = System.currentTimeMillis();
+
+        if ( !DefaultAttributeUpgrader.isUpgradeDone( legacyAttributesDirectory, null ) )
+        {
+            List<Repository> reposes = repositoryRegistry.getRepositories();
+            for ( Repository repo : reposes )
+            {
+                if ( !repo.getRepositoryKind().isFacetAvailable( GroupRepository.class ) )
+                {
+                    if ( !DefaultAttributeUpgrader.isUpgradeDone( legacyAttributesDirectory, repo.getId() ) )
+                    {
+                        logger.info( "Upgrading legacy attributes of repository {}.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                        ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
+                        req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY, this );
+                        repo.recreateAttributes( req, null );
+                        DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, repo.getId() );
+                        logger.info( "Upgrade of legacy attributes of repository {} done.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                    }
+                    else
+                    {
+                        logger.info( "Skipping legacy attributes of repository {}, already marked as upgraded.",
+                            RepositoryStringUtils.getHumanizedNameString( repo ) );
+                    }
+                }
+            }
+            DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, null );
+            logger.info(
+                "Legacy attribute directory upgrade finished. Please delete, move or rename the \"{}\" folder.",
+                legacyAttributesDirectory.getAbsolutePath() );
+        }
+    }
+
+    // == WalkerThrottleController
+
+    @Override
+    public boolean isThrottled()
+    {
+        return limiterUps > 0;
+    }
+
+    @Override
+    public long throttleTime( final ThrottleInfo info )
+    {
+        if ( adjustmentNeeded() )
+        {
+            actualUps = (int) ( info.getTotalProcessItemInvocationCount() / ( info.getTotalTimeWalking() / 1000 ) );
+
+            if ( actualUps > limiterUps )
+            {
+                // hold down the horses, increase sleepTime
+                if ( currentSleepTime.peek() <= 0 )
+                {
+                    currentSleepTime.reset();
+                }
+                else
+                {
+                    currentSleepTime.next();
+                }
+            }
+            else
+            {
+                // lessen the sleep time
+                if ( currentSleepTime.peek() > 0 )
+                {
+                    currentSleepTime.prev();
+                }
+            }
+
+            logger.info( "Actual speed {} UPS (limited to {} UPS), current sleepTime {}ms.", new Object[] { actualUps,
+                limiterUps, currentSleepTime.peek() } );
+        }
+
+        return currentSleepTime.peek();
+    }
+
+    /**
+     * To prevent "oscillation" we do adjustments only once in 5 seconds (or override if needed).
+     * 
+     * @return
+     */
+    protected boolean adjustmentNeeded()
+    {
+        // adjust every 5 second for now
+        if ( ( System.currentTimeMillis() - lastAdjustment ) > 5000 )
+        {
+            this.lastAdjustment = System.currentTimeMillis();
+
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -105,6 +105,7 @@ public class UpgraderThread
                         ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
                         req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY, throttleController );
                         req.getRequestContext().put( RecreateAttributesWalker.FORCE_ATTRIBUTE_RECREATION, Boolean.FALSE );
+                        req.getRequestContext().put( RecreateAttributesWalker.LEGACY_ATTRIBUTES_ONLY, Boolean.TRUE );
                         repo.recreateAttributes( req, null );
                         DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, repo.getId() );
                         logger.info( "Upgrade of legacy attributes of repository {} done.",

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -40,6 +40,8 @@ public class UpgraderThread
 
     private int actualUps;
 
+    private int maximumUps;
+
     private int limiterUps;
 
     private FibonacciNumberSequence currentSleepTime;
@@ -55,6 +57,8 @@ public class UpgraderThread
         // start with sleep time of 100ms
         this.currentSleepTime = new FibonacciNumberSequence( 100 );
         this.lastAdjustment = 0;
+        this.actualUps = 0;
+        this.maximumUps = 0;
         // to have it clearly in thread dumps
         setName( "LegacyAttributesUpgrader" );
         // to not prevent sudden reboots (by user, if upgrading, and rebooting)
@@ -66,6 +70,11 @@ public class UpgraderThread
     public int getActualUps()
     {
         return actualUps;
+    }
+
+    public int getMaximumUps()
+    {
+        return maximumUps;
     }
 
     public int getLimiterUps()
@@ -88,6 +97,7 @@ public class UpgraderThread
         }
         catch ( InterruptedException e )
         {
+            // thread will die off
             return;
         }
         // ping the "lastAdjustment" at very point where thread starts
@@ -140,6 +150,7 @@ public class UpgraderThread
         if ( adjustmentNeeded() )
         {
             actualUps = (int) ( info.getTotalProcessItemInvocationCount() / ( info.getTotalTimeWalking() / 1000 ) );
+            maximumUps = Math.max( actualUps, maximumUps );
 
             if ( actualUps > limiterUps )
             {
@@ -187,5 +198,4 @@ public class UpgraderThread
             return false;
         }
     }
-
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -162,7 +162,7 @@ public class UpgraderThread
                 }
             }
 
-            logger.info( "Actual speed {} UPS (limited to {} UPS), current sleepTime {}ms.", new Object[] { actualUps,
+            logger.info( "Actual speed {} upgrades/sec (limited to {} upgrades/sec), current sleepTime {}ms.", new Object[] { actualUps,
                 limiterUps, currentSleepTime.peek() } );
         }
 
@@ -180,7 +180,6 @@ public class UpgraderThread
         if ( ( System.currentTimeMillis() - lastAdjustment ) > 5000 )
         {
             this.lastAdjustment = System.currentTimeMillis();
-
             return true;
         }
         else

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -60,7 +60,7 @@ public class UpgraderThread
 
     public int getActualUps()
     {
-        return throttleController.getLastAdjustmentTps();
+        return throttleController.getLastSliceTps();
     }
 
     public int getMaximumUps()
@@ -128,8 +128,8 @@ public class UpgraderThread
     public void onAdjustment( final FixedRateWalkerThrottleController controller )
     {
         logger.info(
-            "Actual speed {} upgrades/sec, with average {} upgrade/sec (is limited to {} upgrades/sec), current sleepTime {}ms.",
-            new Object[] { controller.getLastAdjustmentTps(), controller.getGlobalAverageTps(),
-                controller.getLimiterTps(), controller.getCurrentSleepTime() } );
+            "Current speed {} upgrades/sec, with average {} upgrade/sec (is limited to {} upgrades/sec), currently sleeping {}ms per upgrade.",
+            new Object[] { controller.getLastSliceTps(), controller.getGlobalAverageTps(), controller.getLimiterTps(),
+                controller.getCurrentSleepTime() } );
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/UpgraderThread.java
@@ -1,7 +1,20 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes.upgrade;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +22,7 @@ import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.RecreateAttributesWalker;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 import org.sonatype.nexus.proxy.walker.WalkerThrottleController;
@@ -67,14 +81,16 @@ public class UpgraderThread
     @Override
     public void run()
     {
+        // sleep a bit to not start prematurely (ie. nexus startup not done yet)
         try
         {
-            Thread.sleep( 5000 );
+            TimeUnit.SECONDS.sleep( 5 );
         }
         catch ( InterruptedException e )
         {
             return;
         }
+        // ping the "lastAdjustment" at very point where thread starts
         this.lastAdjustment = System.currentTimeMillis();
 
         if ( !DefaultAttributeUpgrader.isUpgradeDone( legacyAttributesDirectory, null ) )
@@ -90,6 +106,7 @@ public class UpgraderThread
                             RepositoryStringUtils.getHumanizedNameString( repo ) );
                         ResourceStoreRequest req = new ResourceStoreRequest( RepositoryItemUid.PATH_ROOT );
                         req.getRequestContext().put( WalkerThrottleController.CONTEXT_KEY, this );
+                        req.getRequestContext().put( RecreateAttributesWalker.FORCE_ATTRIBUTE_RECREATION, Boolean.FALSE );
                         repo.recreateAttributes( req, null );
                         DefaultAttributeUpgrader.markUpgradeDone( legacyAttributesDirectory, repo.getId() );
                         logger.info( "Upgrade of legacy attributes of repository {} done.",

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/RecreateAttributesWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/RecreateAttributesWalker.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.sonatype.nexus.proxy.RequestContext;
+import org.sonatype.nexus.proxy.attributes.TransitioningAttributeStorage;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.walker.AbstractFileWalkerProcessor;
 import org.sonatype.nexus.proxy.walker.WalkerContext;
@@ -26,9 +27,16 @@ public class RecreateAttributesWalker
     public static final String FORCE_ATTRIBUTE_RECREATION = RecreateAttributesWalker.class.getName()
         + ".forceAttributeRecreation";
 
+    public static final String LEGACY_ATTRIBUTES_ONLY = RecreateAttributesWalker.class.getName()
+        + ".forceAttributeRecreation";
+
     private final Repository repository;
 
     private final Map<String, String> initialData;
+
+    private boolean forceAttributeRecreation;
+
+    private boolean legacyAtributesOnly;
 
     public RecreateAttributesWalker( final Repository repository, final Map<String, String> initialData )
     {
@@ -37,15 +45,32 @@ public class RecreateAttributesWalker
     }
 
     @Override
+    public void beforeWalk( WalkerContext context )
+        throws Exception
+    {
+        forceAttributeRecreation = isForceAttributeRecreation( context );
+        legacyAtributesOnly = isLegacyAttributesOnly( context );
+    }
+
+    @Override
     protected void processFileItem( final WalkerContext ctx, final StorageFileItem item )
         throws IOException
     {
+        if ( legacyAtributesOnly )
+        {
+            if ( !item.getRepositoryItemAttributes().containsKey( TransitioningAttributeStorage.FALLBACK_MARKER_KEY ) )
+            {
+                // if legacyAtributesOnly and current item attributes does not carry the marker, throw it away
+                return;
+            }
+        }
+
         if ( getInitialData() != null )
         {
             item.getRepositoryItemAttributes().putAll( initialData );
         }
 
-        if ( isForceAttributeRecreation( ctx ) )
+        if ( forceAttributeRecreation )
         {
             getRepository().getAttributesHandler().storeAttributes( item, item.getContentLocator() );
         }
@@ -77,6 +102,21 @@ public class RecreateAttributesWalker
         {
             // fallback to default behavior: do force it
             return true;
+        }
+    }
+
+    protected boolean isLegacyAttributesOnly( final WalkerContext ctx )
+    {
+        final RequestContext reqestContext = ctx.getResourceStoreRequest().getRequestContext();
+        if ( reqestContext.containsKey( LEGACY_ATTRIBUTES_ONLY, false ) )
+        {
+            // obey the "hint"
+            return Boolean.parseBoolean( String.valueOf( reqestContext.get( LEGACY_ATTRIBUTES_ONLY, false ) ) );
+        }
+        else
+        {
+            // fallback to default behavior: all of them
+            return false;
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
@@ -1,0 +1,62 @@
+package org.sonatype.nexus.proxy.walker;
+
+import org.sonatype.nexus.proxy.walker.WalkerThrottleController.ThrottleInfo;
+
+/**
+ * A simple single-threaded ThrottleInfo used in Walker implementation.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public class DefaultThrottleInfo
+    implements ThrottleInfo
+{
+    private final long walkStarted;
+
+    private long totalProcessItemSpentMillis;
+
+    private long totalProcessItemInvocationCount;
+
+    private long lastProcessItemEnterTime;
+
+    public DefaultThrottleInfo()
+    {
+        this.walkStarted = now();
+        this.totalProcessItemSpentMillis = 0;
+        this.totalProcessItemInvocationCount = 0;
+    }
+
+    protected long now()
+    {
+        return System.currentTimeMillis();
+    }
+
+    public void enterProcessItem()
+    {
+        this.lastProcessItemEnterTime = now();
+    }
+
+    public void exitProcessItem()
+    {
+        totalProcessItemSpentMillis += now() - lastProcessItemEnterTime;
+        totalProcessItemInvocationCount++;
+    }
+
+    @Override
+    public long getTotalProcessItemSpentMillis()
+    {
+        return totalProcessItemSpentMillis;
+    }
+
+    @Override
+    public long getTotalProcessItemInvocationCount()
+    {
+        return totalProcessItemInvocationCount;
+    }
+
+    @Override
+    public long getTotalTimeWalking()
+    {
+        return now() - walkStarted;
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultThrottleInfo.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.walker;
 
 import org.sonatype.nexus.proxy.walker.WalkerThrottleController.ThrottleInfo;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -364,7 +364,7 @@ public class DefaultWalker
             context.stop( e );
         }
 
-        context.getThrottleController().walkEnded( context );
+        context.getThrottleController().walkEnded( context, (DefaultThrottleInfo) context.getContext().get( WALKER_THROTTLE_INFO ) );
     }
 
     protected void afterWalk( WalkerContext context )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -303,6 +303,8 @@ public class DefaultWalker
     {
         try
         {
+            final long processItemEnter = System.currentTimeMillis();
+
             for ( WalkerProcessor processor : context.getProcessors() )
             {
                 if ( processor.isActive() )
@@ -313,6 +315,17 @@ public class DefaultWalker
                     {
                         break;
                     }
+                }
+            }
+
+            if ( !context.isStopped() && context.getThrottleController().isThrottled() )
+            {
+                final long throttleTime =
+                    context.getThrottleController().throttleTime( System.currentTimeMillis() - processItemEnter );
+
+                if ( throttleTime > 0 )
+                {
+                    Thread.sleep( throttleTime );
                 }
             }
         }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -257,6 +257,8 @@ public class DefaultWalker
 
     protected void beforeWalk( WalkerContext context )
     {
+        context.getThrottleController().walkStarted( context );
+
         try
         {
             for ( WalkerProcessor processor : context.getProcessors() )
@@ -361,6 +363,8 @@ public class DefaultWalker
         {
             context.stop( e );
         }
+
+        context.getThrottleController().walkEnded( context );
     }
 
     protected void afterWalk( WalkerContext context )

--- a/nexus/nexus-utils/pom.xml
+++ b/nexus/nexus-utils/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>junit-dep</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/ConstantNumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/ConstantNumberSequence.java
@@ -32,6 +32,11 @@ public class ConstantNumberSequence
         return peek();
     }
 
+    public long prev()
+    {
+        return peek();
+    }
+
     public long peek()
     {
         return val;

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/FibonacciNumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/FibonacciNumberSequence.java
@@ -23,7 +23,9 @@ package org.sonatype.nexus.util;
 public class FibonacciNumberSequence
     implements NumberSequence
 {
-    private final long start;
+    private final long startA;
+
+    private final long startB;
 
     private long a;
 
@@ -36,20 +38,36 @@ public class FibonacciNumberSequence
 
     public FibonacciNumberSequence( long start )
     {
-        this.start = start;
+        this( start, start );
+    }
 
+    public FibonacciNumberSequence( long startA, long startB )
+    {
+        this.startA = startA;
+        this.startB = startB;
         reset();
     }
 
     public long next()
     {
         long res = a;
-        
+
         a = b;
 
         b = res + b;
 
         return res;
+    }
+
+    public long prev()
+    {
+        long tmp = b;
+
+        b = a;
+
+        a = tmp - b;
+
+        return a;
     }
 
     public long peek()
@@ -59,9 +77,8 @@ public class FibonacciNumberSequence
 
     public void reset()
     {
-        a = start;
-
-        b = start;
+        a = startA;
+        b = startB;
     }
 
 }

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/LinearNumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/LinearNumberSequence.java
@@ -1,0 +1,54 @@
+package org.sonatype.nexus.util;
+
+/**
+ * A simple linear number sequence (linear equation).
+ * 
+ * @author cstamas
+ */
+public class LinearNumberSequence
+    implements NumberSequence
+{
+    private final long start;
+
+    private final long step;
+
+    private final long multiplier;
+
+    private final long shift;
+
+    private long current;
+
+    public LinearNumberSequence( final long start, final long step, final long multiplier, final long shift )
+    {
+        this.start = start;
+        this.step = step;
+        this.multiplier = multiplier;
+        this.shift = shift;
+    }
+
+    @Override
+    public long next()
+    {
+        current = current + step;
+        return peek();
+    }
+
+    @Override
+    public long prev()
+    {
+        current = current - step;
+        return peek();
+    }
+
+    @Override
+    public long peek()
+    {
+        return ( current * multiplier ) + shift;
+    }
+
+    @Override
+    public void reset()
+    {
+        this.current = start;
+    }
+}

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/LinearNumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/LinearNumberSequence.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.util;
 
 /**

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/NumberSequence.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/NumberSequence.java
@@ -28,6 +28,13 @@ public interface NumberSequence
     long next();
 
     /**
+     * Returns the previous number in sequence and digresses the sequence.
+     * 
+     * @return
+     */
+    long prev();
+
+    /**
      * Returns the next number in sequence without advancing the sequence. This method will return always the same
      * number unless method {@code next()} is called.
      * 

--- a/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
+++ b/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.util;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,6 +75,33 @@ public class NumberSequenceTest
         for ( int f : fibonacciNumbers )
         {
             Assert.assertEquals( f, fs.next() );
+        }
+    }
+
+    @Test
+    public void testFibonacciSequenceBackAndForth()
+    {
+        int[] fibonacciNumbers = new int[] { 10, 10, 20, 30, 50, 80, 130, 210, 340, 550, 890, 1440, 2330 };
+
+        FibonacciNumberSequence fs = new FibonacciNumberSequence( 10 );
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.next() );
+        }
+
+        fs.reset();
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.next() );
+        }
+
+        ArrayUtils.reverse( fibonacciNumbers );
+
+        for ( int f : fibonacciNumbers )
+        {
+            Assert.assertEquals( f, fs.prev() );
         }
     }
 }

--- a/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
+++ b/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/NumberSequenceTest.java
@@ -39,6 +39,65 @@ public class NumberSequenceTest
     }
 
     @Test
+    public void testLinearSequence()
+    {
+        long startValue = 0;
+
+        // step=1, multiplier=1, shift=0
+        // f(x) = 1*x+0 = x; x starts at 1
+        LinearNumberSequence ls = new LinearNumberSequence( startValue, 1, 1, 0 );
+
+        for ( int i = 1; i < 20; i++ )
+        {
+            Assert.assertEquals( i, ls.next() );
+        }
+
+        ls.reset();
+
+        // forth and back
+        for ( int i = 1; i < 20; i++ )
+        {
+            Assert.assertEquals( i, ls.next() );
+        }
+        for ( int i = 18; i >= 1; i-- )
+        {
+            Assert.assertEquals( i, ls.prev() );
+        }
+    }
+
+    @Test
+    public void testLinearSequenceBitMore()
+    {
+        long startValue = 0;
+
+        // step=10, multiplier=2, shift=10
+        // f(x) = 1*x+0 = x; x starts at 1
+        LinearNumberSequence ls = new LinearNumberSequence( startValue, 10, 2, 10 );
+
+        long f = 0;
+
+        for ( int i = 1; i < 20; i++ )
+        {
+            f = 2 * ( i * 10 ) + 10;
+            Assert.assertEquals( f, ls.next() );
+        }
+
+        ls.reset();
+
+        // forth and back
+        for ( int i = 1; i < 20; i++ )
+        {
+            f = 2 * ( i * 10 ) + 10;
+            Assert.assertEquals( f, ls.next() );
+        }
+        for ( int i = 18; i >= 1; i-- )
+        {
+            f = 2 * ( i * 10 ) + 10;
+            Assert.assertEquals( f, ls.prev() );
+        }
+    }
+
+    @Test
     public void testFibonacciSequence()
     {
         int[] fibonacciNumbers = new int[] { 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233 };


### PR DESCRIPTION
This pull request contains following substantial fixes:
- (F1) TransitioningAttributeStorage made less eager. Fix made attribute-related IO ops from "read, read, write, delete" to "read, read" (worst cases).
- (F2) RecreateAttributesWalker operated on groups too, hence, group member repositories was walked for upgrade multiple times.
- (F3) RecreateAttributesWalker was forcing re-checksumming.
- (F4) on upgrade, attribute save happens only when it originates from "legacy" store (ie. partially upgraded repository will perform saves only on non-upgraded attributes).

And some other minor improvements regarding overall IO load of upgrade.

This pull request contains following major improvements:
- Nexus Core Walker component supports walk-throttling, it is possible to "interfere" with walking speed from now on (by slowing it down, not by walking faster than your HW is capable of! ;)
- Two out-of-the-box throttle controllers implemented: "fixed rate" and "adaptive" (the 2nd is TBD, not yet implemented!).
- AttributeUpgrader component exposed over JMX, and properties like maxTPS are even settable live during upgrade. Also, the upgrade process itself can be invoked/started over JMX (ie. you defer upgrade auto-start by system property to be able to set up for proper JMX monitoring).
- NumberSequence got new member: "linear" number sequence, and it's API is enhanced (got prev() method for stepping back).

The "initial" maxTPS value is set to 100 upgrade/sec, which would upgrade Central repository hosted in Nexus in 5 hours. But, again, the maxTPS is settable over JMX.
