### PR TITLE
NEXUS-4799: Marker file makes upgrader to choke.

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -266,13 +266,27 @@ public class DefaultAttributeUpgrader
     {
         if ( StringUtils.isBlank( repoId ) )
         {
-            return StringUtils.equals( MARKER_TEXT,
-                FileUtils.fileRead( new File( attributesDirectory, MARKER_FILENAME ) ) );
+            final File markerFile = new File( attributesDirectory, MARKER_FILENAME );
+            if ( markerFile.exists() )
+            {
+                return StringUtils.equals( MARKER_TEXT, FileUtils.fileRead( markerFile ) );
+            }
+            else
+            {
+                return false;
+            }
         }
         else
         {
-            return StringUtils.equals( MARKER_TEXT,
-                FileUtils.fileRead( new File( new File( attributesDirectory, repoId ), MARKER_FILENAME ) ) );
+            final File markerFile = new File( new File( attributesDirectory, repoId ), MARKER_FILENAME );
+            if ( markerFile.exists() )
+            {
+                return StringUtils.equals( MARKER_TEXT, FileUtils.fileRead( markerFile ) );
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
When I moved out IOException handling from this method (together with "huh?" catch block),
I forgot about special handling of the case when the file is not present (yet).
