### PR TITLE
Deadlock fixes

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/AsynchronousEventInspectorWrapper.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/AsynchronousEventInspectorWrapper.java
@@ -1,0 +1,47 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.events;
+
+import org.sonatype.plexus.appevents.Event;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * A simple async event inspector wrapper, that wraps other event inspector and makes it async. Usable in tests, but not
+ * only in tests ... albeit, EventInspectors are Components, applying this on them is not quite trivial.
+ * 
+ * @author cstamas
+ * @since 2.0
+ */
+public class AsynchronousEventInspectorWrapper
+    implements EventInspector, AsynchronousEventInspector
+{
+    private final EventInspector eventInspector;
+
+    public AsynchronousEventInspectorWrapper( final EventInspector eventInspector )
+    {
+        this.eventInspector = Preconditions.checkNotNull( eventInspector );
+    }
+
+    @Override
+    public boolean accepts( Event<?> evt )
+    {
+        return eventInspector.accepts( evt );
+    }
+
+    @Override
+    public void inspect( Event<?> evt )
+    {
+        eventInspector.inspect( evt );
+    }
+}

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
@@ -30,7 +30,8 @@ import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.threads.NexusThreadFactory;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 import org.sonatype.plexus.appevents.Event;
-import org.sonatype.sisu.goodies.common.TestAccessible;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * A default implementation of EventInspectorHost, a component simply collecting all EventInspectors and re-emitting
@@ -63,7 +64,7 @@ public class DefaultEventInspectorHost
                 new NexusThreadFactory( "nxevthost", "Event Inspector Host" ), new CallerRunsPolicy() );
     }
 
