### PR TITLE
[NEXUS-4465] Subtract 1 second from scheduled next run

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/scheduling/DefaultTaskConfigManager.java
@@ -136,8 +136,11 @@ public class DefaultTaskConfigManager
 
     public void initializeTasks( Scheduler scheduler )
     {
-        List<CScheduledTask> tasks = new ArrayList<CScheduledTask>( getCurrentConfiguration( false ) );
+        initializeTasks( scheduler, new ArrayList<CScheduledTask>( getCurrentConfiguration( false ) ) );
+    }
 
+    void initializeTasks( Scheduler scheduler, List<CScheduledTask> tasks )
+    {
         if ( tasks != null )
         {
             List<CScheduledTask> tempList = new ArrayList<CScheduledTask>( tasks );
@@ -410,7 +413,14 @@ public class DefaultTaskConfigManager
 
         if ( nextRun != null )
         {
-            schedule.getIterator().resetFrom( nextRun );
+            Date resetFrom = nextRun;
+            // NEXUS-4465: Cron schedule will add 1 second to given time to calculate next scheduled time
+            // so we subtract it in case that next schedule is actually a valid time to run
+            if ( schedule instanceof CronSchedule )
+            {
+                resetFrom = new Date( resetFrom.getTime() - 1000 );
+            }
+            schedule.getIterator().resetFrom( resetFrom );
         }
 
         return schedule;

--- a/nexus/nexus-app/src/test/java/org/sonatype/scheduling/TestNexusTask.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/scheduling/TestNexusTask.java
@@ -1,0 +1,90 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.scheduling;
+
+import java.util.List;
+import java.util.Map;
+
+import org.sonatype.nexus.scheduling.NexusTask;
+import org.sonatype.nexus.scheduling.TaskActivityDescriptor;
+
+public class TestNexusTask
+    extends AbstractSchedulerTask<Object>
+    implements NexusTask<Object>
+{
+
+    private int runCount = 0;
+
+    public int getRunCount()
+    {
+        return runCount;
+    }
+
+    @Override
+    public Object call()
+        throws Exception
+    {
+        runCount++;
+
+        return null;
+    }
+
+    @Override
+    public String getId()
+    {
+        return TestNexusTask.class.getName();
+    }
+
+    @Override
+    public String getName()
+    {
+        return TestNexusTask.class.getName();
+    }
+
+    @Override
+    public boolean isExposed()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSendAlertEmail()
+    {
+        return false;
+    }
+
+    @Override
+    public String getAlertEmail()
+    {
+        return null;
+    }
+
+    @Override
+    public TaskActivityDescriptor getTaskActivityDescriptor()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean allowConcurrentSubmission( final Map<String, List<ScheduledTask<?>>> currentActiveTasks )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean allowConcurrentExecution( final Map<String, List<ScheduledTask<?>>> currentActiveTasks )
+    {
+        return false;
+    }
+
+}

--- a/nexus/nexus-app/src/test/resources/org/sonatype/scheduling/DefaultTaskConfigManagerTest.xml
+++ b/nexus/nexus-app/src/test/resources/org/sonatype/scheduling/DefaultTaskConfigManagerTest.xml
@@ -1,0 +1,10 @@
+<plexus>
+	<components>
+		<component>
+			<role>org.sonatype.scheduling.SchedulerTask</role>
+			<role-hint>org.sonatype.scheduling.TestNexusTask</role-hint>
+			<instantiation-strategy>per-lookup</instantiation-strategy>
+			<implementation>org.sonatype.scheduling.TestNexusTask</implementation>
+		</component>
+	</components>
+</plexus>


### PR DESCRIPTION
On Nexus initialization of tasks use a 1 second before the actual already scheduled next run so next run calculation (that adds a second) will not skip over the already scheduled time.

Alternatively we could change Sonatype scheduler to add a param or a new method that will also consider the passed in time for calculating resetFrom(), but this is more intrusive.

The disadvantage of proposed solution is that if Sonatype scheduler changes (let's say it adds 2 seconds for calculation) then we have to change this. But this is covered by a test now so we should not miss such a change.

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
