### PR TITLE
NEXUS-4852: update Nexus to Eclipse/Jetty 7.6

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -344,7 +344,7 @@
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-jetty-testsuite</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -344,7 +344,7 @@
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-jetty-testsuite</artifactId>
-      <version>1.8</version>
+      <version>2.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nexus/nexus-app/src/test/resources/org/sonatype/nexus/ViewAccessTest.xml
+++ b/nexus/nexus-app/src/test/resources/org/sonatype/nexus/ViewAccessTest.xml
@@ -59,7 +59,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -82,7 +82,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -105,7 +105,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-app/src/test/resources/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemoverLRTest.xml
+++ b/nexus/nexus-app/src/test/resources/org/sonatype/nexus/maven/tasks/DefaultSnapshotRemoverLRTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-app/src/test/resources/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.xml
+++ b/nexus/nexus-app/src/test/resources/org/sonatype/nexus/maven/tasks/Nexus4588CancellationTest.xml
@@ -19,7 +19,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -42,7 +42,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-app/src/test/resources/org/sonatype/nexus/repositories/metadata/RemoteMirrorDownloadTest.xml
+++ b/nexus/nexus-app/src/test/resources/org/sonatype/nexus/repositories/metadata/RemoteMirrorDownloadTest.xml
@@ -15,7 +15,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -38,7 +38,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/pom.xml
@@ -63,8 +63,8 @@
       <artifactId>aether-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/src/test/java/org/sonatype/nexus/restlight/common/AbstractRESTLightClientTest.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-client-common/src/test/java/org/sonatype/nexus/restlight/common/AbstractRESTLightClientTest.java
@@ -30,10 +30,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.jdom.Document;
 import org.junit.Test;
 import org.junit.internal.matchers.IsCollectionContaining;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
-import org.mortbay.jetty.handler.HandlerWrapper;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.slf4j.LoggerFactory;
 
 public class AbstractRESTLightClientTest
@@ -228,11 +228,11 @@ public class AbstractRESTLightClientTest
         server = new Server( port );
 
         HandlerWrapper wrapper = new HandlerWrapper();
