### PR TITLE
(2.1)Boot simplification.

### DIFF
--- a/nexus/nexus-oss-webapp/pom.xml
+++ b/nexus/nexus-oss-webapp/pom.xml
@@ -55,10 +55,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-classworlds</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
 

--- a/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -15,11 +15,11 @@ wrapper.working.dir=../../..
 wrapper.java.command=java
 
 # The main class that JSW will execute within JVM
-wrapper.java.mainclass=org.codehaus.plexus.classworlds.launcher.Launcher
+wrapper.java.mainclass=org.sonatype.plexus.jetty.Jetty7WrapperListener
 
 # The JVM classpath
 wrapper.java.classpath.1=bin/jsw/lib/wrapper-3.2.3.jar
-wrapper.java.classpath.2=./lib/plexus-classworlds-*.jar
+wrapper.java.classpath.2=./lib/*.jar
 wrapper.java.classpath.3=./conf/
 
 # The library path

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/classworlds.conf
@@ -1,4 +1,0 @@
-main is org.sonatype.plexus.jetty.Jetty7CWEnhancedWrapperListener from plexus.core
-
-[plexus.core]
-   load ${bundleBasedir}/lib/*.jar

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-ajp.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-ajp.xml
@@ -52,14 +52,6 @@
   
   <Set name="handler">
     <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-             It makes the Plexus container available for use in the Nexus webapp. -->
-        <Call name="addLifeCycleListener">
-            <Arg>
-              <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-            </Arg>
-        </Call>
-  
         <!-- The following configuration disables JSP taglib support, the validation of which
              slows down Jetty's startup significantly. -->
         <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-dual-ports-with-ssl.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-dual-ports-with-ssl.xml
@@ -49,14 +49,6 @@
     </Call>
     
     <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-             It makes the Plexus container available for use in the Nexus webapp. -->
-        <Call name="addLifeCycleListener">
-            <Arg>
-              <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-            </Arg>
-        </Call>
-  
         <!-- The following configuration disables JSP taglib support, the validation of which
              slows down Jetty's startup significantly. -->
         <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-faster-windows.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-faster-windows.xml
@@ -42,14 +42,6 @@
     
     <Set name="handler">
       <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-          <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-               It makes the Plexus container available for use in the Nexus webapp. -->
-          <Call name="addLifeCycleListener">
-              <Arg>
-                <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-              </Arg>
-          </Call>
-    
           <!-- The following configuration disables JSP taglib support, the validation of which
                slows down Jetty's startup significantly. -->
           <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-header-buffer.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-header-buffer.xml
@@ -44,14 +44,6 @@
     
     <Set name="handler">
       <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-          <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-               It makes the Plexus container available for use in the Nexus webapp. -->
-          <Call name="addLifeCycleListener">
-              <Arg>
-                <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-              </Arg>
-          </Call>
-    
           <!-- The following configuration disables JSP taglib support, the validation of which
                slows down Jetty's startup significantly. -->
           <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-jmx.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-jmx.xml
@@ -36,14 +36,6 @@
 
     <Set name="handler">
         <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-            <!-- The following configuration is REQUIRED, and MUST BE FIRST.
-                 It makes the Plexus container available for use in the Nexus webapp. -->
-            <Call name="addLifeCycleListener">
-                <Arg>
-                    <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener"/>
-                </Arg>
-            </Call>
-
             <!-- The following configuration disables JSP taglib support, the validation of which
                  slows down Jetty's startup significantly. -->
             <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-simple-https-proxy.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-simple-https-proxy.xml
@@ -42,14 +42,6 @@
     </Call>
     
     <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-             It makes the Plexus container available for use in the Nexus webapp. -->
-        <Call name="addLifeCycleListener">
-            <Arg>
-              <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-            </Arg>
-        </Call>
-  
         <!-- The following configuration disables JSP taglib support, the validation of which
              slows down Jetty's startup significantly. -->
         <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-ssl.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty-ssl.xml
@@ -42,14 +42,6 @@
     
     <Set name="handler">
       <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-          <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-               It makes the Plexus container available for use in the Nexus webapp. -->
-          <Call name="addLifeCycleListener">
-              <Arg>
-                <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-              </Arg>
-          </Call>
-    
           <!-- The following configuration disables JSP taglib support, the validation of which
                slows down Jetty's startup significantly. -->
           <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/jetty.xml
@@ -34,14 +34,6 @@
     
     <Set name="handler">
       <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-          <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-               It makes the Plexus container available for use in the Nexus webapp. -->
-          <Call name="addLifeCycleListener">
-              <Arg>
-                <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-              </Arg>
-          </Call>
-    
           <!-- The following configuration disables JSP taglib support, the validation of which
                slows down Jetty's startup significantly. -->
           <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/proxy-https/jetty.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/examples/proxy-https/jetty.xml
@@ -42,14 +42,6 @@
     </Call>
     
     <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-        <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-             It makes the Plexus container available for use in the Nexus webapp. -->
-        <Call name="addLifeCycleListener">
-            <Arg>
-              <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-            </Arg>
-        </Call>
-  
         <!-- The following configuration disables JSP taglib support, the validation of which
              slows down Jetty's startup significantly. -->
         <Call name="addLifeCycleListener">

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
@@ -34,14 +34,6 @@
     
     <Set name="handler">
       <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
-          <!-- The following configuration is REQUIRED, and MUST BE FIRST. 
-               It makes the Plexus container available for use in the Nexus webapp. -->
-          <Call name="addLifeCycleListener">
-              <Arg>
-                <New class="org.sonatype.plexus.jetty.custom.InjectExistingPlexusListener" />
-              </Arg>
-          </Call>
-    
           <!-- The following configuration disables JSP taglib support, the validation of which
                slows down Jetty's startup significantly. -->
           <Call name="addLifeCycleListener">


### PR DESCRIPTION
- Remove unneeded Plexus ClassWorlds Launcher from boot (JSW boots Jetty directly)
- the change above removes the "blocked forever" main Java thread too (was needed, since Launcher would call System.exit if main methods returns). It is just confusing and makes thread dump misleading for people not knowing about this above...
- remove Plexus Classworlds from "shared" libs completely, is unneded
- update all Jetty XML configurations and removing hack, as the hack in there is not needed anymore (actually, not coz of this change, but is unneeded since we made Nexus WAR, Plexus is booted within WAR, not from "outside" of it anymore, Plexus is _never injected_ by this class since that change)

This modifies how JSW boots bundle, but should not affect other stuff like ITs

NOT FOR 2.0!
