### PR TITLE
NXCM-3892: avoid holding onto mdItem lock for longer than necessary

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2Repository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2Repository.java
@@ -344,12 +344,20 @@ public class M2Repository
                     mdItem = (StorageFileItem) super.doRetrieveItem( request );
                 }
 
-                InputStream inputStream = null;
                 try
                 {
-                    inputStream = mdItem.getInputStream();
+                    Metadata metadata;
+                    InputStream inputStream = null;
+                    try
+                    {
+                        inputStream = mdItem.getInputStream();
+                        metadata = MetadataBuilder.read( inputStream );
+                    }
+                    finally
+                    {
+                        IOUtil.close( inputStream ); // Make sure we unlock mdItem ASAP
+                    }
 
-                    Metadata metadata = MetadataBuilder.read( inputStream );
                     Version requiredVersion = getClientSupportedVersion( userAgent );
                     Version metadataVersion = ModelVersionUtility.getModelVersion( metadata );
 
@@ -406,10 +414,6 @@ public class M2Repository
                     }
 
                     return super.doRetrieveItem( request );
-                }
-                finally
-                {
-                    IOUtil.close( inputStream );
                 }
             }
         }


### PR DESCRIPTION
I think there's a potential deadlock in the M2Repository.doRetrieveItem method - at the top of this method a request for maven-metadata.xml.sha1 may be redirected to a request for the maven-metadata.xml, ie. sha1 locked before mdItem. Later on in the same method the mdItem stream is opened (content wrapped by ReadLockingContentLocator) and then the maven-metadata.xml.sha1 request is handled, with the mdItem stream only closed at the end. Because ReadLockingContentLocator only unlocks the item on the close this can lead to mdItem locked before and during sha1.

I believe this inverse locking could lead to a deadlock.

Solution is to unlock the mdItem as soon as we can, before the call to fetch the maven-metadata.xml.sha1.

Kicked off CI sanity test: https://builds.sonatype.org/job/nexus-oss-its-feature/211/
