### PR TITLE
Slight changes for Marshaller's.

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -28,6 +28,7 @@ import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
 
+import com.google.common.base.Preconditions;
 import com.google.common.io.Closeables;
 
 /**
@@ -59,13 +60,18 @@ public class DefaultFSAttributeStorage
      * @param applicationConfiguration
      */
     @Inject
-    public DefaultFSAttributeStorage( final ApplicationConfiguration applicationConfiguration,
-                                      @Named( "xstream-xml" ) final Marshaller marshaller )
+    public DefaultFSAttributeStorage( final ApplicationConfiguration applicationConfiguration )
     {
-        this.applicationConfiguration = applicationConfiguration;
-        this.marshaller = marshaller;
+        this( applicationConfiguration, new JacksonJSONMarshaller() );
+    }
+
+    public DefaultFSAttributeStorage( final ApplicationConfiguration applicationConfiguration,
+                                      final Marshaller marshaller )
+    {
+        this.applicationConfiguration = Preconditions.checkNotNull( applicationConfiguration );
+        this.marshaller = Preconditions.checkNotNull( marshaller );
         this.workingDirectory = initializeWorkingDirectory();
-        getLogger().info( "Default FS AttributeStorage in place." );
+        getLogger().info( "Default FS AttributeStorage in place, using {} marshaller.", marshaller );
     }
 
     public synchronized File initializeWorkingDirectory()

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -34,6 +34,8 @@ import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
 
+import com.google.common.base.Preconditions;
+
 /**
  * AttributeStorage implementation that uses LocalRepositoryStorage of repositories to store attributes "along" the
  * artifacts (well, not along but in same storage but hidden).
@@ -55,10 +57,18 @@ public class DefaultLSAttributeStorage
      * Instantiates a new FSX stream attribute storage.
      */
     @Inject
-    public DefaultLSAttributeStorage( @Named( "jackson-json" ) final Marshaller marshaller )
+    public DefaultLSAttributeStorage()
     {
-        this.marshaller = marshaller;
-        getLogger().info( "Default LS AttributeStorage in place." );
+        this( new JacksonJSONMarshaller() );
+    }
+
+    /**
+     * Instantiates a new FSX stream attribute storage.
+     */
+    public DefaultLSAttributeStorage( final Marshaller marshaller )
+    {
+        this.marshaller = Preconditions.checkNotNull( marshaller );
+        getLogger().info( "Default FS AttributeStorage in place, using {} marshaller.", marshaller );
     }
 
     public boolean deleteAttributes( final RepositoryItemUid uid )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/JacksonJSONMarshaller.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/JacksonJSONMarshaller.java
@@ -18,9 +18,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
+import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.sonatype.nexus.proxy.attributes.internal.DefaultAttributes;
@@ -28,8 +26,6 @@ import org.sonatype.nexus.proxy.attributes.internal.DefaultAttributes;
 /**
  * Jackson JSON Attribute marshaller. Part of NEXUS-4628 "alternate" AttributeStorage implementations.
  */
-@Singleton
-@Named( "jackson-json" )
 public class JacksonJSONMarshaller
     implements Marshaller
 {
@@ -52,10 +48,26 @@ public class JacksonJSONMarshaller
 
     @Override
     public Attributes unmarshal( final InputStream inputStream )
-        throws IOException
+        throws IOException, InvalidInputException
     {
-        final Map<String, String> attributesMap = objectMapper.readValue( inputStream, new TypeReference<Map<String, String>>() {} );
-        return new DefaultAttributes( attributesMap );
+        try
+        {
+            final Map<String, String> attributesMap =
+                objectMapper.readValue( inputStream, new TypeReference<Map<String, String>>()
+                {
+                } );
+            return new DefaultAttributes( attributesMap );
+        }
+        catch ( JsonParseException e )
+        {
+            throw new InvalidInputException( "Persisted attribute malformed!", e );
+        }
     }
 
+    // ==
+
+    public String toString()
+    {
+        return "JacksonJSON";
+    }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/XStreamMarshaller.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/XStreamMarshaller.java
@@ -17,10 +17,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
-import javax.inject.Named;
-import javax.inject.Singleton;
 
 import org.sonatype.nexus.proxy.attributes.internal.DefaultAttributes;
+
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.converters.collections.MapConverter;
@@ -30,9 +29,8 @@ import com.thoughtworks.xstream.converters.collections.MapConverter;
  * 
  * @author cstamas
  * @since 2.0
+ * @deprecated Deprecated in favor of Jackson powered Marshaller, see {@link JacksonJSONMarshaller}.
  */
-@Singleton
-@Named( "xstream-xml" )
 public class XStreamMarshaller
     implements Marshaller
 {
@@ -74,5 +72,11 @@ public class XStreamMarshaller
             throw new InvalidInputException( "XStream claimed file as corrupt.", e );
         }
     }
