### PR TITLE
NEXUS-4862 - add zero lenght handler to attribute files

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -226,6 +226,12 @@ public class DefaultFSAttributeStorage
 
                         marshaller.marshal( attributes, fos );
                     }
+                    catch ( IOException ex )
+                    {
+                        // NEXUS-4862 prevent zero length/corrupt files
+                        target.delete();
+                        throw ex;
+                    }
                     finally
                     {
                         Closeables.closeQuietly( fos );
@@ -306,6 +312,12 @@ public class DefaultFSAttributeStorage
 
             try
             {
+                if ( target.length() == 0 )
+                {
+                    // NEXUS-4862
+                    throw new InvalidInputException( "Attribute of " + uid + " is empty!" );
+                }
+
                 fis = new FileInputStream( target );
 
                 result = marshaller.unmarshal( fis );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -228,7 +228,7 @@ public class DefaultFSAttributeStorage
                     }
                     catch ( IOException ex )
                     {
-                        // NEXUS-4862 prevent zero length/corrupt files
+                        // NEXUS-4871 prevent zero length/corrupt files
                         if ( target.length() == 0 )
                         {
                             target.delete();
@@ -317,7 +317,7 @@ public class DefaultFSAttributeStorage
             {
                 if ( target.length() == 0 )
                 {
-                    // NEXUS-4862
+                    // NEXUS-4871
                     throw new InvalidInputException( "Attribute of " + uid + " is empty!" );
                 }
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultFSAttributeStorage.java
@@ -229,7 +229,10 @@ public class DefaultFSAttributeStorage
                     catch ( IOException ex )
                     {
                         // NEXUS-4862 prevent zero length/corrupt files
-                        target.delete();
+                        if ( target.length() == 0 )
+                        {
+                            target.delete();
+                        }
                         throw ex;
                     }
                     finally

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -239,7 +239,7 @@ public class DefaultLSAttributeStorage
 
                 if ( attributeItem.getLength() == 0 )
                 {
-                    // NEXUS-4862
+                    // NEXUS-4871
                     throw new InvalidInputException( "Attribute of " + uid + " is empty!" );
                 }
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/attributes/DefaultLSAttributeStorage.java
@@ -237,6 +237,12 @@ public class DefaultLSAttributeStorage
             {
                 StorageFileItem attributeItem = (StorageFileItem) attributeItemCandidate;
 
+                if ( attributeItem.getLength() == 0 )
+                {
+                    // NEXUS-4862
+                    throw new InvalidInputException( "Attribute of " + uid + " is empty!" );
+                }
+
                 attributeStream = attributeItem.getContentLocator().getContent();
 
                 result = marshaller.unmarshal( attributeStream );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -140,14 +140,14 @@ public class DefaultFSPeer
                     !item.getRepositoryItemUid().getBooleanAttributeValue( IsItemAttributeMetacontentAttribute.class );
 
                 if ( target != null && ( isCleanupNeeded ||
-                // NEXUS-4862 prevent zero length/corrupt files
+                // NEXUS-4871 prevent zero length/corrupt files
                     target.length() == 0 ) )
                 {
                     target.delete();
                 }
 
                 if ( hiddenTarget != null && ( isCleanupNeeded ||
-                // NEXUS-4862 prevent zero length/corrupt files
+                // NEXUS-4871 prevent zero length/corrupt files
                     hiddenTarget.length() == 0 ) )
                 {
                     hiddenTarget.delete();

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -126,11 +126,6 @@ public class DefaultFSPeer
             final RepositoryItemUidLock uidLock = item.getRepositoryItemUid().getLock();
             uidLock.lock( Action.create );
 
-            // if we ARE NOT handling attributes, do proper cleanup in case of IOEx
-            // if we ARE handling attributes, leave backups in case of IOEx
-            final boolean isCleanupNeeded =
-                !item.getRepositoryItemUid().getBooleanAttributeValue( IsItemAttributeMetacontentAttribute.class );
-
             try
             {
                 handleRenameOperation( hiddenTarget, target );
@@ -139,19 +134,26 @@ public class DefaultFSPeer
             }
             catch ( IOException e )
             {
-                if ( isCleanupNeeded )
-                {
-                    if ( target != null )
-                    {
-                        target.delete();
-                    }
+                // if we ARE NOT handling attributes, do proper cleanup in case of IOEx
+                // if we ARE handling attributes, leave backups in case of IOEx
+                final boolean isCleanupNeeded =
+                    !item.getRepositoryItemUid().getBooleanAttributeValue( IsItemAttributeMetacontentAttribute.class );
 
-                    if ( hiddenTarget != null )
-                    {
-                        hiddenTarget.delete();
-                    }
+                if ( target != null && ( isCleanupNeeded ||
+                // NEXUS-4862 prevent zero length/corrupt files
+                    target.length() == 0 ) )
+                {
+                    target.delete();
                 }
-                else
+
+                if ( hiddenTarget != null && ( isCleanupNeeded ||
+                // NEXUS-4862 prevent zero length/corrupt files
+                    hiddenTarget.length() == 0 ) )
+                {
+                    hiddenTarget.delete();
+                }
+
+                if ( !isCleanupNeeded )
                 {
                     getLogger().warn(
                         "No cleanup done for error that happened while trying to save attibutes of item {}, the backup is left as {}!",

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
@@ -12,13 +12,21 @@
  */
 package org.sonatype.nexus.proxy.attributes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
 import java.io.File;
+import java.util.Date;
 
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.MethodRule;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.configuration.model.CLocalStorage;
 import org.sonatype.nexus.configuration.model.CRepository;
 import org.sonatype.nexus.configuration.model.DefaultCRepository;
@@ -32,6 +40,7 @@ import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
 import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
 import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
 import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.sisu.litmus.testsupport.hamcrest.FileMatchers;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
@@ -182,4 +191,95 @@ public class DefaultAttributeStorageTest
 
         assertNull( attributeStorage.getAttributes( uid ) );
     }
+
+    @Test
+    public void testZeroLenghtFSAttributeStorage()
+        throws Exception
+    {
+        ApplicationConfiguration appCfg = lookup( ApplicationConfiguration.class );
+        File workDir = appCfg.getWorkingDirectory( "proxy/attributes-ng" );
+        workDir.mkdirs();
+
+        RepositoryItemUid uid = getRepositoryItemUidFactory().createUid( repository, "a/b/c.txt" );
+
+        File attFile = new File( workDir, repository.getId() + "/" + uid.getPath() );
+        attFile.getParentFile().mkdirs();
+
+        // make a zero length file
+        attFile.createNewFile();
+        assertThat( attFile, FileMatchers.sized( 0L ) );
+
+        final DefaultFSAttributeStorage fsStorage = new DefaultFSAttributeStorage( appCfg );
+
+        // check getAttributes is gonna delete it
+        Attributes att = fsStorage.getAttributes( uid );
+        assertThat( att, nullValue() );
+        assertThat( attFile, not( FileMatchers.exists() ) );
+
+        DefaultStorageFileItem file =
+            new DefaultStorageFileItem( repository, new ResourceStoreRequest( uid.getPath() ), true, true,
+                new StringContentLocator( "CONTENT" ) );
+
+        // make a zero length file
+        attFile.createNewFile();
+        long creationTime = new Date().getTime();
+        assertThat( attFile, FileMatchers.sized( 0L ) );
+
+        att = file.getRepositoryItemAttributes();
+        fsStorage.putAttributes( uid, att );
+
+        // put shall create the file
+        assertThat( attFile, FileMatchers.exists() );
+        // must be newer then the zero length file
+        assertThat( attFile.lastModified(), greaterThan( creationTime ) );
+
+        Attributes retAtt = fsStorage.getAttributes( uid );
+        assertThat( retAtt, notNullValue() );
+    }
+
+    @Test
+    public void testZeroLenghtLSAttributeStorage()
+        throws Exception
+    {
+        RepositoryItemUid uid = getRepositoryItemUidFactory().createUid( repository, "a/b/c.txt" );
+
+        File attFile = new File( localStorageDirectory, ".nexus/attributes/" + uid.getPath() );
+        attFile.getParentFile().mkdirs();
+
+        // cleanup
+        attFile.delete();
+        new File( localStorageDirectory, ".nexus/trash/.nexus/attributes/" + uid.getPath() ).delete();
+
+        // make a zero length file
+        attFile.createNewFile();
+        assertThat( attFile, FileMatchers.sized( 0L ) );
+
+        final DefaultLSAttributeStorage lsStorage = new DefaultLSAttributeStorage();
+
+        // check getAttributes is gonna delete it
+        Attributes att = lsStorage.getAttributes( uid );
+        assertThat( att, nullValue() );
+        assertThat( attFile, not( FileMatchers.exists() ) );
+
+        DefaultStorageFileItem file =
+            new DefaultStorageFileItem( repository, new ResourceStoreRequest( uid.getPath() ), true, true,
+                new StringContentLocator( "CONTENT" ) );
+
+        // make a zero length file
+        attFile.createNewFile();
+        long creationTime = new Date().getTime();
+        assertThat( attFile, FileMatchers.sized( 0L ) );
+
+        att = file.getRepositoryItemAttributes();
+        lsStorage.putAttributes( uid, att );
+
+        // put shall create the file
+        assertThat( attFile, FileMatchers.exists() );
+        // must be newer then the zero length file
+        assertThat( attFile.lastModified(), greaterThan( creationTime ) );
+
+        Attributes retAtt = lsStorage.getAttributes( uid );
+        assertThat( retAtt, notNullValue() );
+    }
+
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
@@ -196,6 +196,7 @@ public class DefaultAttributeStorageTest
     public void testZeroLenghtFSAttributeStorage()
         throws Exception
     {
+        // NEXUS-4871
         ApplicationConfiguration appCfg = lookup( ApplicationConfiguration.class );
         File workDir = appCfg.getWorkingDirectory( "proxy/attributes-ng" );
         workDir.mkdirs();
@@ -241,6 +242,7 @@ public class DefaultAttributeStorageTest
     public void testZeroLenghtLSAttributeStorage()
         throws Exception
     {
+        // NEXUS-4871
         RepositoryItemUid uid = getRepositoryItemUidFactory().createUid( repository, "a/b/c.txt" );
 
         File attFile = new File( localStorageDirectory, ".nexus/attributes/" + uid.getPath() );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/attributes/DefaultAttributeStorageTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 
 import org.codehaus.plexus.util.FileUtils;
@@ -221,9 +222,7 @@ public class DefaultAttributeStorageTest
             new DefaultStorageFileItem( repository, new ResourceStoreRequest( uid.getPath() ), true, true,
                 new StringContentLocator( "CONTENT" ) );
 
-        // make a zero length file
-        attFile.createNewFile();
-        long creationTime = new Date().getTime();
+        long creationTime = createFile( attFile );
         assertThat( attFile, FileMatchers.sized( 0L ) );
 
         att = file.getRepositoryItemAttributes();
@@ -268,8 +267,7 @@ public class DefaultAttributeStorageTest
                 new StringContentLocator( "CONTENT" ) );
 
         // make a zero length file
-        attFile.createNewFile();
-        long creationTime = new Date().getTime();
+        long creationTime = createFile( attFile );
         assertThat( attFile, FileMatchers.sized( 0L ) );
 
         att = file.getRepositoryItemAttributes();
@@ -282,6 +280,19 @@ public class DefaultAttributeStorageTest
 
         Attributes retAtt = lsStorage.getAttributes( uid );
         assertThat( retAtt, notNullValue() );
+    }
+
+    protected long createFile( File attFile )
+        throws IOException, InterruptedException
+    {
+        attFile.createNewFile();
+        long creationTime = new Date().getTime();
+
+        // https://github.com/sonatype/nexus/pull/308#r460989
+        // This may fail depending on the filesystem timestamp resolution (ext3 uses 1s IIRC)
+        Thread.sleep( 1500 );
+
+        return creationTime;
     }
 
 }


### PR DESCRIPTION
Fixed attribute storage to discard attribute files that are empty (ZERO length)

Also add test condition for this.
