### PR TITLE
NEXUS-4789: Fixes

### DIFF
--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalHttpProxySettingsChangedEvent.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalHttpProxySettingsChangedEvent.java
@@ -16,6 +16,10 @@ import org.sonatype.nexus.configuration.application.GlobalHttpProxySettings;
 import org.sonatype.plexus.appevents.AbstractEvent;
 
 /**
+ * Event fired when global HTTP Proxy settings are changed (within configuration change). The settings carried in
+ * this event will reflect the NEW values, but if you have the {@link GlobalHttpProxySettings} component, you can
+ * query it too <em>after</em> you received this event .
+ * 
  * @since 2.0
  */
 public class GlobalHttpProxySettingsChangedEvent

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalRemoteConnectionSettingsChangedEvent.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/events/GlobalRemoteConnectionSettingsChangedEvent.java
@@ -15,6 +15,11 @@ package org.sonatype.nexus.configuration.application.events;
 import org.sonatype.nexus.configuration.application.GlobalRemoteConnectionSettings;
 import org.sonatype.plexus.appevents.AbstractEvent;
 
+/**
+ * Event fired when global remote connection settings are changed (within configuration change). The settings carried in
+ * this event will reflect the NEW values, but if you have the {@link GlobalRemoteConnectionSettings} component, you can
+ * query it too <em>after</em> you received this event .
+ */
 public class GlobalRemoteConnectionSettingsChangedEvent
     extends AbstractEvent<GlobalRemoteConnectionSettings>
 {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/ahc/AhcProviderEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/ahc/AhcProviderEventInspector.java
@@ -14,7 +14,8 @@ package org.sonatype.nexus.ahc;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
+import org.sonatype.nexus.configuration.application.events.GlobalHttpProxySettingsChangedEvent;
+import org.sonatype.nexus.configuration.application.events.GlobalRemoteConnectionSettingsChangedEvent;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
 import org.sonatype.nexus.proxy.events.AsynchronousEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
@@ -40,13 +41,15 @@ public class AhcProviderEventInspector
     @Override
     public boolean accepts( Event<?> evt )
     {
-        return ( evt instanceof ConfigurationChangeEvent ) || ( evt instanceof NexusStoppedEvent );
+        return ( evt instanceof GlobalRemoteConnectionSettingsChangedEvent )
+            || ( evt instanceof GlobalHttpProxySettingsChangedEvent ) || ( evt instanceof NexusStoppedEvent );
     }
 
     @Override
     public void inspect( Event<?> evt )
     {
-        if ( evt instanceof ConfigurationChangeEvent )
+        if ( ( evt instanceof GlobalRemoteConnectionSettingsChangedEvent )
+            || ( evt instanceof GlobalHttpProxySettingsChangedEvent ) )
         {
             ahcProvider.reset();
         }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
@@ -233,7 +233,7 @@ public class HttpClientProxyUtil
         // consequences, like resetting all the HTTP clients of all remote storages (coz they think there is a change
         // in proxy or remote connection settings, etc).
         final Boolean isNtlmUsedOldValue = (Boolean) ctx.getContextObject( NTLM_IS_IN_USE_KEY );
-        if ( isNtlmUsedOldValue == null || !isNtlmUsedOldValue.booleanValue() != isNtlmUsed )
+        if ( isNtlmUsedOldValue == null || isNtlmUsedOldValue.booleanValue() != isNtlmUsed )
         {
             if ( isNtlmUsed )
             {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtil.java
@@ -58,11 +58,11 @@ public class HttpClientProxyUtil
         // properties, but defaulting it to the same we had before (httpClient defaults)
         int connectionPoolSize =
             SystemPropertiesHelper.getInteger( CONNECTION_POOL_SIZE_KEY,
-                                               MultiThreadedHttpConnectionManager.DEFAULT_MAX_TOTAL_CONNECTIONS );
+                MultiThreadedHttpConnectionManager.DEFAULT_MAX_TOTAL_CONNECTIONS );
 
         httpClient.getHttpConnectionManager().getParams().setConnectionTimeout( timeout );
         httpClient.getHttpConnectionManager().getParams().setSoTimeout( timeout );
-        //httpClient.getHttpConnectionManager().getParams().setTcpNoDelay( true );
+        // httpClient.getHttpConnectionManager().getParams().setTcpNoDelay( true );
         httpClient.getHttpConnectionManager().getParams().setMaxTotalConnections( connectionPoolSize );
         // NOTE: connPool is _per_ repo, hence all of those will connect to same host (unless mirrors are used)
         // so, we are violating intentionally the RFC and we let the whole pool size to chase same host
@@ -97,16 +97,13 @@ public class HttpClientProxyUtil
                 // Using NTLM auth, adding it as first in policies
                 authPrefs.add( 0, AuthPolicy.NTLM );
 
-                logger( logger ).info(
-                    "... authentication setup for NTLM domain '{}'", nras.getNtlmDomain()
-                );
+                logger( logger ).info( "... authentication setup for NTLM domain '{}'", nras.getNtlmDomain() );
 
                 httpConfiguration.setHost( nras.getNtlmHost() );
 
                 httpClient.getState().setCredentials(
                     AuthScope.ANY,
-                    new NTCredentials( nras.getUsername(), nras.getPassword(), nras.getNtlmHost(),
-                                       nras.getNtlmDomain() ) );
+                    new NTCredentials( nras.getUsername(), nras.getPassword(), nras.getNtlmHost(), nras.getNtlmDomain() ) );
 
                 isNtlmUsed = true;
             }
@@ -115,13 +112,11 @@ public class HttpClientProxyUtil
                 UsernamePasswordRemoteAuthenticationSettings uras = (UsernamePasswordRemoteAuthenticationSettings) ras;
 
                 // Using Username/Pwd auth, will not add NTLM
-                logger( logger ).info(
-                    "... authentication setup for remote storage with username '{}'", uras.getUsername()
-                );
+                logger( logger ).info( "... authentication setup for remote storage with username '{}'",
+                    uras.getUsername() );
 
                 httpClient.getState().setCredentials( AuthScope.ANY,
-                                                      new UsernamePasswordCredentials( uras.getUsername(),
-                                                                                       uras.getPassword() ) );
+                    new UsernamePasswordCredentials( uras.getUsername(), uras.getPassword() ) );
 
                 isSimpleAuthUsed = true;
             }
