### PR TITLE
Step3: Consuming fixed Scheduler plus scheduler config related fixes in Core

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/scheduling/NexusScheduler.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/scheduling/NexusScheduler.java
@@ -20,12 +20,24 @@ import org.sonatype.scheduling.NoSuchTaskException;
 import org.sonatype.scheduling.ScheduledTask;
 import org.sonatype.scheduling.schedules.Schedule;
 
+/**
+ * Scheduler component of Nexus, responsible for task management (their schedule, running, and configuration
+ * persistence).
+ * 
+ * @author cstamas
+ */
 public interface NexusScheduler
 {
+    /**
+     * Initializes Nexus scheduler, but loading up tasks from persisted configuration and instantiating them.
+     */
     void initializeTasks();
-    
+
+    /**
+     * Performs a clean shutdown of the Nexus Scheduler.
+     */
     void shutdown();
-    
+
     /**
      * Issue a NexusTask for immediate execution, but have a control over it.
      * 
@@ -34,8 +46,7 @@ public interface NexusScheduler
      * @return
      */
     <T> ScheduledTask<T> submit( String name, NexusTask<T> nexusTask )
-        throws RejectedExecutionException,
-            NullPointerException;
+        throws RejectedExecutionException, NullPointerException;
 
     /**
      * Issue a NexusTask for scheduled execution.
@@ -46,8 +57,7 @@ public interface NexusScheduler
      * @return
      */
     <T> ScheduledTask<T> schedule( String name, NexusTask<T> nexusTask, Schedule schedule )
-        throws RejectedExecutionException,
-            NullPointerException;
+        throws RejectedExecutionException, NullPointerException;
 
     /**
      * Update parameters of a scheduled task
@@ -56,8 +66,7 @@ public interface NexusScheduler
      * @return
      */
     <T> ScheduledTask<T> updateSchedule( ScheduledTask<T> task )
-        throws RejectedExecutionException,
-            NullPointerException;
+        throws RejectedExecutionException, NullPointerException;
 
     /**
      * Returns the map of currently active tasks. The resturned collection is an unmodifiable snapshot. It may differ

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/scheduling/NexusScheduler.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/scheduling/NexusScheduler.java
@@ -24,6 +24,8 @@ public interface NexusScheduler
 {
     void initializeTasks();
     
+    void shutdown();
+    
     /**
      * Issue a NexusTask for immediate execution, but have a control over it.
      * 
@@ -90,6 +92,7 @@ public interface NexusScheduler
      * @throws IllegalArgumentException
      * @deprecated prefer the createTaskInstance(Class<T> type) method instead.
      */
+    @Deprecated
     NexusTask<?> createTaskInstance( String taskType )
         throws IllegalArgumentException;
 

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
@@ -524,6 +524,8 @@ public class DefaultNexus
 
         // Due to no dependency mechanism in NX for components, we need to fire off a hint about shutdown first
         applicationEventMulticaster.notifyEventListeners( new NexusStoppingEvent( this ) );
+        
+        nexusScheduler.shutdown();
 
         applicationEventMulticaster.notifyEventListeners( new NexusStoppedEvent( this ) );
 

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/DefaultNexusScheduler.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/DefaultNexusScheduler.java
@@ -46,11 +46,19 @@ public class DefaultNexusScheduler
         return plexusContainer;
     }
 
+    @Override
     public void initializeTasks()
     {
         scheduler.initializeTasks();
     }
 
+    @Override
+    public void shutdown()
+    {
+        scheduler.shutdown();
+    }
+    
+    @Override
     public <T> ScheduledTask<T> submit( String name, NexusTask<T> nexusTask )
         throws RejectedExecutionException, NullPointerException
     {
@@ -64,6 +72,7 @@ public class DefaultNexusScheduler
         }
     }
 
+    @Override
     public <T> ScheduledTask<T> schedule( String name, NexusTask<T> nexusTask, Schedule schedule )
         throws RejectedExecutionException, NullPointerException
     {
@@ -77,6 +86,7 @@ public class DefaultNexusScheduler
         }
     }
 
+    @Override
     public <T> ScheduledTask<T> updateSchedule( ScheduledTask<T> task )
         throws RejectedExecutionException, NullPointerException
     {
@@ -88,22 +98,27 @@ public class DefaultNexusScheduler
         return task;
     }
 
+    @Override
     public Map<String, List<ScheduledTask<?>>> getAllTasks()
     {
         return scheduler.getAllTasks();
     }
 
+    @Override
     public Map<String, List<ScheduledTask<?>>> getActiveTasks()
     {
         return scheduler.getActiveTasks();
     }
 
+    @Override
     public ScheduledTask<?> getTaskById( String id )
         throws NoSuchTaskException
     {
         return scheduler.getTaskById( id );
     }
 
+    @Override
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public NexusTask<?> createTaskInstance( String taskType )
         throws IllegalArgumentException
@@ -111,6 +126,7 @@ public class DefaultNexusScheduler
         return (NexusTask) scheduler.createTaskInstance( taskType );
     }
 
