### PR TITLE
NXCM-3133 - Made it possible to have multiple PathProtectionDescriptor for one PlexusResource

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AdvancedPlexusResourceSecurity.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AdvancedPlexusResourceSecurity.java
@@ -1,0 +1,20 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.rest;
+
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+
+public interface AdvancedPlexusResourceSecurity
+{
+    PathProtectionDescriptor[] getResourceProtections();
+}

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AdvancedSecurityPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AdvancedSecurityPlexusResource.java
@@ -13,8 +13,17 @@
 package org.sonatype.nexus.rest;
 
 import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.plexus.rest.resource.PlexusResource;
 
-public interface AdvancedPlexusResourceSecurity
+/**
+ * Allow automatically managed Rest Resource to have multiple security constraints.
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public interface AdvancedSecurityPlexusResource
+    extends PlexusResource
 {
+
     PathProtectionDescriptor[] getResourceProtections();
+
 }

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
@@ -218,15 +218,34 @@ public class NexusApplication
     @Override
     protected void handlePlexusResourceSecurity( PlexusResource resource )
     {
-        PathProtectionDescriptor descriptor = resource.getResourceProtection();
+        PathProtectionDescriptor[] descriptors;
+        if ( resource instanceof AdvancedPlexusResourceSecurity )
+        {
+            descriptors = ( (AdvancedPlexusResourceSecurity) resource ).getResourceProtections();
+        }
+        else
+        {
+            PathProtectionDescriptor descriptor = resource.getResourceProtection();
+            if ( descriptor == null )
+            {
+                descriptors = null;
+            }
+            else
+            {
+                descriptors = new PathProtectionDescriptor[] { descriptor };
+            }
+        }
 
-        if ( descriptor == null )
+        if ( descriptors == null )
         {
             return;
         }
 
-        this.protectedPathManager.addProtectedResource( "/service/*"
-                                                        + descriptor.getPathPattern(), descriptor.getFilterExpression() );
+        for ( PathProtectionDescriptor descriptor : descriptors )
+        {
+            this.protectedPathManager.addProtectedResource( "/service/*" + descriptor.getPathPattern(),
+                descriptor.getFilterExpression() );
+        }
     }
 
     @Override

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
@@ -34,6 +34,7 @@ import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
 import org.sonatype.plexus.rest.resource.PlexusResource;
 import org.sonatype.security.web.ProtectedPathManager;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.thoughtworks.xstream.XStream;
 
 /**
@@ -219,9 +220,9 @@ public class NexusApplication
     protected void handlePlexusResourceSecurity( PlexusResource resource )
     {
         PathProtectionDescriptor[] descriptors;
-        if ( resource instanceof AdvancedPlexusResourceSecurity )
+        if ( resource instanceof AdvancedSecurityPlexusResource )
         {
-            descriptors = ( (AdvancedPlexusResourceSecurity) resource ).getResourceProtections();
+            descriptors = ( (AdvancedSecurityPlexusResource) resource ).getResourceProtections();
         }
         else
         {
@@ -255,4 +256,11 @@ public class NexusApplication
 
         handlePlexusResourceSecurity( resource );
     }
+
+    @VisibleForTesting
+    void setProtectedPathManager( ProtectedPathManager pathManager )
+    {
+        this.protectedPathManager = pathManager;
+    }
+
 }

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/NexusApplicationTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/NexusApplicationTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -40,6 +41,7 @@ public class NexusApplicationTest
         verify( desc ).getFilterExpression();
         verify( desc ).getPathPattern();
         verify( pathManager ).addProtectedResource( "/service/*null", null );
+        verifyNoMoreInteractions( resource, desc, pathManager );
     }
 
     @Test
@@ -59,6 +61,7 @@ public class NexusApplicationTest
         verify( desc2 ).getFilterExpression();
         verify( desc2 ).getPathPattern();
         verify( pathManager, times( 2 ) ).addProtectedResource( "/service/*null", null );
+        verifyNoMoreInteractions( resource, desc1, desc2, pathManager );
     }
 
 }

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/NexusApplicationTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/NexusApplicationTest.java
@@ -1,0 +1,64 @@
+package org.sonatype.nexus.rest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.plexus.rest.resource.PlexusResource;
+import org.sonatype.security.web.ProtectedPathManager;
+
+public class NexusApplicationTest
+{
+
+    private NexusApplication nexusApp;
+
+    private ProtectedPathManager pathManager;
+
+    @Before
+    public void createApp()
+    {
+        nexusApp = new NexusApplication();
+        pathManager = mock( ProtectedPathManager.class );
+        nexusApp.setProtectedPathManager( pathManager );
+    }
+
+    @Test
+    public void regularResource()
+    {
+        PlexusResource resource = mock( PlexusResource.class );
+        PathProtectionDescriptor desc = mock( PathProtectionDescriptor.class );
+        when( resource.getResourceProtection() ).thenReturn( desc );
+
+        nexusApp.handlePlexusResourceSecurity( resource );
+
+        verify( resource ).getResourceProtection();
+        verify( desc ).getFilterExpression();
+        verify( desc ).getPathPattern();
+        verify( pathManager ).addProtectedResource( "/service/*null", null );
+    }
+
+    @Test
+    public void regularAdvancedSecurityResource()
+    {
+        AdvancedSecurityPlexusResource resource = mock( AdvancedSecurityPlexusResource.class );
+        PathProtectionDescriptor desc1 = mock( PathProtectionDescriptor.class );
+        PathProtectionDescriptor desc2 = mock( PathProtectionDescriptor.class );
+        when( resource.getResourceProtections() ).thenReturn( new PathProtectionDescriptor[] { desc1, desc2 } );
+
+        nexusApp.handlePlexusResourceSecurity( resource );
+
+        verify( resource, never() ).getResourceProtection();
+        verify( resource ).getResourceProtections();
+        verify( desc1 ).getFilterExpression();
+        verify( desc1 ).getPathPattern();
+        verify( desc2 ).getFilterExpression();
+        verify( desc2 ).getPathPattern();
+        verify( pathManager, times( 2 ) ).addProtectedResource( "/service/*null", null );
+    }
+
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/security/ThreePrivsSecurityResource.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/security/ThreePrivsSecurityResource.java
@@ -1,0 +1,19 @@
+package org.sonatype.nexus.plugins.security;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.sonatype.security.realms.tools.AbstractStaticSecurityResource;
+import org.sonatype.security.realms.tools.StaticSecurityResource;
+
+@Component( role = StaticSecurityResource.class, hint = "ThreePrivsSecurityResource" )
+public class ThreePrivsSecurityResource
+    extends AbstractStaticSecurityResource
+    implements StaticSecurityResource
+{
+
+    @Override
+    public String getResourcePath()
+    {
+        return "/META-INF/nexus-three-privs-plugin-security.xml";
+    }
+
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/security/api/ThreePrivsSecurityPlexusResource.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/security/api/ThreePrivsSecurityPlexusResource.java
@@ -1,0 +1,57 @@
+package org.sonatype.nexus.plugins.security.api;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.restlet.Context;
+import org.restlet.data.Request;
+import org.restlet.data.Response;
+import org.restlet.resource.ResourceException;
+import org.restlet.resource.Variant;
+import org.sonatype.nexus.rest.AbstractNexusPlexusResource;
+import org.sonatype.nexus.rest.AdvancedSecurityPlexusResource;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.plexus.rest.resource.PlexusResource;
+
+@Component( role = PlexusResource.class, hint = "ThreePrivsSecurityPlexusResource" )
+public class ThreePrivsSecurityPlexusResource extends AbstractNexusPlexusResource
+implements AdvancedSecurityPlexusResource
+{
+
+    private static final String URI = "/three_privs";
+
+    private static final PathProtectionDescriptor[] PROTECTIONS = new PathProtectionDescriptor[] {
+        new PathProtectionDescriptor( URI, "authcBasic,perms[nexus:threepriv:one]" ),
+        new PathProtectionDescriptor( URI, "authcBasic,perms[nexus:threepriv:two]" ),
+        new PathProtectionDescriptor( URI, "authcBasic,perms[nexus:threepriv:three]" ) };
+
+    @Override
+    public PathProtectionDescriptor[] getResourceProtections()
+    {
+        return PROTECTIONS;
+    }
+
+    @Override
+    public String getResourceUri()
+    {
+        return URI;
+    }
+
+    @Override
+    public PathProtectionDescriptor getResourceProtection()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getPayloadInstance()
+    {
+        return null;
+    }
+
+    @Override
+    public Object get( Context context, Request request, Response response, Variant variant )
+        throws ResourceException
+    {
+        return "pong";
+    }
+
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/resources/META-INF/nexus-three-privs-plugin-security.xml
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/resources/META-INF/nexus-three-privs-plugin-security.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2008-2012 Sonatype, Inc.
+
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/pro/attributions
+    Sonatype and Sonatype Nexus are trademarks of Sonatype, Inc. Apache Maven is a trademark of the Apache Foundation.
+    M2Eclipse is a trademark of the Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<!-- Default nexus security configuration -->
+<!-- used as default config source -->
+<security>
+  <version>2.0.1</version>
+  <roles>
+  </roles>
+  <privileges>
+    <privilege>
+      <id>threepriv-one</id>
+      <type>method</type>
+      <name>one</name>
+      <description>one</description>
+      <properties>
+        <property>
+          <key>method</key>
+          <value>create,read</value>
+        </property>
+        <property>
+          <key>permission</key>
+          <value>nexus:threepriv:one</value>
+        </property>
+      </properties>
+    </privilege>
+    <privilege>
+      <id>threepriv-two</id>
+      <type>method</type>
+      <name>one</name>
+      <description>one</description>
+      <properties>
+        <property>
+          <key>method</key>
+          <value>create,read</value>
+        </property>
+        <property>
+          <key>permission</key>
+          <value>nexus:threepriv:two</value>
+        </property>
+      </properties>
+    </privilege>
+    <privilege>
+      <id>threepriv-three</id>
+      <type>method</type>
+      <name>one</name>
+      <description>one</description>
+      <properties>
+        <property>
+          <key>method</key>
+          <value>create,read</value>
+        </property>
+        <property>
+          <key>permission</key>
+          <value>nexus:threepriv:three</value>
+        </property>
+      </properties>
+    </privilege>
+  </privileges>
+</security>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm3133/NXCM3133AdvancedSecurityPlexusResourceIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nxcm3133/NXCM3133AdvancedSecurityPlexusResourceIT.java
@@ -1,0 +1,54 @@
+package org.sonatype.nexus.integrationtests.nxcm3133;
+
+import static org.sonatype.nexus.test.utils.NexusRequestMatchers.isSuccessful;
+import static org.sonatype.nexus.test.utils.NexusRequestMatchers.respondsWithStatusCode;
+
+import java.io.IOException;
+
+import org.hamcrest.Matcher;
+import org.restlet.data.Response;
+import org.sonatype.nexus.integrationtests.AbstractPrivilegeTest;
+import org.sonatype.nexus.integrationtests.RequestFacade;
+import org.sonatype.nexus.integrationtests.TestContainer;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class NXCM3133AdvancedSecurityPlexusResourceIT
+    extends AbstractPrivilegeTest
+{
+    @DataProvider
+    public Object[][] privs()
+    {
+        return new Object[][] { //
+            new Object[] { "threepriv-one" },//
+            new Object[] { "threepriv-three" }, //
+            new Object[] { "threepriv-two" } //
+        };
+    }
+
+    @Test( dataProvider = "privs" )
+    public void access( String priv )
+        throws IOException
+    {
+        TestContainer.getInstance().getTestContext().setSecureTest( true );
+
+        // no privilege
+        check( respondsWithStatusCode( 403 ) );
+
+        // give priv
+        addPrivilege( TEST_USER_NAME, priv );
+        check( isSuccessful() );
+        removePrivilege( TEST_USER_NAME, priv );
+        check( respondsWithStatusCode( 403 ) );
+    }
+
+    protected void check( Matcher<Response> matcher )
+        throws IOException
+    {
+        TestContainer.getInstance().getTestContext().setUsername( TEST_USER_NAME );
+        TestContainer.getInstance().getTestContext().setPassword( TEST_USER_PASSWORD );
+
+        RequestFacade.doGet( "service/local/three_privs", matcher );
+    }
+
+}

--- a/nexus/nexus-test-harness/nexus-test-utils/src/main/java/org/sonatype/nexus/integrationtests/NexusRestClient.java
+++ b/nexus/nexus-test-harness/nexus-test-utils/src/main/java/org/sonatype/nexus/integrationtests/NexusRestClient.java
@@ -207,7 +207,7 @@ public class NexusRestClient
             final String responseText = entity.getText();
             if ( responseMatcher != null )
             {
-                assertThat( response, responseMatcher );
+                assertThat( responseText, response, responseMatcher );
             }
             return responseText;
         }


### PR DESCRIPTION
Quick way to allow multiple PathProtectionDescriptor  w/o breaking current API.

This can be moved outside to plexus-restlet-brige.
