### PR TITLE
NEXUS-4831 - Failed Nexus3882IPAtAthenticationFailureFeedIT.failAuthentication

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
@@ -31,7 +31,7 @@ import com.sun.syndication.feed.synd.SyndEntry;
 import com.sun.syndication.feed.synd.SyndFeed;
 
 /**
- * Tests for deployment entries in feeds.
+ * Tests for fail to login entries in feeds.
  */
 public class Nexus3882IPAtAthenticationFailureFeedIT
     extends AbstractPrivilegeTest

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
@@ -12,14 +12,14 @@
  */
 package org.sonatype.nexus.integrationtests.nexus3882;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.sonatype.nexus.test.utils.StatusMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.sonatype.nexus.test.utils.NexusRequestMatchers.hasStatusCode;
+import static org.sonatype.nexus.test.utils.StatusMatchers.isError;
 
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.restlet.data.Status;
 import org.sonatype.nexus.integrationtests.AbstractPrivilegeTest;
 import org.sonatype.nexus.integrationtests.TestContainer;
 import org.sonatype.nexus.test.utils.FeedUtil;
@@ -45,7 +45,10 @@ public class Nexus3882IPAtAthenticationFailureFeedIT
         TestContainer.getInstance().getTestContext().setUsername( "juka" );
         TestContainer.getInstance().getTestContext().setPassword( "juka" );
 
-        assertThat( UserCreationUtil.login(), isError() );
+        assertThat( UserCreationUtil.login(), hasStatusCode( 401 ) );
+
+        // NexusAuthenticationEventInspector is asynchronous
+        getEventInspectorsUtil().waitForCalmPeriod();
 
         TestContainer.getInstance().getTestContext().useAdminForRequests();
 

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3882/Nexus3882IPAtAthenticationFailureFeedIT.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.integrationtests.nexus3882;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.sonatype.nexus.test.utils.NexusRequestMatchers.hasStatusCode;
-import static org.sonatype.nexus.test.utils.StatusMatchers.isError;
 
 import java.util.List;
 import java.util.regex.Matcher;


### PR DESCRIPTION
Feed entry happen with an async event, so ITs need to wait for all async event to finish processing before it can grab results.
