### PR TITLE
Fixed gitattributes for text files of test repositories which are to be ...

### DIFF
--- a/nexus/nexus-proxy/src/test/resources/.gitattributes
+++ b/nexus/nexus-proxy/src/test/resources/.gitattributes
@@ -1,0 +1,2 @@
+*.pom              -text -crlf
+maven-metadata.xml -text -crlf


### PR DESCRIPTION
...treated as binary as otherwise checksum errors will occur (on Windows)
