### PR TITLE
Boot simplification

### DIFF
--- a/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
+++ b/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
@@ -105,6 +105,11 @@
         <include>org.sonatype.plexus:*</include>
         <include>org.sonatype.appcontext:*</include>
       </includes>
+      <!-- Ultimately should be removed (needs changes in AppContext)
+      <excludes>
+        <exclude>org.codehaus.plexus:plexus-classworlds</exclude>
+      </excludes>
+      -->
       <useProjectArtifact>false</useProjectArtifact>
       <unpack>false</unpack>
       <useTransitiveDependencies>false</useTransitiveDependencies>

--- a/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -15,11 +15,11 @@ wrapper.working.dir=../../..
 wrapper.java.command=java
 
 # The main class that JSW will execute within JVM
-wrapper.java.mainclass=org.codehaus.plexus.classworlds.launcher.Launcher
+wrapper.java.mainclass=org.sonatype.plexus.jetty.Jetty7WrapperListener
 
 # The JVM classpath
 wrapper.java.classpath.1=bin/jsw/lib/wrapper-3.2.3.jar
-wrapper.java.classpath.2=./lib/plexus-classworlds-*.jar
+wrapper.java.classpath.2=./lib/*.jar
 wrapper.java.classpath.3=./conf/
 
 # The library path
@@ -27,7 +27,7 @@ wrapper.java.library.path.1=bin/jsw/lib
 
 # Additional JVM parameters (tune if needed, but match the sequence of numbers!)
 wrapper.java.additional.1=-Dsun.net.inetaddr.ttl=3600
-wrapper.java.additional.2=-DbundleBasedir=.
+wrapper.java.additional.2=-Djetty.bundleBasedir=.
 wrapper.java.additional.3=-Djava.io.tmpdir=./tmp
 wrapper.java.additional.4=-DjettyContext=nexus.properties
 wrapper.java.additional.5=-DjettyPlexusCompatibility=true

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
@@ -1,4 +1,0 @@
-main is org.sonatype.plexus.jetty.Jetty7WrapperListener from plexus.core
-
-[plexus.core]
-   load ${bundleBasedir}/lib/*.jar


### PR DESCRIPTION
Simplifies boot process, and also lessens memory consumption (by not creating a ClassWorld at place where it is unused anyway).

We should leave out Plexus Classworlds from the "top" of boot hierarchy,
as we do not gain anything with it, only complicate things.

This change is for eyes only, would break today's OSS ITs and Pro bundle!