@@ -189,20 +184,17 @@ public class HttpClientProxyUtil
                                 + " for BOTH server side and proxy side authentication!\n"
                                 + " You MUST reconfigure server side auth and use BASIC/DIGEST scheme\n"
                                 + " if you have to use NTLM proxy, otherwise it will not work!\n"
-                                + " *** SERVER SIDE AUTH OVERRIDDEN"
-                        );
+                                + " *** SERVER SIDE AUTH OVERRIDDEN" );
                     }
 
-                    logger( logger ).info(
-                        "... proxy authentication setup for NTLM domain '{}'", nras.getNtlmDomain()
-                    );
+                    logger( logger ).info( "... proxy authentication setup for NTLM domain '{}'", nras.getNtlmDomain() );
 
                     httpConfiguration.setHost( nras.getNtlmHost() );
 
                     httpClient.getState().setProxyCredentials(
                         AuthScope.ANY,
                         new NTCredentials( nras.getUsername(), nras.getPassword(), nras.getNtlmHost(),
-                                           nras.getNtlmDomain() ) );
+                            nras.getNtlmDomain() ) );
 
                     isNtlmUsed = true;
                 }
@@ -212,13 +204,11 @@ public class HttpClientProxyUtil
                         (UsernamePasswordRemoteAuthenticationSettings) ras;
 
                     // Using Username/Pwd auth, will not add NTLM
-                    logger( logger ).info(
-                        "... proxy authentication setup for remote storage with username '{}'", uras.getUsername()
-                    );
+                    logger( logger ).info( "... proxy authentication setup for remote storage with username '{}'",
+                        uras.getUsername() );
 
                     httpClient.getState().setProxyCredentials( AuthScope.ANY,
-                                                               new UsernamePasswordCredentials( uras.getUsername(),
-                                                                                                uras.getPassword() ) );
+                        new UsernamePasswordCredentials( uras.getUsername(), uras.getPassword() ) );
                 }
 
                 httpClient.getParams().setParameter( AuthPolicy.AUTH_SCHEME_PRIORITY, authPrefs );
@@ -231,21 +221,28 @@ public class HttpClientProxyUtil
         {
             logger( logger ).info(
                 "... simple scenario: simple authentication used with no proxy in between target and us,"
-                    + " will use preemptive authentication"
-            );
+                    + " will use preemptive authentication" );
 
             // we have authentication, let's do it preemptive
             httpClient.getParams().setAuthenticationPreemptive( true );
         }
 
         // mark the fact that NTLM is in use
