### PR TITLE
Harmonized handling of thread interruption during sleep period of thrott...

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -343,7 +343,15 @@ public class DefaultWalker
 
                 if ( throttleTime > 0 )
                 {
-                    Thread.sleep( throttleTime );
+                    try
+                    {
+                        Thread.sleep( throttleTime );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        throw new TaskInterruptedException( "Thread \"" + Thread.currentThread().getName()
+                            + "\" is interrupted!", false );
+                    }
                 }
             }
         }


### PR DESCRIPTION
...le controller with DefaultWalkerContext.isStopped()/TaskUtil.checkInterruption, throwing TaskInterruptedException instead of InterruptedException helps with AbstractNexusTask.call() and its logging/eventing, i.e. cancellation instead of error
