### PR TITLE
NXCM-3900: nexus-maven-plugin depends on artifacts not in Central

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -219,6 +219,18 @@
       <groupId>org.sonatype.nexus.restlight</groupId>
       <artifactId>nexus-restlight-client-common</artifactId>
     </dependency>
+    <!-- We don't want to use a "nexus only" patched HttpClient 3.1 that is not in Central -->
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
@@ -332,10 +344,12 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-core</artifactId>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-bean-collections</artifactId>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -344,12 +344,10 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-core</artifactId>
-      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-bean-collections</artifactId>
-      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/nexus/nexus-clients/nexus-rest-client-java/pom.xml
+++ b/nexus/nexus-clients/nexus-rest-client-java/pom.xml
@@ -50,18 +50,6 @@
       <artifactId>plexus-restlet-bridge</artifactId>
       <version>${plexus.restlet.bridge.version}</version>
     </dependency>
-    <!-- We don't want to use a "nexus only" patched HttpClient 3.1 that is not in Central -->
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/nexus/nexus-clients/nexus-rest-client-java/pom.xml
+++ b/nexus/nexus-clients/nexus-rest-client-java/pom.xml
@@ -50,6 +50,18 @@
       <artifactId>plexus-restlet-bridge</artifactId>
       <version>${plexus.restlet.bridge.version}</version>
     </dependency>
+    <!-- We don't want to use a "nexus only" patched HttpClient 3.1 that is not in Central -->
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/nexus/nexus-clients/nexus-restlight-clients/pom.xml
+++ b/nexus/nexus-clients/nexus-restlight-clients/pom.xml
@@ -50,10 +50,11 @@
         <artifactId>jdom</artifactId>
         <version>1.1</version>
       </dependency>
+      <!-- We don't want to use a "nexus only" patched HttpClient 3.1 that is not in Central -->
       <dependency>
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
-        <version>3.1.SONATYPE</version>
+        <version>3.1</version>
         <exclusions>
           <exclusion>
             <artifactId>commons-logging</artifactId>

--- a/nexus/nexus-oss-webapp-tattletale/pom.xml
+++ b/nexus/nexus-oss-webapp-tattletale/pom.xml
@@ -116,6 +116,8 @@
                   <excludes>
                     <!-- I hate this too, but other pattern did not help (ie. xmlpull-*.jar) At least build will fail anyway if version changes... -->
                     <exclude>xmlpull-1.1.3.1.jar</exclude>
+                    <!-- Remove once Commons Beanutils 1.8.4 is released and we upgrade to it, see BEANUTILS-379 -->
+                    <exclude>commons-beanutils-core-1.7.0.jar</exclude>
                   </excludes>
                 </configuration>
               </execution>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -159,8 +159,7 @@
 
     <aether.version>1.13</aether.version>
     <aspectj.version>1.6.11</aspectj.version>
-    <commons-beanutils.baseVersion>1.7.0</commons-beanutils.baseVersion>
-    <commons-beanutils.version>${commons-beanutils.baseVersion}-SONATYPE</commons-beanutils.version>
+    <commons-beanutils.version>1.7.0</commons-beanutils.version>
     <enunciate.version>1.20</enunciate.version>
     <jetty.version>6.1.19</jetty.version>
     <jsw.binaries.version>3.2.3.5</jsw.binaries.version>
@@ -601,7 +600,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils-bean-collections</artifactId>
-        <version>${commons-beanutils.baseVersion}</version>
+        <version>${commons-beanutils.version}</version>
       </dependency>
 
       <!-- SLF4J Logging -->


### PR DESCRIPTION
Hence, it's unusable unless you access RSO too to grab those ("patched" mainly) artifacts.

Most notably, Apache HttpClient 3.1 is patched and is used "almost everywhere", even if that patch is actually needed in Nexus CommonsHttpClient RRS implementation only.

Commons Beanutils Core (and -bean-collection) was also "patched" ones, due to [BEANUTILS-379](https://issues.apache.org/jira/browse/BEANUTILS-379) but in this pull it is reverted to "vanilla" ones (available on Central) and tuned Tattletale configuration instead.

This should make nexus-maven-plugin (and actually any Nexus Restlight Client user) able to resolve dependencies from Central.
