### PR TITLE
NXCM-3808: expose bundle-basedir property to jetty context

### DIFF
--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/src/main/conf/jetty.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-packaging/src/main/conf/jetty.xml
@@ -54,7 +54,7 @@
 
     <New id="ArtifactoryContext" class="org.eclipse.jetty.webapp.WebAppContext">
       <Arg><Ref id="Contexts"/></Arg>
-      <Arg>${bundleBasedir}/artifactory-bridge</Arg>
+      <Arg>${bundle-basedir}/artifactory-bridge</Arg>
       <Arg>/artifactory</Arg>
       <Set name="extractWAR">false</Set>
     </New>

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
@@ -7,6 +7,7 @@ application-port=8081
 application-host=0.0.0.0
 nexus-webapp=${bundleBasedir}/nexus
 nexus-webapp-context-path=/nexus
+bundle-basedir=${bundleBasedir}
 
 # Nexus section
 nexus-work=${bundleBasedir}/../sonatype-work/nexus

--- a/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/nexus.properties
+++ b/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/nexus.properties
@@ -7,6 +7,7 @@ application-port=8081
 application-host=0.0.0.0
 nexus-webapp=${bundleBasedir}/nexus
 nexus-webapp-context-path=/nexus
+bundle-basedir=${bundleBasedir}
 
 # Nexus section
 #nexus-work=${bundleBasedir}/../sonatype-work/nexus


### PR DESCRIPTION
Appcontext 2.0 appears to only expose properties that are explicitly listed in nexus.properties. This breaks the use of ${bundleBasedir} in the custom jetty.xml from the nexus-migration-plugin. The simplest fix appears to be to change this line to use ${bundle-basedir} and export "bundle-basedir=${bundleBasedir}" in nexus.properties. However, if someone can provide a more correct fix then I'm happy to close this pull-request in favour of that.

(Note that the nexus-migration-plugin application context is constructed before the PlexusContainerContextListener fires.)