-
+    
+    // ==
+    
+    public String toString()
+    {
+        return "XStream";
+    }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
@@ -18,9 +18,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
+import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.sonatype.nexus.proxy.attributes.internal.DefaultAttributes;
@@ -30,8 +28,6 @@ import com.fasterxml.jackson.xml.XmlMapper;
 /**
  * Jackson XML backed Attribute marshaller. Part of NEXUS-4628 "alternate" AttributeStorage implementations.
  */
-@Singleton
-@Named( "jackson-xml" )
 public class JacksonXMLMarshaller
     implements Marshaller
 {
@@ -56,8 +52,24 @@ public class JacksonXMLMarshaller
     public Attributes unmarshal( final InputStream inputStream )
         throws IOException
     {
-        final Map<String, String> attributesMap = objectMapper.readValue( inputStream, new TypeReference<Map<String, String>>() {} );
-        return new DefaultAttributes( attributesMap );
+        try
+        {
+            final Map<String, String> attributesMap =
+                objectMapper.readValue( inputStream, new TypeReference<Map<String, String>>()
+                {
+                } );
+            return new DefaultAttributes( attributesMap );
+        }
+        catch ( JsonParseException e )
+        {
+            throw new InvalidInputException( "Persisted attribute malformed!", e );
+        }
     }
 
+    // ==
+
+    public String toString()
+    {
+        return "JacksonXML";
+    }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/JacksonXMLMarshaller.java
@@ -18,6 +18,8 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.stream.XMLStreamException;
+
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
@@ -63,6 +65,17 @@ public class JacksonXMLMarshaller
         catch ( JsonParseException e )
         {
             throw new InvalidInputException( "Persisted attribute malformed!", e );
+        }
+        catch ( IOException e )
+        {
+            if ( e.getCause() instanceof XMLStreamException )
+            {
+                throw new InvalidInputException( "Persisted attribute malformed!", e );
+            }
+            else
+            {
+                throw e;
+            }
         }
     }
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/MarshallerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/MarshallerTest.java
@@ -1,0 +1,93 @@
+package org.sonatype.nexus.proxy.attributes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.sonatype.nexus.proxy.attributes.internal.DefaultAttributes;
+
+public class MarshallerTest
+{
+    protected void doTest( final Marshaller marshaller )
+        throws IOException
+    {
+        doTestSimpleRoundtrip( marshaller );
+        doTestUnparseableRoundtrip( marshaller );
+    }
+
+    protected void doTestSimpleRoundtrip( final Marshaller marshaller )
+        throws IOException
+    {
+        // simple roundtrip
+        final Attributes attributes1 = new DefaultAttributes();
+        attributes1.put( "foo", "fooVal" );
+        attributes1.put( "bar", "barVal" );
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        marshaller.marshal( attributes1, bos );
+        final ByteArrayInputStream bis = new ByteArrayInputStream( bos.toByteArray() );
+        final Attributes attributes2 = marshaller.unmarshal( bis );
+        // size same
+        assertThat( attributes2.asMap().size(), equalTo( attributes1.asMap().size() ) );
+        // as maps are equal
+        assertThat( attributes2.asMap(), equalTo( attributes1.asMap() ) );
+        // but we deal with two different instances
+        assertThat( System.identityHashCode( attributes2 ), not( equalTo( System.identityHashCode( attributes1 ) ) ) );
+    }
+
+    protected void doTestUnparseableRoundtrip( final Marshaller marshaller )
+        throws IOException
+    {
+        // simple roundtrip
+        final Attributes attributes1 = new DefaultAttributes();
+        attributes1.put( "foo", "fooVal" );
+        attributes1.put( "bar", "barVal" );
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        marshaller.marshal( attributes1, bos );
+
+        // break the data
+        final byte[] data = bos.toByteArray();
+        data[0] = 'a';
+        data[1] = 'b';
+        data[2] = 'c';
+
+        final ByteArrayInputStream bis = new ByteArrayInputStream( data );
+        try
+        {
+            final Attributes attributes2 = marshaller.unmarshal( bis );
+            throw new AssertionError( "Unmarshal should fail and throw InvalidInputException!" );
+        }
+        catch ( InvalidInputException e )
+        {
+            // good
+        }
+    }
+
+    // ==
+
+    @Test
+    public void testXstream()
+        throws IOException
+    {
+        doTest( new XStreamMarshaller() );
+    }
+
+    @Test
+    public void testJacksonJSON()
+        throws IOException
+    {
+        doTest( new JacksonJSONMarshaller() );
+    }
+
+    @Test
+    public void testJacksonXML()
+        throws IOException
+    {
+        doTest( new JacksonXMLMarshaller() );
+    }
+
+}

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/MarshallerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/MarshallerTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.attributes;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
- New Jackson based marshallers did not properly honor parsing problems (hence, Nexus was not recreating attributes but was choking on them)
- Marshallers are not components anymore, just simple classes created when needed
- XStream marshaller deprecated with a message pointing to JacksonJSON one
- improved robustness (null-checks) and logging of AttributeStorages