-        wrapper.addHandler( new AbstractHandler()
+        wrapper.setHandler( new AbstractHandler()
         {
 
             @Override
-            public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+            public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
                 throws IOException, ServletException
             {
                 response.setStatus( 400 );

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/pom.xml
@@ -34,8 +34,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
     </dependency>
     <dependency>
       <groupId> org.jdom</groupId>

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/ConversationalFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/ConversationalFixture.java
@@ -12,10 +12,10 @@
  */
 package org.sonatype.nexus.restlight.testharness;
 
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,8 +102,9 @@ public class ConversationalFixture
 
             private int conversationIndex = 0;
 
-            public void handle( final String target, final HttpServletRequest request, final HttpServletResponse response, final int dispatch )
-            throws IOException, ServletException
+            public void handle( final String target, final Request baseRequest,
+                                final HttpServletRequest request, final HttpServletResponse response )
+                throws IOException, ServletException
             {
                 Logger logger = LoggerFactory.getLogger( ConversationalFixture.class );
 
@@ -127,7 +128,7 @@ public class ConversationalFixture
                 {
                     RESTTestFixture fixture = conversation.get( conversationIndex++ );
 
-                    fixture.getTestHandler().handle( target, request, response, dispatch );
+                    fixture.getTestHandler().handle( target, baseRequest, request, response );
 
                     traversedConversation.add( fixture );
                 }

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/DELETEFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/DELETEFixture.java
@@ -15,9 +15,9 @@ package org.sonatype.nexus.restlight.testharness;
 import org.jdom.Document;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,10 +123,9 @@ public class DELETEFixture
     {
         Handler handler = new AbstractHandler()
         {
-            public void handle( final String target, final HttpServletRequest request,
-                final HttpServletResponse response, final int dispatch )
-                throws IOException,
-                    ServletException
+            public void handle( final String target, final Request baseRequest,
+                                final HttpServletRequest request, final HttpServletResponse response )
+                throws IOException, ServletException
             {
                 Logger logger = LoggerFactory.getLogger( GETFixture.class );
 

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/GETFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/GETFixture.java
@@ -15,10 +15,10 @@ package org.sonatype.nexus.restlight.testharness;
 import org.jdom.Document;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,8 +177,9 @@ extends AbstractRESTTestFixture
     {
         Handler handler = new AbstractHandler()
         {
-            public void handle( final String target, final HttpServletRequest request, final HttpServletResponse response, final int dispatch )
-            throws IOException, ServletException
+            public void handle( final String target, final Request baseRequest,
+                                final HttpServletRequest request, final HttpServletResponse response )
+                throws IOException, ServletException
             {
                 Logger logger = LoggerFactory.getLogger( GETFixture.class );
 

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/POSTFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/POSTFixture.java
@@ -17,10 +17,10 @@ import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,8 +214,9 @@ extends AbstractRESTTestFixture
     {
         return new AbstractHandler()
         {
-            public void handle( final String target, final HttpServletRequest request, final HttpServletResponse response, final int dispatch )
-            throws IOException, ServletException
+            public void handle( final String target, final Request baseRequest,
+                                final HttpServletRequest request, final HttpServletResponse response )
+                throws IOException, ServletException
             {
                 Logger logger = LoggerFactory.getLogger( POSTFixture.class );
 

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/PUTFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/PUTFixture.java
@@ -17,9 +17,9 @@ import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,8 +130,8 @@ public class PUTFixture
     {
         return new AbstractHandler()
         {
-            public void handle( final String target, final HttpServletRequest request,
-                final HttpServletResponse response, final int dispatch )
+            public void handle( final String target, final Request baseRequest,
+                final HttpServletRequest request, final HttpServletResponse response )
                 throws IOException,
                     ServletException
             {

--- a/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/RESTTestFixture.java
+++ b/nexus/nexus-clients/nexus-restlight-clients/nexus-restlight-test-harness/src/main/java/org/sonatype/nexus/restlight/testharness/RESTTestFixture.java
@@ -12,8 +12,8 @@
  */
 package org.sonatype.nexus.restlight.testharness;
 
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
 
 /**
  * <p>

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/DownloadRemoteIndexerManagerLRTest.java
@@ -30,13 +30,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.maven.index.context.IndexingContext;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.junit.Test;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Response;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
 import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
 
 // This is an IT just because it runs longer then 15 seconds
@@ -66,11 +67,11 @@ public class DownloadRemoteIndexerManagerLRTest
         ResourceHandler resource_handler = new ResourceHandler()
         {
             @Override
-            public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+            public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
                 throws IOException, ServletException
             {
                 System.out.print( "JETTY: " + target );
-                super.handle( target, request, response, dispatch );
+                super.handle( target, baseRequest, request, response );
                 System.out.println( "  ::  " + ((Response)response).getStatus() );
             }
         };

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/resources/org/sonatype/nexus/ReindexLRTest.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/resources/org/sonatype/nexus/ReindexLRTest.xml
@@ -13,7 +13,7 @@
               <servletInfo>
                 <mapping>/*</mapping>
                 <servletClass>
-                  org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                  org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -32,7 +32,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -51,7 +51,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -70,7 +70,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -89,7 +89,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -111,7 +111,7 @@
               <servletInfo>
                 <mapping>/*</mapping>
                 <servletClass>
-                  org.mortbay.jetty.servlet.DefaultServlet
+                  org.eclipse.jetty.servlet.DefaultServlet
                 </servletClass>
                 <parameters>
                   <property>
@@ -134,7 +134,7 @@
               <servletInfo>
                 <mapping>/*</mapping>
                 <servletClass>
-                  org.mortbay.jetty.servlet.DefaultServlet
+                  org.eclipse.jetty.servlet.DefaultServlet
                 </servletClass>
                 <parameters>
                   <property>

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/resources/META-INF/plexus/components.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/resources/META-INF/plexus/components.xml
@@ -62,7 +62,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/src/test/resources/components.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/src/test/resources/components.xml
@@ -74,7 +74,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -126,7 +126,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>

--- a/nexus/nexus-core-plugins/nexus-lvo-plugin/src/test/resources/org/sonatype/nexus/plugins/lvo/strategy/HttpGetDiscoveryStrategyTest.xml
+++ b/nexus/nexus-core-plugins/nexus-lvo-plugin/src/test/resources/org/sonatype/nexus/plugins/lvo/strategy/HttpGetDiscoveryStrategyTest.xml
@@ -11,7 +11,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>

--- a/nexus/nexus-core-plugins/nexus-rrb-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-rrb-plugin/pom.xml
@@ -125,8 +125,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReaderTest.java
+++ b/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReaderTest.java
@@ -32,11 +32,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mortbay.jetty.Connector;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.sonatype.nexus.proxy.repository.DefaultRemoteConnectionSettings;
 import org.sonatype.nexus.proxy.repository.DefaultRemoteProxySettings;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
@@ -73,7 +73,7 @@ public class MavenRepositoryReaderTest
         Handler handler = new AbstractHandler()
         {
 
-            public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+            public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
                 throws IOException, ServletException
             {
                 String path = target;

--- a/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/ValidHTMLJettyDefaultServlet.java
+++ b/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/ValidHTMLJettyDefaultServlet.java
@@ -17,9 +17,9 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.mortbay.jetty.servlet.DefaultServlet;
-import org.mortbay.resource.Resource;
-import org.mortbay.util.URIUtil;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.URIUtil;
 
 public class ValidHTMLJettyDefaultServlet extends DefaultServlet
 {

--- a/nexus/nexus-mock/src/test/resources/nexus-ui/WEB-INF/web.xml
+++ b/nexus/nexus-mock/src/test/resources/nexus-ui/WEB-INF/web.xml
@@ -103,7 +103,7 @@
         everything). 
     <servlet>
         <servlet-name>default</servlet-name>
-        <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
+        <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
         <init-param>
             <param-name>useFileMappedBuffer</param-name>
             <param-value>false</param-value>

--- a/nexus/nexus-oss-webapp/pom.xml
+++ b/nexus/nexus-oss-webapp/pom.xml
@@ -28,10 +28,6 @@
 
   <name>Nexus : Distros : Nexus OSS Bundle</name>
 
-  <properties>
-    <jetty.version>7.5.4.v20111024</jetty.version>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/M2RepositoryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/M2RepositoryTest.java
@@ -338,21 +338,27 @@ public class M2RepositoryTest
         // repository.setEnforceReleaseRedownloadPolicy( enforceReleaseRedownloadPolicy );
         repository.getCurrentCoreConfiguration().commitChanges();
 
-        mdFile.setLastModified( System.currentTimeMillis() - ( 3L * 24L * 60L * 60L * 1000L ) );
-
-        Thread.sleep( 500 ); // wait for FS
-
-        repository.retrieveItem( new ResourceStoreRequest( path, false ) );
-
-        mdFile.setLastModified( System.currentTimeMillis() - ( 2L * 24L * 60L * 60L * 1000L ) );
-
-        Thread.sleep( 500 ); // wait for FS
+        for ( int i = 0; i < 10 && !mdFile.setLastModified( System.currentTimeMillis() - ( 3L * A_DAY ) ); i++ )
+        {
+            System.gc(); // helps with FS sync'ing on Windows
+            Thread.sleep( 500 ); // wait for FS
+        }
 
         repository.retrieveItem( new ResourceStoreRequest( path, false ) );
 
-        mdFile.setLastModified( System.currentTimeMillis() - ( 1L * 24L * 60L * 60L * 1000L ) );
+        for ( int i = 0; i < 10 && !mdFile.setLastModified( System.currentTimeMillis() - ( 2L * A_DAY ) ); i++ )
+        {
+            System.gc(); // helps with FS sync'ing on Windows
+            Thread.sleep( 500 ); // wait for FS
+        }
 
-        Thread.sleep( 500 ); // wait for FS
+        repository.retrieveItem( new ResourceStoreRequest( path, false ) );
+
+        for ( int i = 0; i < 10 && !mdFile.setLastModified( System.currentTimeMillis() - ( 1L * A_DAY ) ); i++ )
+        {
+            System.gc(); // helps with FS sync'ing on Windows
+            Thread.sleep( 500 ); // wait for FS
+        }
 
         repository.retrieveItem( new ResourceStoreRequest( path, false ) );
 

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/GroupingBehaviourTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/GroupingBehaviourTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/LinkTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/LinkTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M1LayoutedM2ShadowRepositoryTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M1LayoutedM2ShadowRepositoryTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M1RepositoryTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M1RepositoryTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M2LayoutedM1ShadowRepositoryTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M2LayoutedM1ShadowRepositoryTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M2RepositoryTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/M2RepositoryTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/NonProxyHostsTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/NonProxyHostsTest.xml
@@ -23,7 +23,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RemoteAuthTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RemoteAuthTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -43,7 +43,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -72,7 +72,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepoChecksumPolicyTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepoChecksumPolicyTest.xml
@@ -11,7 +11,7 @@
 						<servletInfos>
 							<servletInfo>
 								<mapping>/*</mapping>
-								<servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+								<servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
 								<parameters>
 									<property>
 										<name>resourceBase</name>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepoConversionTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepoConversionTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryEvictUnusedItemsTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryEvictUnusedItemsTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryExpireCacheTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryExpireCacheTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryRedeployTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RepositoryRedeployTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RouterTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/RouterTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimpleProxyIndexerTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimpleProxyIndexerTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimplePullTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimplePullTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimpleRemoteLeakTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/SimpleRemoteLeakTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/events/ConfigurationChangeEventTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/events/ConfigurationChangeEventTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/ArtifactStoreRequestTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/ArtifactStoreRequestTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/Nexus4423Maven3MetadataTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/Nexus4423Maven3MetadataTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/metadata/GroupMetadataMergeTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/metadata/GroupMetadataMergeTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -83,7 +83,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -106,7 +106,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -129,7 +129,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/metadata/RecreateMavenMetadataWalkerTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/maven/metadata/RecreateMavenMetadataWalkerTest.xml
@@ -13,7 +13,7 @@
 						<servletInfos>
 							<servletInfo>
 								<mapping>/*</mapping>
-								<servletClass> org.mortbay.jetty.servlet.DefaultServlet
+								<servletClass> org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/repository/AccessTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/repository/AccessTest.xml
@@ -58,7 +58,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -81,7 +81,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -104,7 +104,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/repository/RecreateAttributesWalkerTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/repository/RecreateAttributesWalkerTest.xml
@@ -14,7 +14,7 @@
               <servletInfo>
                 <mapping>/*</mapping>
                 <servletClass>
-                  org.mortbay.jetty.servlet.DefaultServlet
+                  org.eclipse.jetty.servlet.DefaultServlet
                 </servletClass>
                 <parameters>
                   <property>

--- a/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/walker/WalkerTest.xml
+++ b/nexus/nexus-proxy/src/test/resources/org/sonatype/nexus/proxy/walker/WalkerTest.xml
@@ -14,7 +14,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -37,7 +37,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>
@@ -60,7 +60,7 @@
 							<servletInfo>
 								<mapping>/*</mapping>
 								<servletClass>
-									org.mortbay.jetty.servlet.DefaultServlet
+									org.eclipse.jetty.servlet.DefaultServlet
 								</servletClass>
 								<parameters>
 									<property>

--- a/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/components.xml
+++ b/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/src/main/resources/default-config/components.xml
@@ -90,7 +90,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>
@@ -142,7 +142,7 @@
             <servletInfos>
               <servletInfo>
                 <mapping>/*</mapping>
-                <servletClass>org.mortbay.jetty.servlet.DefaultServlet</servletClass>
+                <servletClass>org.eclipse.jetty.servlet.DefaultServlet</servletClass>
                 <parameters>
                   <property>
                     <name>resourceBase</name>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
@@ -438,16 +438,9 @@
                       <type>tar.gz</type>
                     </artifactItem>
                     <artifactItem>
-                      <groupId>org.mortbay.jetty</groupId>
-                      <artifactId>jetty</artifactId>
-                      <version>6.1.26</version>
-                      <classifier>bundle</classifier>
-                      <type>zip</type>
-                    </artifactItem>
-                    <artifactItem>
                       <groupId>org.eclipse.jetty</groupId>
                       <artifactId>jetty-distribution</artifactId>
-                      <version>7.2.0.v20101020</version>
+                      <version>${jetty.version}</version>
                       <classifier>bundle</classifier>
                       <type>tar.gz</type>
                     </artifactItem>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
@@ -441,7 +441,6 @@
                       <groupId>org.eclipse.jetty</groupId>
                       <artifactId>jetty-distribution</artifactId>
                       <version>${jetty.version}</version>
-                      <classifier>bundle</classifier>
                       <type>tar.gz</type>
                     </artifactItem>
                   </artifactItems>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1197/Nexus1197CheckUserAgentIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1197/Nexus1197CheckUserAgentIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.FileNotFoundException;
 
 import static org.hamcrest.Matchers.*;
-import org.mortbay.jetty.Server;
+import org.eclipse.jetty.server.Server;
 import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
 import org.sonatype.nexus.test.utils.TestProperties;
 import org.testng.Assert;

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1197/RequestHandler.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1197/RequestHandler.java
@@ -18,7 +18,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 
 public class RequestHandler
     extends AbstractHandler
@@ -26,7 +27,7 @@ public class RequestHandler
 
     private String userAgent;
 
-    public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+    public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
         throws IOException, ServletException
     {
         this.userAgent = request.getHeader( "User-Agent" );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus166/JettyMemoryLeak.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus166/JettyMemoryLeak.java
@@ -19,10 +19,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.swing.JOptionPane;
 
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -41,7 +41,7 @@ public class JettyMemoryLeak
         {
             private int[] ints = new int[1024 * 1024];
 
-            public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+            public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
                 throws IOException, ServletException
             {
                 int[] cache = ints;

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Jetty7WarCargoIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Jetty7WarCargoIT.java
@@ -20,7 +20,7 @@ public class Nexus3860Jetty7WarCargoIT
     @Override
     public File getContainerLocation()
     {
-        return new File( "target/nexus/jetty-distribution-7.2.0.v20101020" );
+        return new File( "target/nexus/jetty-distribution-7.6.0.v20120127" );
     }
 
     @Override

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/AutoBlockITSupport.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4539/AutoBlockITSupport.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.maven.index.artifact.Gav;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.StoppingException;
 import org.hamcrest.Matchers;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.sonatype.jettytestsuite.ControlledServer;

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus634/Nexus634CheckDoesNotGoRemoteIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus634/Nexus634CheckDoesNotGoRemoteIT.java
@@ -16,7 +16,7 @@ import java.io.File;
 
 import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.mortbay.jetty.Server;
+import org.eclipse.jetty.server.Server;
 import org.restlet.data.MediaType;
 import org.sonatype.nexus.rest.model.RepositoryProxyResource;
 import org.sonatype.nexus.rest.model.ScheduledServicePropertyResource;

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus634/TouchTrackingHandler.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus634/TouchTrackingHandler.java
@@ -21,8 +21,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 
 public class TouchTrackingHandler
     extends AbstractHandler
@@ -35,7 +36,7 @@ public class TouchTrackingHandler
         this.touchedTargets = new ArrayList<String>();
     }
 
-    public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+    public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
         throws IOException, ServletException
     {
         touchedTargets.add( target );

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/handler/ReturnErrorHandler.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/handler/ReturnErrorHandler.java
@@ -17,8 +17,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.handler.AbstractHandler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.restlet.data.Method;
 
 /**
@@ -44,7 +44,7 @@ public class ReturnErrorHandler
             this.headOk = headOk;
         }
 
-        public void handle( String target, HttpServletRequest request, HttpServletResponse response, int dispatch )
+        public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
             throws IOException,
             ServletException
         {

--- a/nexus/nexus-test-harness/nexus-test-harness-selenium/src/test/resources/nexus-ui/WEB-INF/web.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-selenium/src/test/resources/nexus-ui/WEB-INF/web.xml
@@ -103,7 +103,7 @@
         everything). 
     <servlet>
         <servlet-name>default</servlet-name>
-        <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
+        <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
         <init-param>
             <param-name>useFileMappedBuffer</param-name>
             <param-value>false</param-value>

--- a/nexus/nexus-webapp/pom.xml
+++ b/nexus/nexus-webapp/pom.xml
@@ -37,7 +37,6 @@
 
     <plugin-repository.directory>${project.build.finalName}/WEB-INF/plugin-repository</plugin-repository.directory>
     <optional-plugins.directory>${project.build.finalName}/WEB-INF/optional-plugins</optional-plugins.directory>
-    <jetty.version>7.4.4.v20110707</jetty.version>
   </properties>
 
   <dependencies>
@@ -446,8 +445,8 @@
 
       <plugin>
         <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.19</version>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>${jetty.version}</version>
         <configuration>
           <webXml>${basedir}/src/main/webapp-war-extras/WEB-INF/web.xml</webXml>
         </configuration>

--- a/nexus/nexus-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/nexus/nexus-webapp/src/main/webapp/WEB-INF/web.xml
@@ -118,7 +118,7 @@
     everything). 
     <servlet>
       <servlet-name>default</servlet-name>
-      <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
+      <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
       <init-param>
         <param-name>useFileMappedBuffer</param-name>
         <param-value>false</param-value>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -162,7 +162,7 @@
     <commons-beanutils.baseVersion>1.7.0</commons-beanutils.baseVersion>
     <commons-beanutils.version>${commons-beanutils.baseVersion}-SONATYPE</commons-beanutils.version>
     <enunciate.version>1.20</enunciate.version>
-    <jetty.version>6.1.19</jetty.version>
+    <jetty.version>7.6.0.v20120127</jetty.version>
     <jsw.binaries.version>3.2.3.5</jsw.binaries.version>
     <maven.version>3.0.1</maven.version>
     <micromailer.version>1.1.1</micromailer.version>
@@ -175,7 +175,7 @@
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2</plexus-jetty7.version>
-    <plexus-jetty-testsuite.version>1.8</plexus-jetty-testsuite.version>
+    <plexus-jetty-testsuite.version>2.0-SNAPSHOT</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
@@ -301,22 +301,32 @@
 
       <!-- Jetty -->
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-deploy</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty-sslengine</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mortbay.jetty</groupId>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
         <version>${jetty.version}</version>
       </dependency>
@@ -1019,7 +1029,7 @@
       <dependency>
         <groupId>org.sonatype.http-testing-harness</groupId>
         <artifactId>server-provider</artifactId>
-        <version>0.4.3</version>
+        <version>0.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
 
@@ -1394,6 +1404,16 @@
                   </includes>
 
                   <message>Do not use log4j api directly in tests. Use slf4j api instead.</message>
+                </bannedDependencies>
+                <bannedDependencies>
+                  <searchTransitive>true</searchTransitive>
+                  <excludes>
+                    <exclude>org.mortbay.jetty:*</exclude>
+                  </excludes>
+                  <includes>
+                    <include>org.eclipse.jetty:*:${jetty.version}</include>
+                  </includes>
+                  <message>Use the Eclipse/Jetty version defined in nexus parent. See jetty.version property</message>
                 </bannedDependencies>
 
                 <!-- <requirePluginVersions> <banSnapshots>false</banSnapshots> </requirePluginVersions> -->

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -1032,6 +1032,18 @@
         <version>0.5.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.sonatype.http-testing-harness</groupId>
+        <artifactId>junit-runner</artifactId>
+        <version>0.5.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.http-testing-harness</groupId>
+        <artifactId>testng-runner</artifactId>
+        <version>0.5.0</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- The modules -->
       <dependency>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -175,7 +175,7 @@
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2</plexus-jetty7.version>
-    <plexus-jetty-testsuite.version>2.0-SNAPSHOT</plexus-jetty-testsuite.version>
+    <plexus-jetty-testsuite.version>2.0</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
@@ -1029,7 +1029,7 @@
       <dependency>
         <groupId>org.sonatype.http-testing-harness</groupId>
         <artifactId>server-provider</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.5.0</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Nexus UTs were still running against Jetty 6.

This pull request updates all UTs and ITs to run on Jetty 7 and adds an enforcer rule.

See also:

https://github.com/sonatype/sisu-jetty-testsuite/pull/2
https://github.com/sonatype/http-testing-harness/pull/1