-    @TestAccessible
+    @VisibleForTesting 
     public DefaultEventInspectorHost( final Map<String, EventInspector> eventInspectors )
     {
         this();

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultEventInspectorHost.java
@@ -30,6 +30,7 @@ import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.threads.NexusThreadFactory;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 import org.sonatype.plexus.appevents.Event;
+import org.sonatype.sisu.goodies.common.TestAccessible;
 
 /**
  * A default implementation of EventInspectorHost, a component simply collecting all EventInspectors and re-emitting
@@ -60,6 +61,13 @@ public class DefaultEventInspectorHost
         this.hostThreadPool =
             new ThreadPoolExecutor( 0, HOST_THREAD_POOL_SIZE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
                 new NexusThreadFactory( "nxevthost", "Event Inspector Host" ), new CallerRunsPolicy() );
+    }
+
+    @TestAccessible
+    public DefaultEventInspectorHost( final Map<String, EventInspector> eventInspectors )
+    {
+        this();
+        this.eventInspectors = eventInspectors;
     }
 
     // == Disposable iface, to manage ExecutorService lifecycle
@@ -154,9 +162,8 @@ public class DefaultEventInspectorHost
                 }
                 catch ( Exception e )
                 {
-                    getLogger().warn(
-                        "Async EventInspector implementation='" + ei.getClass().getName()
-                            + "' had problem accepting an event='" + evt.getClass() + "'", e );
+                    getLogger().warn( "Async EventInspector implementation={} had problem accepting an event={}",
+                        new Object[] { ei.getClass().getName(), evt.getClass(), e } );
                 }
             }
         }

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DeleteRepositoryFoldersEventInspector.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DeleteRepositoryFoldersEventInspector.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.events;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventPostRemove;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -30,6 +31,7 @@ import org.sonatype.plexus.appevents.Event;
 @Component( role = EventInspector.class, hint = "DeleteRepositoryFoldersEventInspector" )
 public class DeleteRepositoryFoldersEventInspector
     extends AbstractEventInspector
+    implements AsynchronousEventInspector
 {
     @Requirement
     private NexusScheduler nexusScheduler;

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/RepositoryConfigurationUpdatedEventInspector.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/RepositoryConfigurationUpdatedEventInspector.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.events;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
 import org.sonatype.nexus.scheduling.NexusScheduler;
@@ -28,6 +29,7 @@ import org.sonatype.plexus.appevents.Event;
 @Component( role = EventInspector.class, hint = "RepositoryConfigurationUpdatedEventInspector" )
 public class RepositoryConfigurationUpdatedEventInspector
     extends AbstractEventInspector
+    implements AsynchronousEventInspector
 {
     @Requirement
     private NexusScheduler nexusScheduler;

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.events;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
@@ -72,15 +72,18 @@ public class DefaultEventInspectorHostTest
         @Override
         public void inspect( Event<?> evt )
         {
-            countDownLatch.countDown();
-            this.inspectInvoked = System.currentTimeMillis();
             try
             {
+                this.inspectInvoked = System.currentTimeMillis();
                 Thread.sleep( 100 );
             }
             catch ( InterruptedException e )
             {
                 // nothing
+            }
+            finally
+            {
+                countDownLatch.countDown();
             }
         }
     }

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/events/DefaultEventInspectorHostTest.java
@@ -1,0 +1,87 @@
+package org.sonatype.nexus.events;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspectorWrapper;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusStartedEvent;
+import org.sonatype.plexus.appevents.Event;
+
+public class DefaultEventInspectorHostTest
+{
+    @Test
+    public void testSyncThenAsyncExecution()
+        throws Exception
+    {
+        final InvocationTimestampEventInspector syncEI = new InvocationTimestampEventInspector();
+        final InvocationTimestampEventInspector asyncEI = new InvocationTimestampEventInspector();
+
+        final HashMap<String, EventInspector> map = new HashMap<String, EventInspector>( 2 );
+        map.put( "sync", syncEI );
+        map.put( "async", new AsynchronousEventInspectorWrapper( asyncEI ) );
+
+        final DefaultEventInspectorHost host = new DefaultEventInspectorHost( map );
+
+        host.onEvent( new NexusStartedEvent( this ) );
+
+        // to handle possible async peculiarites
+        syncEI.await();
+        asyncEI.await();
+
+        // they both should be invoked
+        assertThat( syncEI.getInspectInvoked(), greaterThan( 0L ) );
+        assertThat( asyncEI.getInspectInvoked(), greaterThan( 0L ) );
+
+        // sync has to be invoked before async
+        assertThat( asyncEI.getInspectInvoked(), greaterThan( syncEI.getInspectInvoked() ) );
+        assertThat( asyncEI.getInspectInvoked() - syncEI.getInspectInvoked(), greaterThanOrEqualTo( 100L ) );
+    }
+
+    // ==
+
+    public static class InvocationTimestampEventInspector
+        implements EventInspector
+    {
+        private long inspectInvoked = -1;
+
+        private CountDownLatch countDownLatch = new CountDownLatch( 1 );
+
+        public long getInspectInvoked()
+        {
+            return inspectInvoked;
+        }
+
+        public void await()
+            throws InterruptedException
+        {
+            countDownLatch.await();
+        }
+
+        @Override
+        public boolean accepts( Event<?> evt )
+        {
+            return true;
+        }
+
+        @Override
+        public void inspect( Event<?> evt )
+        {
+            countDownLatch.countDown();
+            this.inspectInvoked = System.currentTimeMillis();
+            try
+            {
+                Thread.sleep( 100 );
+            }
+            catch ( InterruptedException e )
+            {
+                // nothing
+            }
+        }
+    }
+}

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
@@ -1,0 +1,190 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.events;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.ApplicationStatusSource;
+import org.sonatype.nexus.proxy.NoSuchRepositoryException;
+import org.sonatype.nexus.proxy.events.AbstractEventInspector;
+import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
+import org.sonatype.nexus.proxy.events.RepositoryRegistryEventAdd;
+import org.sonatype.nexus.proxy.events.RepositoryRegistryRepositoryEvent;
+import org.sonatype.nexus.proxy.maven.MavenRepository;
+import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.scheduling.AbstractNexusRepositoriesPathAwareTask;
+import org.sonatype.nexus.scheduling.NexusScheduler;
+import org.sonatype.nexus.tasks.RepairIndexTask;
+import org.sonatype.nexus.tasks.UpdateIndexTask;
+import org.sonatype.plexus.appevents.Event;
+
+/**
+ * Listens for events and manages indexes by doing reindexes when needed (on repository configuration updates).
+ * <p>
+ * This EventInspector HAS TO BY ASYNC
+ * 
+ * @author Toni Menzel
+ * @author cstamas
+ */
+@Component( role = EventInspector.class, hint = "IndexingRepositoryRegistryRepositoryAsyncEventInspector" )
+public class IndexingRepositoryRegistryRepositoryAsyncEventInspector
+    extends AbstractEventInspector
+    implements AsynchronousEventInspector
+{
+    @Requirement
+    private RepositoryRegistry repoRegistry;
+
+    @Requirement
+    private NexusScheduler nexusScheduler;
+
+    @Requirement
+    private ApplicationStatusSource applicationStatusSource;
+
+    public boolean accepts( Event<?> evt )
+    {
+        return ( evt instanceof RepositoryRegistryRepositoryEvent )
+            || ( evt instanceof RepositoryConfigurationUpdatedEvent );
+    }
+
+    public void inspect( Event<?> evt )
+    {
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
+
+        Repository repository = null;
+        if ( evt instanceof RepositoryRegistryRepositoryEvent )
+        {
+            repository = ( (RepositoryRegistryRepositoryEvent) evt ).getRepository();
+        }
+        else if ( evt instanceof RepositoryConfigurationUpdatedEvent )
+        {
+            repository = ( (RepositoryConfigurationUpdatedEvent) evt ).getRepository();
+        }
+
+        try
+        {
+            // check registry for existance, wont be able to do much
+            // if doesn't exist yet
+            repoRegistry.getRepositoryWithFacet( repository.getId(), MavenRepository.class );
+
+            inspectForIndexerManager( evt, repository );
+        }
+        catch ( NoSuchRepositoryException e )
+        {
+            getLogger().debug( "Attempted to handle repository that isn't yet in registry" );
+        }
+    }
+
+    private void inspectForIndexerManager( Event<?> evt, Repository repository )
+    {
+        try
+        {
+            // we are handling repo events, like addition and removal
+            if ( evt instanceof RepositoryRegistryEventAdd )
+            {
+                // create the initial index
+                if ( applicationStatusSource.getSystemStatus().isNexusStarted() && repository.isIndexable() )
+                {
+                    // Create the initial index for the repository
+                    reindexRepo( repository, false, "Creating initial index, repositoryId=" + repository.getId() );
+                }
+            }
+            else if ( evt instanceof RepositoryConfigurationUpdatedEvent )
+            {
+                RepositoryConfigurationUpdatedEvent event = (RepositoryConfigurationUpdatedEvent) evt;
+
+                // we need to do a full reindex of a Maven2 Proxy repository if:
+                // a) if remoteUrl changed
+                // b) if download remote index enabled (any repo type)
+                // c) if repository is made searchable
+                // TODO: are we sure only a) needs a check for Maven2? I think all of them need
+                if ( event.isRemoteUrlChanged() || event.isDownloadRemoteIndexEnabled() || event.isMadeSearchable() )
+                {
+                    String taskName = null;
+
+                    String logMessage = null;
+
+                    if ( event.isRemoteUrlChanged() )
+                    {
+                        taskName = append( taskName, "remote URL changed" );
+
+                        logMessage = append( logMessage, "remote URL changed" );
+                    }
+
+                    if ( event.isDownloadRemoteIndexEnabled() )
+                    {
+                        taskName = append( taskName, "enabled download of indexes" );
+
+                        logMessage = append( logMessage, "enabled download of indexes" );
+                    }
+
+                    if ( event.isMadeSearchable() )
+                    {
+                        taskName = append( taskName, "enabled searchable" );
+
+                        logMessage = append( logMessage, "enabled searchable" );
+                    }
+
+                    taskName = taskName + ", repositoryId=" + event.getRepository().getId() + ".";
+
+                    logMessage =
+                        logMessage + " on repository \"" + event.getRepository().getName() + "\" (id="
+                            + event.getRepository().getId() + "), doing full reindex of it.";
+
+                    reindexRepo( event.getRepository(), true, taskName );
+
+                    getLogger().info( logMessage );
+                }
+            }
+        }
+        catch ( Exception e )
+        {
+            getLogger().error( "Could not maintain indexing contexts!", e );
+        }
+    }
+
+    private void reindexRepo( Repository repository, boolean full, String taskName )
+    {
+        AbstractNexusRepositoriesPathAwareTask<Object> rt;
+        if ( full )
+        {
+            rt = nexusScheduler.createTaskInstance( RepairIndexTask.class );
+        }
+        else
+        {
+            rt = nexusScheduler.createTaskInstance( UpdateIndexTask.class );
+        }
+
+        rt.setRepositoryId( repository.getId() );
+
+        nexusScheduler.submit( taskName, rt );
+    }
+
+    private String append( String message, String append )
+    {
+        if ( StringUtils.isBlank( message ) )
+        {
+            return StringUtils.capitalizeFirstLetter( append );
+        }
+        else
+        {
+            return message + ", " + append;
+        }
+    }
+}

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryEventInspector.java
@@ -14,8 +14,6 @@ package org.sonatype.nexus.events;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.util.StringUtils;
-import org.sonatype.nexus.ApplicationStatusSource;
 import org.sonatype.nexus.index.IndexerManager;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
@@ -27,23 +25,17 @@ import org.sonatype.nexus.proxy.events.RepositoryRegistryRepositoryEvent;
 import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
 import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.scheduling.AbstractNexusRepositoriesPathAwareTask;
-import org.sonatype.nexus.scheduling.NexusScheduler;
-import org.sonatype.nexus.tasks.RepairIndexTask;
-import org.sonatype.nexus.tasks.UpdateIndexTask;
 import org.sonatype.plexus.appevents.Event;
 
 /**
- * Listens for events and manages IndexerManager by adding and removing indexing contexts, and doing reindexes when
- * needed (on repository configuration updates).
+ * Listens for events and manages IndexerManager by adding and removing indexing contexts.
  * <p>
- * Split {@link RepositoryRegistryRepositoryEventInspector} into two parts. One is this and the other is
- * {@link RepositoryRegistryRepositoryEventInspector} This part is subject to be moved out of core (luceneindexer
- * plugin)
+ * This EventInspector component HAS TO BE sync!
  * 
  * @author Toni Menzel
+ * @author cstamas
  */
-@Component( role = EventInspector.class, hint = "LuceneIndexingRepositoryRegistryRepositoryEventInspector" )
+@Component( role = EventInspector.class, hint = "IndexingRepositoryRegistryRepositoryEventInspector" )
 public class IndexingRepositoryRegistryRepositoryEventInspector
     extends AbstractEventInspector
 {
@@ -52,12 +44,6 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
 
     @Requirement
     private RepositoryRegistry repoRegistry;
-
-    @Requirement
-    private NexusScheduler nexusScheduler;
-
-    @Requirement
-    private ApplicationStatusSource applicationStatusSource;
 
     protected IndexerManager getIndexerManager()
     {
@@ -72,8 +58,12 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
 
     public void inspect( Event<?> evt )
     {
-        Repository repository = null;
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
 
+        Repository repository = null;
         if ( evt instanceof RepositoryRegistryRepositoryEvent )
         {
             repository = ( (RepositoryRegistryRepositoryEvent) evt ).getRepository();
@@ -82,18 +72,12 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
         {
             repository = ( (RepositoryConfigurationUpdatedEvent) evt ).getRepository();
         }
-        else
-        {
-            // how did I get here at all?
-            return;
-        }
 
         try
         {
-            // check registry for existance, wont be able to do much
+            // check registry for existence, wont be able to do much
             // if doesn't exist yet
             repoRegistry.getRepositoryWithFacet( repository.getId(), MavenRepository.class );
-
             inspectForIndexerManager( evt, repository );
         }
         catch ( NoSuchRepositoryException e )
@@ -110,15 +94,7 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
             if ( evt instanceof RepositoryRegistryEventAdd )
             {
                 getIndexerManager().addRepositoryIndexContext( repository.getId() );
-
                 getIndexerManager().setRepositoryIndexContextSearchable( repository.getId(), repository.isSearchable() );
-
-                // create the initial index
-                if ( applicationStatusSource.getSystemStatus().isNexusStarted() && repository.isIndexable() )
-                {
-                    // Create the initial index for the repository
-                    reindexRepo( repository, false, "Creating initial index, repositoryId=" + repository.getId() );
-                }
             }
             else if ( evt instanceof RepositoryRegistryEventRemove )
             {
@@ -128,54 +104,6 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
             else if ( evt instanceof RepositoryConfigurationUpdatedEvent )
             {
                 getIndexerManager().updateRepositoryIndexContext( repository.getId() );
-
-                if ( evt instanceof RepositoryConfigurationUpdatedEvent )
-                {
-                    RepositoryConfigurationUpdatedEvent event = (RepositoryConfigurationUpdatedEvent) evt;
-
-                    // we need to do a full reindex of a Maven2 Proxy repository if:
-                    // a) if remoteUrl changed
-                    // b) if download remote index enabled (any repo type)
-                    // c) if repository is made searchable
-                    // TODO: are we sure only a) needs a check for Maven2? I think all of them need
-                    if ( event.isRemoteUrlChanged() || event.isDownloadRemoteIndexEnabled() || event.isMadeSearchable() )
-                    {
-                        String taskName = null;
-
-                        String logMessage = null;
-
-                        if ( event.isRemoteUrlChanged() )
-                        {
-                            taskName = append( taskName, "remote URL changed" );
-
-                            logMessage = append( logMessage, "remote URL changed" );
-                        }
-
-                        if ( event.isDownloadRemoteIndexEnabled() )
-                        {
-                            taskName = append( taskName, "enabled download of indexes" );
-
-                            logMessage = append( logMessage, "enabled download of indexes" );
-                        }
-
-                        if ( event.isMadeSearchable() )
-                        {
-                            taskName = append( taskName, "enabled searchable" );
-
-                            logMessage = append( logMessage, "enabled searchable" );
-                        }
-
-                        taskName = taskName + ", repositoryId=" + event.getRepository().getId() + ".";
-
-                        logMessage =
-                            logMessage + " on repository \"" + event.getRepository().getName() + "\" (id="
-                                + event.getRepository().getId() + "), doing full reindex of it.";
-
-                        reindexRepo( event.getRepository(), true, taskName );
-
-                        getLogger().info( logMessage );
-                    }
-                }
             }
         }
         catch ( Exception e )
@@ -183,34 +111,4 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
             getLogger().error( "Could not maintain indexing contexts!", e );
         }
     }
-
-    private void reindexRepo( Repository repository, boolean full, String taskName )
-    {
-        AbstractNexusRepositoriesPathAwareTask<Object> rt;
-        if ( full )
-        {
-            rt = nexusScheduler.createTaskInstance( RepairIndexTask.class );
-        }
-        else
-        {
-            rt = nexusScheduler.createTaskInstance( UpdateIndexTask.class );
-        }
-
-        rt.setRepositoryId( repository.getId() );
-
-        nexusScheduler.submit( taskName, rt );
-    }
-
-    private String append( String message, String append )
-    {
-        if ( StringUtils.isBlank( message ) )
-        {
-            return StringUtils.capitalizeFirstLetter( append );
-        }
-        else
-        {
-            return message + ", " + append;
-        }
-    }
-
 }


### PR DESCRIPTION
Step1: Change to DefaultInspectorHost wrt async inspector handling.

Before this, the event inspectors were processed in undefined order,
as they were coming in (as SISU injected them, unsure was this
nondeterministic or not). Anyway, event inspector implementations
was impled with NO expectations about order, so this change is fine.

With this change, all that happens is that system GUARANTEES
that when an async inspector is about to be executed, all the
sync inspectors were already run and finished.

Hence, this change makes fix for NEXUS-4784 simple: just factor out the
task scheduling code after line (currently 130)

getIndexerManager().updateRepositoryIndexContext( repository.getId() );

(but keep this line above in sync inspector), and this fixes
the problem described in NEXUS-4784 (and many others too).

Step2: Factor out task scheduling code from any sync EventInspector into async EventInspectors.

Step3: Revisit DefaultScheduler (component doing task scheduling) and evaluate use of ConcurrentHashMap and other better solutions over current strict locking.
# 

In progress, not for vote yet.
