### PR TITLE
NEXUS-4787: Upgrade EHCache to latest

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/cache/AbstractPathCache.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/cache/AbstractPathCache.java
@@ -18,27 +18,27 @@ package org.sonatype.nexus.proxy.cache;
 public abstract class AbstractPathCache
     implements PathCache
 {
-    public final boolean contains( String path )
+    public final boolean contains( final String path )
     {
         return doContains( makeKeyFromPath( path ) );
     }
 
-    public final boolean isExpired( String path )
+    public final boolean isExpired( final String path )
     {
         return doIsExpired( makeKeyFromPath( path ) );
     }
 
-    public final void put( String path, Object element )
+    public final void put( final String path, final Object element )
     {
         doPut( makeKeyFromPath( path ), element, -1 );
     }
 
-    public final void put( String path, Object element, int expiration )
+    public final void put( final String path, final Object element, final int expiration )
     {
         doPut( makeKeyFromPath( path ), element, expiration );
     }
 
-    public final boolean remove( String path )
+    public final boolean remove( final String path )
     {
         if ( contains( path ) )
         {
@@ -64,7 +64,7 @@ public abstract class AbstractPathCache
         return result;
     }
 
-    public abstract boolean removeWithChildren( String path );
+    public abstract boolean removeWithChildren( final String path );
 
     public final boolean purge()
     {

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
@@ -67,7 +67,6 @@ import org.sonatype.nexus.templates.TemplateManager;
 import org.sonatype.nexus.templates.TemplateSet;
 import org.sonatype.nexus.templates.repository.RepositoryTemplate;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
-import org.sonatype.plexus.components.ehcache.PlexusEhCacheWrapper;
 import org.sonatype.security.SecuritySystem;
 
 /**
@@ -140,9 +139,6 @@ public class DefaultNexus
      */
     @Requirement
     private SecuritySystem securitySystem;
-
-    @Requirement
-    private PlexusEhCacheWrapper cacheWrapper;
 
     @Requirement
     private ArtifactPackagingMapper artifactPackagingMapper;
@@ -439,8 +435,6 @@ public class DefaultNexus
 
         try
         {
-            cacheWrapper.start();
-
             // force config load and validation
             // applies configuration and notifies listeners
             nexusConfiguration.loadConfiguration( true );
@@ -532,8 +526,6 @@ public class DefaultNexus
         nexusConfiguration.dropInternals();
 
         securitySystem.stop();
-
-        cacheWrapper.stop();
 
         applicationStatusSource.getSystemStatus().setState( SystemState.STOPPED );
         

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>security-system</artifactId>
       <version>${plexus-security.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-ehcache</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.sonatype.security.realms</groupId>

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
@@ -56,6 +56,12 @@
         <artifactId>security-system</artifactId>
         <version>${plexus-security.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.sonatype.spice</groupId>
+            <artifactId>plexus-ehcache</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -96,12 +96,12 @@
       <artifactId>commons-httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.spice</groupId>
-      <artifactId>plexus-ehcache</artifactId>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-ehcache</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
+      <artifactId>ehcache-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.shiro</groupId>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
@@ -14,8 +14,11 @@ package org.sonatype.nexus.proxy.cache;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.StartingException;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.StoppingException;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
-import org.sonatype.plexus.components.ehcache.PlexusEhCacheWrapper;
+import org.sonatype.sisu.ehcache.CacheManagerComponent;
 
 /**
  * The Class EhCacheCacheManager is a thin wrapper around EhCache, just to make things going.
@@ -25,16 +28,16 @@ import org.sonatype.plexus.components.ehcache.PlexusEhCacheWrapper;
 @Component( role = CacheManager.class )
 public class EhCacheCacheManager
     extends AbstractLoggingComponent
-    implements CacheManager
+    implements CacheManager, Startable
 {
     @Requirement
-    private PlexusEhCacheWrapper cacheManager;
-    
+    private CacheManagerComponent cacheManagerComponent;
+
     public static final String SINGLE_PATH_CACHE_NAME = "path-cache";
 
     public PathCache getPathCache( String cache )
     {
-        net.sf.ehcache.CacheManager ehCacheManager = this.cacheManager.getEhCacheManager();
+        final net.sf.ehcache.CacheManager ehCacheManager = cacheManagerComponent.getCacheManager();
 
         if ( !ehCacheManager.cacheExists( SINGLE_PATH_CACHE_NAME ) )
         {
@@ -42,5 +45,19 @@ public class EhCacheCacheManager
         }
 
         return new EhCachePathCache( cache, ehCacheManager.getEhcache( SINGLE_PATH_CACHE_NAME ) );
+    }
+
+    @Override
+    public void start()
+        throws StartingException
+    {
+        // nop
+    }
+
+    @Override
+    public void stop()
+        throws StoppingException
+    {
+        cacheManagerComponent.shutdown();
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
@@ -14,9 +14,6 @@ package org.sonatype.nexus.proxy.cache;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.StartingException;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.StoppingException;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.sisu.ehcache.CacheManagerComponent;
 
@@ -28,7 +25,7 @@ import org.sonatype.sisu.ehcache.CacheManagerComponent;
 @Component( role = CacheManager.class )
 public class EhCacheCacheManager
     extends AbstractLoggingComponent
-    implements CacheManager, Startable
+    implements CacheManager
 {
     @Requirement
     private CacheManagerComponent cacheManagerComponent;
@@ -45,19 +42,5 @@ public class EhCacheCacheManager
         }
 
         return new EhCachePathCache( cache, ehCacheManager.getEhcache( SINGLE_PATH_CACHE_NAME ) );
-    }
-
-    @Override
-    public void start()
-        throws StartingException
-    {
-        // nop
-    }
-
-    @Override
-    public void stop()
-        throws StoppingException
-    {
-        cacheManagerComponent.shutdown();
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCachePathCache.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCachePathCache.java
@@ -22,6 +22,8 @@ import net.sf.ehcache.Statistics;
 
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 
+import com.google.common.base.Preconditions;
+
 /**
  * The Class EhCacheCache is a thin wrapper around EHCache just to make things going.
  * 
@@ -42,8 +44,8 @@ public class EhCachePathCache
      */
     public EhCachePathCache( final String repositoryId, final Ehcache cache )
     {
-        this._repositoryId = repositoryId;
-        this._ec = cache;
+        this._repositoryId = Preconditions.checkNotNull( repositoryId );
+        this._ec = Preconditions.checkNotNull( cache );
     }
 
     protected String getRepositoryId()
@@ -56,12 +58,12 @@ public class EhCachePathCache
         return _ec;
     }
 
-    public boolean doContains( String key )
+    public boolean doContains( final String key )
     {
         return getEHCache().get( key ) != null;
     }
 
-    public boolean doIsExpired( String key )
+    public boolean doIsExpired( final String key )
     {
         if ( getEHCache().isKeyInCache( key ) )
         {
@@ -81,7 +83,7 @@ public class EhCachePathCache
         }
     }
 
-    public void doPut( String key, Object element, int expiration )
+    public void doPut( final String key, final Object element, final int expiration )
     {
         Element el = new Element( key, element );
         if ( expiration != -1 )
@@ -120,7 +122,7 @@ public class EhCachePathCache
         // getEHCache().flush();
 
         // this above is not true anymore, since the "shared-cache" implementor forgot about the fact that using purge()
-        // will purge _all_ caches (it purges the one shared!), not just this repo's cache 
+        // will purge _all_ caches (it purges the one shared!), not just this repo's cache
         return removeWithChildren( RepositoryItemUid.PATH_ROOT );
     }
 

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/users/ForgotPasswordTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/users/ForgotPasswordTest.java
@@ -144,8 +144,16 @@ public class ForgotPasswordTest
 
     @Override
     public void tearDown()
+        throws Exception
     {
-        server.stop();
+        try
+        {
+            server.stop();
+        }
+        finally
+        {
+            super.tearDown();
+        }
     }
 
 }

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/security/StatelessAndStatefulWebSessionManagerEhCacheTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/security/StatelessAndStatefulWebSessionManagerEhCacheTest.java
@@ -12,30 +12,42 @@
  */
 package org.sonatype.nexus.security;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import org.apache.shiro.cache.ehcache.EhCache;
-import org.apache.shiro.cache.ehcache.EhCacheManager;
-import org.apache.shiro.session.mgt.eis.CachingSessionDAO;
-import org.hamcrest.MatcherAssert;
-
-import java.io.Serializable;
-
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.io.Serializable;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+
+import org.apache.shiro.cache.ehcache.EhCache;
+import org.apache.shiro.cache.ehcache.EhCacheManager;
+import org.apache.shiro.session.mgt.eis.CachingSessionDAO;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+
 /**
- * Repeats the tests of StatelessAndStatefulWebSessionManager, using ehCache as the session store.
- * This test will check the cache instance directly (using the ehcache API to verify the cached contents)
+ * Repeats the tests of StatelessAndStatefulWebSessionManager, using ehCache as the session store. This test will check
+ * the cache instance directly (using the ehcache API to verify the cached contents)
  */
-public class StatelessAndStatefulWebSessionManagerEhCacheTest extends StatelessAndStatefulWebSessionManagerTest
+public class StatelessAndStatefulWebSessionManagerEhCacheTest
+    extends StatelessAndStatefulWebSessionManagerTest
 {
+    private EhCacheManager ehCacheManager = null;
+
     private CacheManager cacheManager = null;
+
+    @After
+    public void tearDownSecurityObjects()
+    {
+        // clean up after ourselves
+        ehCacheManager.destroy();
+    }
 
     protected void setupCacheManager( NexusWebRealmSecurityManager securityManager )
     {
-        EhCacheManager ehCacheManager = new EhCacheManager();
+        ehCacheManager = new EhCacheManager();
         ehCacheManager.init();
 
         cacheManager = ehCacheManager.getCacheManager();
@@ -52,13 +64,13 @@ public class StatelessAndStatefulWebSessionManagerEhCacheTest extends StatelessA
         MatcherAssert.assertThat( sessionDAO.getActiveSessionsCache(), is( instanceOf( EhCache.class ) ) );
     }
 
-
     protected void verifyNoSessionStored()
     {
         super.verifyNoSessionStored();
 
         // use the EhCache API to verify no sessions are stored
-        MatcherAssert.assertThat( cacheManager.getCache( CachingSessionDAO.ACTIVE_SESSION_CACHE_NAME ).getSize(), is( 0 ) );
+        MatcherAssert.assertThat( cacheManager.getCache( CachingSessionDAO.ACTIVE_SESSION_CACHE_NAME ).getSize(),
+            is( 0 ) );
 
     }
 
@@ -71,7 +83,7 @@ public class StatelessAndStatefulWebSessionManagerEhCacheTest extends StatelessA
         Cache cache = cacheManager.getCache( CachingSessionDAO.ACTIVE_SESSION_CACHE_NAME );
 
         MatcherAssert.assertThat( cache.getSize(), is( 1 ) );
-       // again using the sessionId
+        // again using the sessionId
         MatcherAssert.assertThat( cache.get( sessionId ), notNullValue() );
 
     }

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/AppContextModule.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/AppContextModule.java
@@ -1,0 +1,41 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.web;
+
+import org.sonatype.appcontext.AppContext;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.AbstractModule;
+
+/**
+ * Module exposing AppContext as component.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class AppContextModule
+    extends AbstractModule
+{
+    private final AppContext appContext;
+
+    public AppContextModule( final AppContext appContext )
+    {
+        this.appContext = Preconditions.checkNotNull( appContext );
+    }
+
+    @Override
+    protected void configure()
+    {
+        bind( AppContext.class ).toInstance( appContext );
+    }
+}

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.web;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -75,25 +76,27 @@ public class PlexusContainerContextListener
         {
             try
             {
-                AppContext plexusContext =
+                final AppContext plexusContext =
                     createContainerContext( context,
                         (Map<String, Object>) context.getAttribute( AppContext.class.getName() ) );
 
-                ContainerConfiguration plexusConfiguration =
+                final ContainerConfiguration plexusConfiguration =
                     new DefaultContainerConfiguration().setName( context.getServletContextName() ).setContainerConfigurationURL(
                         plexusXmlFile.toURI().toURL() ).setContext( (Map) plexusContext ).setAutoWiring( true ).setClassPathScanning(
                         PlexusConstants.SCANNING_INDEX ).setComponentVisibility( PlexusConstants.GLOBAL_VISIBILITY );
+
+                final ArrayList<Module> modules = new ArrayList<Module>( 1 );
+                modules.add( new AppContextModule( plexusContext ) );
 
                 final Module[] customModules = (Module[]) context.getAttribute( CUSTOM_MODULES );
 
                 if ( customModules != null )
                 {
-                    plexusContainer = new DefaultPlexusContainer( plexusConfiguration, customModules );
+                    modules.addAll( Arrays.asList( customModules ) );
                 }
-                else
-                {
-                    plexusContainer = new DefaultPlexusContainer( plexusConfiguration );
-                }
+
+                plexusContainer =
+                    new DefaultPlexusContainer( plexusConfiguration, modules.toArray( new Module[modules.size()] ) );
 
                 context.setAttribute( PlexusConstants.PLEXUS_KEY, plexusContainer );
 

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -1424,6 +1424,13 @@
                   </includes>
                   <message>Use the Eclipse/Jetty version defined in nexus parent. See jetty.version property</message>
                 </bannedDependencies>
+                <bannedDependencies>
+                  <searchTransitive>true</searchTransitive>
+                  <excludes>
+                    <exclude>org.sonatype.spice:plexus-ehcache</exclude>
+                  </excludes>
+                  <message>Use the org.sonatype.sisu:sisu-ehcache instead of plexus-ehcache!</message>
+                </bannedDependencies>
 
                 <!-- <requirePluginVersions> <banSnapshots>false</banSnapshots> </requirePluginVersions> -->
               </rules>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -170,7 +170,7 @@
     <plexus-app-events.version>1.0.1</plexus-app-events.version>
     <plexus-cli.version>1.2</plexus-cli.version>
     <plexus-digest.version>1.1</plexus-digest.version>
-    <sisu-ehcache.version>1.0-SNAPSHOT</sisu-ehcache.version>
+    <sisu-ehcache.version>1.0</sisu-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2</plexus-jetty7.version>
@@ -238,7 +238,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>3.0</version>
       </dependency>
 
       <dependency>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -170,7 +170,7 @@
     <plexus-app-events.version>1.0.1</plexus-app-events.version>
     <plexus-cli.version>1.2</plexus-cli.version>
     <plexus-digest.version>1.1</plexus-digest.version>
-    <plexus-ehcache.version>1.3</plexus-ehcache.version>
+    <sisu-ehcache.version>1.0-SNAPSHOT</sisu-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2</plexus-jetty7.version>
@@ -238,7 +238,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>2.1</version>
+        <version>3.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -533,6 +533,12 @@
         <groupId>org.sonatype.security</groupId>
         <artifactId>security-system</artifactId>
         <version>${plexus-security.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.sonatype.spice</groupId>
+            <artifactId>plexus-ehcache</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.sonatype.security.realms</groupId>
@@ -811,15 +817,14 @@
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.spice</groupId>
-        <artifactId>plexus-ehcache</artifactId>
-        <version>${plexus-ehcache.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-ehcache</artifactId>
+        <version>${sisu-ehcache.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-core</artifactId>
+        <version>2.5.1</version>
       </dependency>
 
       <!-- Restlet.org et al -->
@@ -937,18 +942,6 @@
         <artifactId>commons-lang</artifactId>
         <version>2.3</version>
         <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>ehcache</artifactId>
-        <version>1.6.2</version>
-        <type>jar</type>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.sonatype.spice</groupId>


### PR DESCRIPTION
Currently it is 2.5.1. 

This change bumps EHCache version to latest,
but is not trivial one, especially since we have a legacy plexus
component used by nexus core and security. 

As the sisu-ehcache was cleaned, GAV changed to reflect these changes and is made a
drop-in replacement for the old plexus one. But, the new
pure SISU ehcache component depends on new AppContext, this
is bumped too (anyway needed for Jetty8 incoming changes).
