### PR TITLE
[discuss] NXCM-3821: grant API-Key privilege to admin and deployment roles

### DIFF
--- a/nexus/nexus-app/src/main/resources/META-INF/nexus/static-security.xml
+++ b/nexus/nexus-app/src/main/resources/META-INF/nexus/static-security.xml
@@ -26,6 +26,7 @@
             <privileges>
                 <privilege>1000</privilege>
                 <privilege>1001</privilege> <!-- Security Admin -->
+                <privilege>83</privilege> <!-- API-Key Access -->
             </privileges>
             <roles />
         </role>
@@ -34,6 +35,9 @@
             <name>Nexus Deployment Role</name>
             <description>Deployment role for Nexus</description>
             <sessionTimeout>60</sessionTimeout>
+            <privileges>
+                <privilege>83</privilege> <!-- API-Key Access -->
+            </privileges>
             <roles>
                 <role>anonymous</role>
                 <role>ui-basic</role>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1170/Nexus1170ReducePermissionCheckingIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1170/Nexus1170ReducePermissionCheckingIT.java
@@ -56,15 +56,7 @@ public class Nexus1170ReducePermissionCheckingIT
 
         for ( ClientPermission clientPermission : permissions )
         {
-            if ( "apikey:access".equals( clientPermission.getId() ) )
-            {
-                // admin user should NOT have API-key access by default
-                Assert.assertEquals( 0, clientPermission.getValue() );
-            }
-            else
-            {
-                Assert.assertEquals( 15, clientPermission.getValue() );
-            }
+            Assert.assertEquals( 15, clientPermission.getValue() );
         }
     }
 
@@ -119,6 +111,8 @@ public class Nexus1170ReducePermissionCheckingIT
         this.checkPermission( permissions, "nexus:componentrealmtypes", 0 );
         this.checkPermission( permissions, "nexus:componentsrepotypes", 1 );
         this.checkPermission( permissions, "security:componentsuserlocatortypes", 0 );
+
+        this.checkPermission( permissions, "apikey:access", 15 );
 
         for ( ClientPermission outPermission : permissions )
         {


### PR DESCRIPTION
CI build: https://builds.sonatype.org/job/nexus-oss-its-feature/187/

Discussion: should both admin and deployment roles have this privilege? Or just admin? Or neither by default?