+    @Override
     public <T> T createTaskInstance( Class<T> taskType )
         throws IllegalArgumentException
     {

--- a/nexus/nexus-app/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
@@ -27,17 +27,18 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.nexus.configuration.AbstractConfigurable;
 import org.sonatype.nexus.configuration.Configurator;
 import org.sonatype.nexus.configuration.CoreConfiguration;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.configuration.application.NexusConfiguration;
 import org.sonatype.nexus.configuration.model.CProps;
 import org.sonatype.nexus.configuration.model.CScheduleConfig;
 import org.sonatype.nexus.configuration.model.CScheduledTask;
 import org.sonatype.nexus.configuration.model.CScheduledTaskCoreConfiguration;
-import org.sonatype.nexus.logging.Slf4jPlexusLogger;
 import org.sonatype.nexus.scheduling.NexusTask;
 import org.sonatype.nexus.scheduling.TaskUtils;
 import org.sonatype.scheduling.schedules.CronSchedule;
@@ -59,14 +60,13 @@ public class DefaultTaskConfigManager
     extends AbstractConfigurable
     implements TaskConfigManager
 {
-
-    private Logger logger = Slf4jPlexusLogger.getPlexusLogger( getClass() );
+    private final Logger logger = LoggerFactory.getLogger(  getClass() );
 
     /**
      * The app config holding tasks.
      */
     @Requirement
-    private ApplicationConfiguration applicationConfiguration;
+    private NexusConfiguration applicationConfiguration;
 
     /**
      * Plexus.

--- a/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 
 import org.junit.Test;
 import org.sonatype.nexus.configuration.AbstractNexusTestCase;
-import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.configuration.application.NexusConfiguration;
 import org.sonatype.nexus.configuration.model.CScheduledTask;
 import org.sonatype.scheduling.schedules.CronSchedule;
 import org.sonatype.scheduling.schedules.DailySchedule;
@@ -38,7 +38,7 @@ public class DefaultTaskConfigManagerTest
 
     private DefaultTaskConfigManager defaultManager;
 
-    private ApplicationConfiguration applicationConfiguration;
+    private NexusConfiguration applicationConfiguration;
 
     private static final String PROPERTY_KEY_START_DATE = "startDate";
 
@@ -78,10 +78,9 @@ public class DefaultTaskConfigManagerTest
         super.setUp();
 
         defaultScheduler = (DefaultScheduler) lookup( Scheduler.class.getName() );
-
         defaultManager = (DefaultTaskConfigManager) lookup( TaskConfigManager.class.getName() );
-
-        applicationConfiguration = (ApplicationConfiguration) lookup( ApplicationConfiguration.class );
+        applicationConfiguration = lookup( NexusConfiguration.class );
+        applicationConfiguration.loadConfiguration();
     }
 
     @Test

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractNexusTestEnvironment.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/AbstractNexusTestEnvironment.java
@@ -16,7 +16,6 @@ import org.sonatype.nexus.mime.MimeUtil;
 import org.sonatype.nexus.proxy.cache.CacheManager;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidFactory;
 import org.sonatype.nexus.proxy.item.uid.RepositoryItemUidAttributeManager;
-import org.sonatype.scheduling.Scheduler;
 import org.sonatype.security.SecuritySystem;
 
 public abstract class AbstractNexusTestEnvironment
@@ -24,8 +23,6 @@ public abstract class AbstractNexusTestEnvironment
 {
     /** The cache manager. */
     private CacheManager cacheManager;
-
-    private Scheduler scheduler;
 
     private RepositoryItemUidFactory repositoryItemUidFactory;
 
@@ -35,8 +32,6 @@ public abstract class AbstractNexusTestEnvironment
         throws Exception
     {
         super.setUp();
-
-        scheduler = lookup( Scheduler.class );
 
         cacheManager = lookup( CacheManager.class );
 
@@ -58,11 +53,6 @@ public abstract class AbstractNexusTestEnvironment
     protected CacheManager getCacheManager()
     {
         return cacheManager;
-    }
-
-    protected Scheduler getScheduler()
-    {
-        return scheduler;
     }
 
     protected RepositoryItemUidFactory getRepositoryItemUidFactory()

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -178,7 +178,7 @@
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
-    <plexus-task-scheduler.version>1.4.3</plexus-task-scheduler.version>
+    <plexus-task-scheduler.version>1.5.0-SNAPSHOT</plexus-task-scheduler.version>
     <plexus-velocity.version>1.1.7</plexus-velocity.version>
     <restlet.version>1.1.6-SONATYPE-5348-V4</restlet.version>
     <shiro.version>1.1.0</shiro.version>


### PR DESCRIPTION
Step3: pulling in fixed Scheduler and fixes to scheduler config.
- tasks config was locking wrong object for some time, ApplicationConfig is just a
  "proxy" since long time (see ApplicationConfigurationAdapter)
- tasks config moved to proper module to get a handle on proper object to lock on
- Nexus now manages the lifecycle of scheduler

Also, see _what_ are we about to pull in:
https://github.com/sonatype/sisu-task-scheduler/pull/5
