### PR TITLE
Fix for rare race condition.

### DIFF
--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationEventInspector.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/maven/tasks/Nexus4588CancellationEventInspector.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.maven.tasks;
 
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.RepositoryEventExpireCaches;
-import org.sonatype.nexus.proxy.events.RepositoryItemEventRetrieve;
 import org.sonatype.plexus.appevents.Event;
 import org.sonatype.scheduling.TaskUtil;
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
@@ -56,7 +56,8 @@ public class IndexingRepositoryRegistryRepositoryAsyncEventInspector
 
     public boolean accepts( Event<?> evt )
     {
-        return ( evt instanceof RepositoryRegistryRepositoryEvent )
+        return applicationStatusSource.getSystemStatus().isNexusStarted()
+            && ( evt instanceof RepositoryRegistryRepositoryEvent )
             || ( evt instanceof RepositoryConfigurationUpdatedEvent );
     }
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
@@ -99,7 +99,7 @@ public class IndexingRepositoryRegistryRepositoryAsyncEventInspector
             if ( evt instanceof RepositoryRegistryEventAdd )
             {
                 // create the initial index
-                if ( applicationStatusSource.getSystemStatus().isNexusStarted() && repository.isIndexable() )
+                if ( repository.isIndexable() )
                 {
                     // Create the initial index for the repository
                     reindexRepo( repository, false, "Creating initial index, repositoryId=" + repository.getId() );

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryAsyncEventInspector.java
@@ -56,9 +56,8 @@ public class IndexingRepositoryRegistryRepositoryAsyncEventInspector
 
     public boolean accepts( Event<?> evt )
     {
-        return applicationStatusSource.getSystemStatus().isNexusStarted()
-            && ( evt instanceof RepositoryRegistryRepositoryEvent )
-            || ( evt instanceof RepositoryConfigurationUpdatedEvent );
+        return ( ( evt instanceof RepositoryRegistryRepositoryEvent ) || ( evt instanceof RepositoryConfigurationUpdatedEvent ) )
+            && applicationStatusSource.getSystemStatus().isNexusStarted();
     }
 
     public void inspect( Event<?> evt )

--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/record/AbstractFeedRecorderEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/record/AbstractFeedRecorderEventInspector.java
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.feeds.record;
 
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.sonatype.nexus.ApplicationStatusSource;
 import org.sonatype.nexus.feeds.FeedRecorder;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
 
@@ -25,8 +26,21 @@ public abstract class AbstractFeedRecorderEventInspector
     @Requirement
     private FeedRecorder feedRecorder;
 
+    @Requirement
+    private ApplicationStatusSource applicationStatusSource;
+
     protected FeedRecorder getFeedRecorder()
     {
         return feedRecorder;
+    }
+
+    protected ApplicationStatusSource getApplicationStatusSource()
+    {
+        return applicationStatusSource;
+    }
+
+    protected boolean isNexusStarted()
+    {
+        return getApplicationStatusSource().getSystemStatus().isNexusStarted();
     }
 }

--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/record/NexusBootEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/src/main/java/org/sonatype/nexus/feeds/record/NexusBootEventInspector.java
@@ -13,8 +13,6 @@
 package org.sonatype.nexus.feeds.record;
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.sonatype.nexus.ApplicationStatusSource;
 import org.sonatype.nexus.feeds.FeedRecorder;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
@@ -31,9 +29,6 @@ import org.sonatype.plexus.appevents.Event;
 public class NexusBootEventInspector
     extends AbstractFeedRecorderEventInspector
 {
-    @Requirement
-    private ApplicationStatusSource applicationStatusSource;
-
     @Override
     public boolean accepts( Event<?> evt )
     {
@@ -45,15 +40,17 @@ public class NexusBootEventInspector
     {
         if ( evt instanceof NexusStartedEvent )
         {
-            getFeedRecorder().addSystemEvent( FeedRecorder.SYSTEM_BOOT_ACTION, "Started Nexus (version "
-                + applicationStatusSource.getSystemStatus().getVersion() + " "
-                + applicationStatusSource.getSystemStatus().getEditionShort() + ")" );
+            getFeedRecorder().addSystemEvent(
+                FeedRecorder.SYSTEM_BOOT_ACTION,
+                "Started Nexus (version " + getApplicationStatusSource().getSystemStatus().getVersion() + " "
+                    + getApplicationStatusSource().getSystemStatus().getEditionShort() + ")" );
         }
         else if ( evt instanceof NexusStoppedEvent )
         {
-            getFeedRecorder().addSystemEvent( FeedRecorder.SYSTEM_BOOT_ACTION, "Stopping Nexus (version "
-                + applicationStatusSource.getSystemStatus().getVersion() + " "
-                + applicationStatusSource.getSystemStatus().getEditionShort() + ")" );
+            getFeedRecorder().addSystemEvent(
+                FeedRecorder.SYSTEM_BOOT_ACTION,
+                "Stopping Nexus (version " + getApplicationStatusSource().getSystemStatus().getVersion() + " "
+                    + getApplicationStatusSource().getSystemStatus().getEditionShort() + ")" );
         }
     }
 


### PR DESCRIPTION
I had this happened once, and might be related to what Alin reported this morning too:
the update indexes task started to run "out of the blue" of my just booted Nexus (virgin).
It was 1st start, so no configuration preexisted either.

What happened is due the async nature of this event inspector, and the fact
how it tried to discover "should the event be handled". Boot process does emit events
this inspector listens to! But, due to "burst" nature of boot, it is possible that the inspect
method executes when the process is actually done, but is about to process an event sent
during boot (is async).

By moving that Nexus "state check" to the accept() method, that
is executed synchronously (!) we are shielded against this.
