### PR TITLE
Added GlobalHttpProxySettingsChangedEvent to help updating HTTP clients ...

### DIFF
--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/configuration/application/DefaultGlobalHttpProxySettingsTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/configuration/application/DefaultGlobalHttpProxySettingsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.configuration.application;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.sonatype.nexus.AbstractNexusTestCase;
+import org.sonatype.nexus.configuration.application.events.GlobalHttpProxySettingsChangedEvent;
+import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
+import org.sonatype.plexus.appevents.Event;
+import org.sonatype.plexus.appevents.EventListener;
+
+public class DefaultGlobalHttpProxySettingsTest
+    extends AbstractNexusTestCase
+{
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void testEvents()
+        throws Exception
+    {
+        NexusConfiguration cfg = lookup( NexusConfiguration.class );
+        cfg.loadConfiguration();
+
+        final Event<GlobalHttpProxySettings>[] event = new Event[1];
+        ApplicationEventMulticaster applicationEventMulticaster = lookup( ApplicationEventMulticaster.class );
+        applicationEventMulticaster.addEventListener( new EventListener()
+        {
+            public void onEvent( Event<?> evt )
+            {
+                if ( evt instanceof GlobalHttpProxySettingsChangedEvent )
+                {
+                    event[0] = (GlobalHttpProxySettingsChangedEvent) evt;
+                }
+            }
+        } );
+
+        GlobalHttpProxySettings settings = lookup( GlobalHttpProxySettings.class );
+
+        settings.setHostname( "foo.bar.com" );
+        settings.setPort( 1234 );
+        cfg.saveConfiguration();
+
+        Assert.assertNotNull( event[0].getEventSender() );
+        Assert.assertEquals( settings, event[0].getEventSender() );
+        Assert.assertEquals( "foo.bar.com", event[0].getEventSender().getHostname() );
+        Assert.assertEquals( 1234, event[0].getEventSender().getPort() );
+
+    }
+}

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/DefaultGlobalHttpProxySettings.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/DefaultGlobalHttpProxySettings.java
@@ -13,10 +13,8 @@
 package org.sonatype.nexus.configuration.application;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.codehaus.plexus.component.annotations.Component;
@@ -25,6 +23,7 @@ import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.nexus.configuration.AbstractConfigurable;
 import org.sonatype.nexus.configuration.Configurator;
 import org.sonatype.nexus.configuration.CoreConfiguration;
+import org.sonatype.nexus.configuration.application.events.GlobalHttpProxySettingsChangedEvent;
 import org.sonatype.nexus.configuration.model.CGlobalHttpProxySettingsCoreConfiguration;
 import org.sonatype.nexus.configuration.model.CRemoteHttpProxySettings;
 import org.sonatype.nexus.proxy.repository.DefaultRemoteProxySettings;
@@ -268,4 +267,19 @@ public class DefaultGlobalHttpProxySettings
 
         getCurrentConfiguration( true ).setNonProxyHosts( new ArrayList<String>( nonProxyHosts ) );
     }
+
+    @Override
+    public boolean commitChanges()
+        throws ConfigurationException
+    {
+        boolean wasDirty = super.commitChanges();
+
+        if ( wasDirty )
+        {
+            getApplicationEventMulticaster().notifyEventListeners( new GlobalHttpProxySettingsChangedEvent( this ) );
+        }
+
+        return wasDirty;
+    }
+
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalHttpProxySettingsChangedEvent.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalHttpProxySettingsChangedEvent.java
@@ -1,0 +1,35 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.configuration.application.events;
+
+import org.sonatype.nexus.configuration.application.GlobalHttpProxySettings;
+import org.sonatype.plexus.appevents.AbstractEvent;
+
+/**
+ * @since 2.0
+ */
+public class GlobalHttpProxySettingsChangedEvent
+    extends AbstractEvent<GlobalHttpProxySettings>
+{
+
+    public GlobalHttpProxySettingsChangedEvent( GlobalHttpProxySettings settings )
+    {
+        super( settings );
+    }
+
+    public GlobalHttpProxySettings getGlobalHttpProxySettings()
+    {
+        return getEventSender();
+    }
+
+}


### PR DESCRIPTION
...when network related configuration changed, similar to existing GlobalRemoteConnectionSettingsChangedEvent

The code we currently have in AhcProviderEventInspector resets HTTP clients too often since it does so for any configuration change, regardless whether it affects the HTTP clients or not.
