### PR TITLE
NXCM-3808: A better fix

### DIFF
--- a/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -30,12 +30,13 @@ wrapper.java.additional.1=-Dsun.net.inetaddr.ttl=3600
 wrapper.java.additional.2=-DbundleBasedir=.
 wrapper.java.additional.3=-Djava.io.tmpdir=./tmp
 wrapper.java.additional.4=-DjettyContext=nexus.properties
-wrapper.java.additional.5=-DjettyPlexusCompatibility=true
-#wrapper.java.additional.6=-Xdebug
-#wrapper.java.additional.7=-Xnoagent
-#wrapper.java.additional.8=-Djava.compiler=NONE
-#wrapper.java.additional.9=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#wrapper.java.additional.10=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.5=-DjettyContextIncludeKeys=bundleBasedir
+wrapper.java.additional.6=-DjettyPlexusCompatibility=true
+#wrapper.java.additional.7=-Xdebug
+#wrapper.java.additional.8=-Xnoagent
+#wrapper.java.additional.9=-Djava.compiler=NONE
+#wrapper.java.additional.10=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#wrapper.java.additional.11=-XX:+HeapDumpOnOutOfMemoryError
 
 wrapper.app.parameter.1=./conf/jetty.xml
 

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
@@ -1,4 +1,4 @@
-main is org.sonatype.plexus.jetty.Jetty7WrapperListener from plexus.core
+main is org.sonatype.plexus.jetty.Jetty7CWEnhancedWrapperListener from plexus.core
 
 [plexus.core]
    load ${bundleBasedir}/lib/*.jar

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -174,7 +174,7 @@
     <plexus-ehcache.version>1.3</plexus-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
-    <plexus-jetty7.version>1.1</plexus-jetty7.version>
+    <plexus-jetty7.version>1.2</plexus-jetty7.version>
     <plexus-jetty-testsuite.version>1.8</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -174,7 +174,7 @@
     <plexus-ehcache.version>1.3</plexus-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
-    <plexus-jetty7.version>1.0</plexus-jetty7.version>
+    <plexus-jetty7.version>1.1</plexus-jetty7.version>
     <plexus-jetty-testsuite.version>1.8</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
@@ -239,7 +239,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>2.0</version>
+        <version>2.1-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -239,7 +239,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Added support for custom key inclusions into Jetty7 AppContext.

This makes the "bundleBasedir" system property enlisted for inclusion.

To verify: just modify jetty.xml and instead of "${nexus-webapp}" use "${bundleBasedir}/nexus".

This also opens up possibilities in future (ie. new keys needed on context)
