### PR TITLE
NEXUS-4826 - removing org.jsecurity entries

### DIFF
--- a/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
+++ b/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
@@ -32,10 +32,8 @@
     </rollingPolicy>
   </appender>
   
-  <logger name="org.jsecurity" level="WARN" />
   <logger name="httpclient" level="INFO" />
   <logger name="org.sonatype.nexus.rest.NexusApplication" level="ERROR" />
-  <logger name="org.jsecurity.subject.AbstractRememberMeManager" level="ERROR" />
   <logger name="org.apache.http" level="INFO" />
   <logger name="org.restlet" level="WARN" />
   <logger name="org.apache.commons" level="WARN" />


### PR DESCRIPTION
org.jsecurity date from a legacy entry onto log4j.properties that was there since the file was create https://github.com/sonatype/nexus/commit/20814f6b64e56198fee366e15ec2f62d31ef5898#L2R11
