### PR TITLE
o [NEXUS-4848] Make throttle controller UT more robust

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleController.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleController.java
@@ -105,8 +105,11 @@ public class FixedRateWalkerThrottleController
      * Creates a new instance of fixed rate throttle controller without callback and some defaults (adjustment slice
      * size is 2 seconds).
      * 
-     * @param limiterTps
-     * @param numberSequence
+     * @param limiterTps the TPS limit you want to enforce, values -1 means do not limit (you can tune the value on
+     *            runtime too), 0 means "freeze" (walk will effectively sleep only, will not advance), and any positive
+     *            number means the maximum wanted TPS.
+     * @param numberSequence The numberSequence must be non-null, and will be reset, and it's initial state have to be a
+     *            non-negative number, otherwise IllegalArgumentException is thrown.
      * @throws IllegalArgumentException If passed in numberSequence is not having needed characteristics.
      */
     public FixedRateWalkerThrottleController( final int limiterTps, final NumberSequence numberSequence )
@@ -170,11 +173,17 @@ public class FixedRateWalkerThrottleController
         this.limiterTps = limiterTps;
     }
 
+    /**
+     * @return the current adjustment period in ms (time that has to pass before an adjustment is made)
+     */
     public long getSliceSize()
     {
         return sliceSize;
     }
 
+    /**
+     * Set the current adjustment period in ms (time that has to pass before an adjustment is made)
+     */
     public void setSliceSize( final long sliceSize )
     {
         Preconditions.checkArgument( sliceSize > 0 );

--- a/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
+++ b/nexus/nexus-api/src/test/java/org/sonatype/nexus/proxy/walker/FixedRateWalkerThrottleControllerTest.java
@@ -34,15 +34,13 @@ public class FixedRateWalkerThrottleControllerTest
     @Test
     public void testDoesItHelpAtAll()
     {
-        // set unrealistic TPS and we do "little" (1ms) in processItem method (to get the ceiling to compare with)
-        final int measuredTpsUnreal = performAndMeasureActualTps( 100000000, new ConstantNumberSequence( 1 ) );
-        // set 500 TPS and we do "little" (1ms) in processItem method
-        final int measuredTps500 = performAndMeasureActualTps( 500, new ConstantNumberSequence( 1 ) );
-        // set 200 TPS and we do "little" (1ms) in processItem method
-        final int measuredTps200 = performAndMeasureActualTps( 200, new ConstantNumberSequence( 1 ) );
+        final int measuredTpsHigh = performAndMeasureActualTps( 20, new ConstantNumberSequence( 1 ) );
+        final int measuredTpsMid = performAndMeasureActualTps( 10, new ConstantNumberSequence( 1 ) );
+        final int measuredTpsLow = performAndMeasureActualTps( 5, new ConstantNumberSequence( 1 ) );
 
-        assertThat( "TPS500 should less than Unreal one", measuredTps500, lessThan( measuredTpsUnreal ) );
-        assertThat( "TPS200 should less than TPS500 one", measuredTps200, lessThan( measuredTps500 ) );
+        System.err.println( measuredTpsHigh + "\n" + measuredTpsMid + "\n" + measuredTpsLow );
+        assertThat( "Mid TPS should be less than high TPS run", measuredTpsMid, lessThan( measuredTpsHigh ) );
+        assertThat( "Low TPS should be less than medium TPS run", measuredTpsLow, lessThan( measuredTpsMid ) );
     }
 
     // ==
@@ -55,7 +53,8 @@ public class FixedRateWalkerThrottleControllerTest
 
         final TestThrottleInfo info = new TestThrottleInfo();
         final WalkerContext context = Mockito.mock( WalkerContext.class );
-        final int iterationCount = 1000;
+        // sleeptime starts oscillating after the 10th iteration, give some extra iterations to bring down the average
+        final int iterationCount = 25;
         final long startTime = System.currentTimeMillis();
         fixedRateWalkerThrottleController.walkStarted( context );
         for ( int i = 0; i < iterationCount; i++ )


### PR DESCRIPTION
Tweaked the UT to get an already throttled baseline, to minimize the risk of underperforming because of other load and thus invalidating the assertions.

([Test failed on the grid](https://builds.sonatype.org/job/nexus-oss-its-external-developer/jdk=java-6x,label=win/4/testReport/org.sonatype.nexus.proxy.walker/FixedRateWalkerThrottleControllerTest/testDoesItHelpAtAll/) because the 'unlimited' run had less TPS than the throttled one.)
