### PR TITLE
NEXUS-4885: LoggerContext.reset() does not clear status messages

### DIFF
--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
@@ -52,6 +52,7 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.status.StatusManager;
 import ch.qos.logback.core.util.StatusPrinter;
 
 //TODO configuration operations should be locking
@@ -390,6 +391,7 @@ public class LogbackLogManager
             JoranConfigurator configurator = new JoranConfigurator();
             configurator.setContext( lc );
             lc.reset();
+            lc.getStatusManager().clear();
             configurator.doConfigure( new File( logConfigDir, LOG_CONF ) );
         }
         catch ( JoranException je )


### PR DESCRIPTION
This causes a gradual classloader-leak in the nexus-mock tests, intermittently leading to a PermGen OOM.
See also http://jira.qos.ch/browse/LBCLASSIC-273 which mentions StatusManager.clear() as a workaround.