-        if ( isNtlmUsed )
+        // but ONLY IF IT CHANGED!
+        // Otherwise, doing it always, actually marks the ctx itself as "changed", causing an avalanche of other
+        // consequences, like resetting all the HTTP clients of all remote storages (coz they think there is a change
+        // in proxy or remote connection settings, etc).
+        final Boolean isNtlmUsedOldValue = (Boolean) ctx.getContextObject( NTLM_IS_IN_USE_KEY );
+        if ( isNtlmUsedOldValue == null || !isNtlmUsedOldValue.booleanValue() != isNtlmUsed )
         {
-            ctx.putContextObject( NTLM_IS_IN_USE_KEY, Boolean.TRUE );
-        }
-        else
-        {
-            ctx.putContextObject( NTLM_IS_IN_USE_KEY, Boolean.FALSE );
+            if ( isNtlmUsed )
+            {
+                ctx.putContextObject( NTLM_IS_IN_USE_KEY, Boolean.TRUE );
+            }
+            else
+            {
+                ctx.putContextObject( NTLM_IS_IN_USE_KEY, Boolean.FALSE );
+            }
         }
     }
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtilTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtilTest.java
@@ -1,0 +1,153 @@
+package org.sonatype.nexus.proxy.storage.remote.commonshttpclient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+import java.util.Set;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
+import org.sonatype.nexus.proxy.repository.RemoteConnectionSettings;
+import org.sonatype.nexus.proxy.repository.RemoteProxySettings;
+import org.sonatype.nexus.proxy.storage.remote.DefaultRemoteStorageContext;
+
+public class HttpClientProxyUtilTest
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Test
+    public void testHttpClientProxyUtilUseDoesNotModifyContext()
+    {
+        final RemoteConnectionSettings remoteConnectionSettings = new RemoteConnectionSettings()
+        {
+            @Override
+            public void setUserAgentCustomizationString( String userAgentCustomizationString )
+            {
+            }
+
+            @Override
+            public void setRetrievalRetryCount( int retrievalRetryCount )
+            {
+            }
+
+            @Override
+            public void setQueryString( String queryString )
+            {
+            }
+
+            @Override
+            public void setConnectionTimeout( int connectionTimeout )
+            {
+            }
+
+            @Override
+            public String getUserAgentCustomizationString()
+            {
+                return null;
+            }
+
+            @Override
+            public int getRetrievalRetryCount()
+            {
+                return 3;
+            }
+
+            @Override
+            public String getQueryString()
+            {
+                return null;
+            }
+
+            @Override
+            public int getConnectionTimeout()
+            {
+                return 12000;
+            }
+        };
+        final RemoteProxySettings remoteProxySettings = new RemoteProxySettings()
+        {
+            @Override
+            public void setProxyAuthentication( RemoteAuthenticationSettings proxyAuthentication )
+            {
+            }
+
+            @Override
+            public void setPort( int port )
+            {
+            }
+
+            @Override
+            public void setNonProxyHosts( Set<String> nonProxyHosts )
+            {
+            }
+
+            @Override
+            public void setHostname( String hostname )
+            {
+            }
+
+            @Override
+            public void setBlockInheritance( boolean val )
+            {
+            }
+
+            @Override
+            public boolean isEnabled()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isBlockInheritance()
+            {
+                return false;
+            }
+
+            @Override
+            public RemoteAuthenticationSettings getProxyAuthentication()
+            {
+                return null;
+            }
+
+            @Override
+            public int getPort()
+            {
+                return 0;
+            }
+
+            @Override
+            public Set<String> getNonProxyHosts()
+            {
+                return null;
+            }
+
+            @Override
+            public String getHostname()
+            {
+                return null;
+            }
+        };
+        final DefaultRemoteStorageContext ctx = new DefaultRemoteStorageContext( null );
+        ctx.setRemoteConnectionSettings( remoteConnectionSettings );
+        ctx.setRemoteProxySettings( remoteProxySettings );
+
+        final HttpClient httpClient = new HttpClient();
+
+        // get last changed
+        long lastChanged = ctx.getLastChanged();
+
+        // 1st invocation, should modify it
+        HttpClientProxyUtil.applyProxyToHttpClient( httpClient, ctx, logger );
+        assertThat( ctx.getLastChanged(), greaterThan( lastChanged ) );
+
+        // now 2nd invocation, should not change
+        lastChanged = ctx.getLastChanged();
+        HttpClientProxyUtil.applyProxyToHttpClient( httpClient, ctx, logger );
+        assertThat( ctx.getLastChanged(), equalTo( lastChanged ) );
+    }
+
+}


### PR DESCRIPTION
Culprit was HttpClientProxyUtil that was "touching" RemoteStorageContext on every
invocation. This was not an issue so far, since these calls happened only from
RemoteRepositoryStorages. But in a moment any "third party" component -- not
participating in RRS -- does the same, it causes all of RSS to detect as
"settings changed" and reconfigure their underlying transport.

Also, AHC provider modified to make use of newly introduced events
(thanks to Bentmann)

Added Javadocs to the two related events.

---

Note: all this happens due to lack of NEXUS-4689, that would enable all interested "parties" to simply grab a HTTPClient (an abstraction, not an actual 3rd party http client implementation that would be hidden beneath it) from a provider. Without this, the 3rd parties are forced to "tamper" with lower levels of Nexus... doing stuff they should actually never do.
