### PR TITLE
Bumping Jetty version to just released 8.1.0

### DIFF
--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
@@ -103,7 +103,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
@@ -177,8 +177,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-artifactory/pom.xml
@@ -221,7 +221,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-test-harness/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-migration-plugin/nexus-migration-plugin-test-harness/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nexus/nexus-logging-extras/pom.xml
+++ b/nexus/nexus-logging-extras/pom.xml
@@ -59,7 +59,7 @@
     <!-- We have servlet util classes too -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <!-- Testing -->

--- a/nexus/nexus-oss-webapp/pom.xml
+++ b/nexus/nexus-oss-webapp/pom.xml
@@ -67,6 +67,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.0.1</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/nexus/nexus-oss-webapp/pom.xml
+++ b/nexus/nexus-oss-webapp/pom.xml
@@ -29,7 +29,7 @@
   <name>Nexus : Distros : Nexus OSS Bundle</name>
 
   <properties>
-    <jetty.version>7.5.4.v20111024</jetty.version>
+    <jetty.version>8.1.0.v20120127</jetty.version>
   </properties>
 
   <dependencies>
@@ -65,8 +65,8 @@
     <!--  The Jetty itself -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <scope>compile</scope>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
     </dependency>
 
     <dependency>

--- a/nexus/nexus-rest-api/pom.xml
+++ b/nexus/nexus-rest-api/pom.xml
@@ -99,7 +99,7 @@
     <!-- This module does depend as "compile", also, plugin depending on this module needs it too -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
 

--- a/nexus/nexus-test-harness/nexus-test-harness-selenium/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-selenium/pom.xml
@@ -213,7 +213,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/nexus/nexus-web-utils/pom.xml
+++ b/nexus/nexus-web-utils/pom.xml
@@ -49,7 +49,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/nexus/nexus-webapp/pom.xml
+++ b/nexus/nexus-webapp/pom.xml
@@ -45,7 +45,7 @@
     <!-- This is here to prevent it coming into WAR -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -735,8 +735,8 @@
       <!-- Various commonly used deps -->
       <dependency>
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>3.0.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This bumps Jetty version to 8.1.0 and ServletAPI version to 3.0

As last released Nexus (1.9.2.4) used ancient Jetty 6.x line, we should keep up and make a step to latest one. 
