### PR TITLE
o [NEXUS-4778] Wait for async events after reindex tasks

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/SearchMessageUtil.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/SearchMessageUtil.java
@@ -654,6 +654,8 @@ public class SearchMessageUtil
 
         // let s w8 a few time for indexes
         TaskScheduleUtil.waitForAllTasksToStop();
+        // be safe and wait for async events as well
+        new EventInspectorsUtil( RequestFacade.getNexusRestClient() ).waitForCalmPeriod();
     }
 
     /**


### PR DESCRIPTION
Nothing obvious wrong with the failing test, so this is just taking a guess.
