### PR TITLE
NEXUS-4855: Making registry be lazy about map creation.

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryRegistry.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/registry/DefaultRepositoryRegistry.java
@@ -213,6 +213,9 @@ public class DefaultRepositoryRegistry
     /** The repository registry map */
     private final Map<String, Repository> _repositories = new HashMap<String, Repository>();
 
+    /** The repository registry RO "view" */
+    private volatile Map<String, Repository> _repositoriesView;
+
     /**
      * Returns a copy of map with repositories. Is synchronized method, to allow consistent-read access. Methods
      * modifying this map are all also synchronized (see API Interface and above), while all the "reading" methods from
@@ -220,17 +223,24 @@ public class DefaultRepositoryRegistry
      */
     protected synchronized Map<String, Repository> getRepositoriesMap()
     {
-        return Collections.unmodifiableMap( new HashMap<String, Repository>( _repositories ) );
+        if ( _repositoriesView == null )
+        {
+            _repositoriesView = Collections.unmodifiableMap( new HashMap<String, Repository>( _repositories ) );
+        }
+
+        return _repositoriesView;
     }
 
     protected synchronized void repositoriesMapPut( final Repository repository )
     {
         _repositories.put( repository.getId(), repository );
+        _repositoriesView = Collections.unmodifiableMap( new HashMap<String, Repository>( _repositories ) );
     }
 
     protected synchronized void repositoriesMapRemove( final String repositoryId )
     {
         _repositories.remove( repositoryId );
+        _repositoriesView = Collections.unmodifiableMap( new HashMap<String, Repository>( _repositories ) );
     }
 
     protected void doRemoveRepository( final String repoId, final boolean silently )


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-4855

The `getRepositoriesMap()` is where all of registry calls boils down. Current implementation was creating a _copy_ of whole registry map per method invocation. This was a huge overhead, especially when the map itself is huge.

Instead, now registry maintains the "repo map" and the "RO view of repo map" in par, and always hands off the same instance, and recreates it only on repo map changes.
