### PR TITLE
WalkerProcessor processItem method is invoked only of non-collection items

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalkerContext.java
@@ -29,8 +29,6 @@ public class DefaultWalkerContext
 
     private final WalkerFilter walkerFilter;
 
-    private final boolean collectionsOnly;
-
     private final ResourceStoreRequest request;
 
     private final WalkerThrottleController throttleController;
@@ -50,11 +48,11 @@ public class DefaultWalkerContext
 
     public DefaultWalkerContext( Repository store, ResourceStoreRequest request, WalkerFilter filter )
     {
-        this( store, request, filter, true, false );
+        this( store, request, filter, true );
     }
 
     public DefaultWalkerContext( Repository store, ResourceStoreRequest request, WalkerFilter filter,
-                                 boolean localOnly, boolean collectionsOnly )
+                                 boolean localOnly )
     {
         super();
 
@@ -63,8 +61,6 @@ public class DefaultWalkerContext
         this.request = request;
 
         this.walkerFilter = filter;
-
-        this.collectionsOnly = collectionsOnly;
 
         this.running = true;
 
@@ -83,12 +79,6 @@ public class DefaultWalkerContext
     public boolean isLocalOnly()
     {
         return request.isRequestLocalOnly();
-    }
-
-    @Override
-    public boolean isCollectionsOnly()
-    {
-        return collectionsOnly;
     }
 
     @Override

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/WalkerContext.java
@@ -40,13 +40,6 @@ public interface WalkerContext
     boolean isLocalOnly();
 
     /**
-     * The WalkerProcessors will get notified only on collections.
-     * 
-     * @return
-     */
-    boolean isCollectionsOnly();
-
-    /**
      * Returns the context.
      * 
      * @return

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -211,11 +211,6 @@ public class DefaultWalker
             return collCount;
         }
 
-        if ( context.isStopped() )
-        {
-            return collCount;
-        }
-
         Collection<StorageItem> ls = null;
 
         if ( shouldProcessRecursively )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/walker/DefaultWalker.java
@@ -211,12 +211,6 @@ public class DefaultWalker
             return collCount;
         }
 
-        // user may call stop()
-        if ( shouldProcess )
-        {
-            processItem( context, coll );
-        }
-
         if ( context.isStopped() )
         {
             return collCount;
@@ -230,7 +224,7 @@ public class DefaultWalker
 
             for ( StorageItem i : ls )
             {
-                if ( !context.isCollectionsOnly() && !StorageCollectionItem.class.isAssignableFrom( i.getClass() ) )
+                if (  !(i instanceof StorageCollectionItem) )
                 {
                     if ( filter.shouldProcess( context, i ) )
                     {
@@ -244,7 +238,7 @@ public class DefaultWalker
                     }
                 }
 
-                if ( StorageCollectionItem.class.isAssignableFrom( i.getClass() ) )
+                if ( i instanceof StorageCollectionItem )
                 {
                     // user may call stop()
                     collCount = walkRecursive( collCount, context, filter, (StorageCollectionItem) i );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/walker/WalkerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/walker/WalkerTest.java
@@ -93,7 +93,7 @@ public class WalkerTest
 
         Assert.assertEquals( 10, wp.collEnters );
         Assert.assertEquals( 10, wp.collExits );
-        Assert.assertEquals( 10, wp.colls );
+        Assert.assertEquals( 0, wp.colls );
         Assert.assertEquals( 4, wp.files );
         Assert.assertEquals( 0, wp.links );
     }


### PR DESCRIPTION
Historically, processItem was invoked for all kind of items, even collections.
As it turns out, we have NO WalkerProcessor that actually uses this, all of them
eagerly test for collections and simply do nothing. Another nice example is
SnapshotRemover, it's WalkerProcessor -- that IS interested in collections only
has empty processItem method (!), and performs all his work in onCollectionExit
method.
