### PR TITLE
Smaller fixes.

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1089/Nexus1089SecureProxyIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/proxy/nexus1089/Nexus1089SecureProxyIT.java
@@ -27,26 +27,29 @@ import org.testng.annotations.Test;
 public class Nexus1089SecureProxyIT
     extends AbstractNexusProxyIntegrationTest
 {
+    protected ServletServer secureProxyServer = null;
 
     @Override
-    @BeforeMethod(alwaysRun = true)
+    @BeforeMethod( alwaysRun = true )
     public void startProxy()
         throws Exception
     {
-        ServletServer server = lookup( ServletServer.class, "secure" );
-        server.start();
+        secureProxyServer = lookup( ServletServer.class, "secure" );
+        secureProxyServer.start();
     }
 
     @Override
-    @AfterMethod(alwaysRun = true)
+    @AfterMethod( alwaysRun = true )
     public void stopProxy()
         throws Exception
     {
-        ServletServer server = lookup( ServletServer.class, "secure" );
-        server.stop();
+        if ( secureProxyServer != null )
+        {
+            secureProxyServer.stop();
+        }
     }
 
-    @Test(groups = PROXY)
+    @Test( groups = PROXY )
     public void downloadArtifact()
         throws Exception
     {

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -779,7 +779,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
         <type>jar</type>
       </dependency>
       <dependency>


### PR DESCRIPTION
- bumping xstream from 1.4.1 to 1.4.2 -- small if no impact, this is 1st release with greater then 1.3.x xstream, so make it with today's latest
- IT fix, to avoid NPE when ITs are failing
