### PR TITLE
NEXUS-4894 - Add some locks for read/write operations

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/configuration/RevertableConfiguration.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/configuration/RevertableConfiguration.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.configuration;
 
+import java.util.concurrent.locks.Lock;
+
 import org.sonatype.configuration.ConfigurationException;
 
 /**
@@ -49,4 +51,19 @@ public interface RevertableConfiguration
     // ==
     
     Object getConfiguration( boolean forWrite );
+
+    /**
+     * Returns the configuration lock used on write operations (like {@link #commitChanges()} and
+     * {@link #rollbackChanges()})
+     * 
+     * @return
+     */
+    Lock getConfigurationWriteLock();
+
+    /**
+     * Returns the configuration lock used on read operations (like {@link #validateChanges()})
+     * 
+     * @return
+     */
+    Lock getConfigurationReadLock();
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/AbstractDefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/AbstractDefaultTargetRegistryTest.java
@@ -1,0 +1,67 @@
+package org.sonatype.nexus.proxy.target;
+
+import java.util.Arrays;
+
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.proxy.AbstractNexusTestCase;
+import org.sonatype.nexus.proxy.maven.maven1.Maven1ContentClass;
+import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
+import org.sonatype.nexus.proxy.registry.ContentClass;
+
+/**
+ * Support class for DefaultTargetRegistry testing
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public abstract class AbstractDefaultTargetRegistryTest
+    extends AbstractNexusTestCase
+{
+
+    protected ApplicationConfiguration applicationConfiguration;
+
+    protected TargetRegistry targetRegistry;
+
+    protected ContentClass maven1;
+
+    protected ContentClass maven2;
+
+    public AbstractDefaultTargetRegistryTest()
+    {
+        super();
+    }
+
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        applicationConfiguration = lookup( ApplicationConfiguration.class );
+
+        maven1 = new Maven1ContentClass();
+
+        maven2 = new Maven2ContentClass();
+
+        targetRegistry = lookup( TargetRegistry.class );
+
+        // adding two targets
+        Target t1 =
+            new Target( "maven2-public", "Maven2 (public)", maven2,
+                Arrays.asList( new String[] { "/org/apache/maven/((?!sources\\.).)*" } ) );
+
+        targetRegistry.addRepositoryTarget( t1 );
+
+        Target t2 =
+            new Target( "maven2-with-sources", "Maven2 sources", maven2,
+                Arrays.asList( new String[] { "/org/apache/maven/.*" } ) );
+
+        targetRegistry.addRepositoryTarget( t2 );
+
+        Target t3 =
+            new Target( "maven1", "Maven1", maven1, Arrays.asList( new String[] { "/org\\.apache\\.maven.*" } ) );
+
+        targetRegistry.addRepositoryTarget( t3 );
+
+        applicationConfiguration.saveConfiguration();
+    }
+
+}

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
@@ -1,0 +1,136 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.target;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Collections2.transform;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Test;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+/**
+ * Long run test that tries DefaultTargetRegistry with 100 threads and more then a thousand operations looking for
+ * concurrency exceptions
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public class DefaultTargetRegistryLRTest
+    extends AbstractDefaultTargetRegistryTest
+{
+    private Function<Target, String> toIds = new Function<Target, String>()
+    {
+        @Override
+        public String apply( Target input )
+        {
+            checkNotNull( input );
+            return input.getId();
+        }
+    };
+
+    private static final int OPERATIONS = 2000;
+
+    private static final int THREADS = OPERATIONS / 10;
+
+    public void single( final int ref )
+        throws Exception
+    {
+        List<String> ids = Lists.newArrayList();
+        for ( int j = 0; j < 5; j++ )
+        {
+
+            String id = Long.toHexString( System.nanoTime() + ref + j + ref * j );
+            Target target = new Target( id, "name" + id, j % 3 == 0 ? maven1 : maven2, Arrays.asList( ".*/" + id ) );
+            targetRegistry.addRepositoryTarget( target );
+            ids.add( id );
+        }
+
+        applicationConfiguration.saveConfiguration();
+
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( t, notNullValue() );
+            assertThat( t.getId(), equalTo( id ) );
+            assertThat( t.getName(), equalTo( "name" + id ) );
+        }
+
+        Collection<String> targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        targets.containsAll( ids );
+
+        for ( String id : ids )
+        {
+            targetRegistry.removeRepositoryTarget( id );
+            // I really wanna try to break this
+            applicationConfiguration.saveConfiguration();
+        }
+
+        targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( "ref: " + ref + " ids: " + ids, t, nullValue() );
+            assertThat( "ref: " + ref + " ids: " + ids, targets, not( containsInAnyOrder( id ) ) );
+        }
+    }
+
+    @Test
+    public void testConcurrency()
+        throws Exception
+    {
+        List<FutureTask<String>> calls = Lists.newArrayList();
+        for ( int i = 0; i < OPERATIONS; i++ )
+        {
+            final int j = i;
+            Callable<String> c = new Callable<String>()
+            {
+                @Override
+                public String call()
+                    throws Exception
+                {
+                    single( j );
+
+                    return "ok";
+                }
+            };
+            calls.add( new FutureTask<String>( c ) );
+        }
+
+        Executor executor = Executors.newFixedThreadPool( THREADS );
+        for ( FutureTask<String> futureTask : calls )
+        {
+            executor.execute( futureTask );
+        }
+
+        for ( FutureTask<String> futureTask : calls )
+        {
+            assertThat( futureTask.get(), equalTo( "ok" ) );
+        }
+    }
+
+}

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
@@ -12,79 +12,20 @@
  */
 package org.sonatype.nexus.proxy.target;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Collections2.transform;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.FutureTask;
 
 import org.junit.Test;
-import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
-import org.sonatype.nexus.proxy.AbstractNexusTestCase;
-import org.sonatype.nexus.proxy.maven.maven1.Maven1ContentClass;
-import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
-import org.sonatype.nexus.proxy.registry.ContentClass;
 import org.sonatype.nexus.proxy.repository.Repository;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
+/**
+ * Simple DefaultTargetRegistry creation test
+ */
 public class DefaultTargetRegistryTest
-    extends AbstractNexusTestCase
+    extends AbstractDefaultTargetRegistryTest
 {
-    protected ApplicationConfiguration applicationConfiguration;
-
-    protected TargetRegistry targetRegistry;
-
-    protected ContentClass maven1;
-
-    protected ContentClass maven2;
-
-    protected void setUp()
-        throws Exception
-    {
-        super.setUp();
-
-        applicationConfiguration = lookup( ApplicationConfiguration.class );
-
-        maven1 = new Maven1ContentClass();
-
-        maven2 = new Maven2ContentClass();
-
-        targetRegistry = lookup( TargetRegistry.class );
-
-        // adding two targets
-        Target t1 = new Target( "maven2-public", "Maven2 (public)", maven2, Arrays
-            .asList( new String[] { "/org/apache/maven/((?!sources\\.).)*" } ) );
-
-        targetRegistry.addRepositoryTarget( t1 );
-
-        Target t2 = new Target( "maven2-with-sources", "Maven2 sources", maven2, Arrays
-            .asList( new String[] { "/org/apache/maven/.*" } ) );
-
-        targetRegistry.addRepositoryTarget( t2 );
-
-        Target t3 = new Target( "maven1", "Maven1", maven1, Arrays.asList( new String[] { "/org\\.apache\\.maven.*" } ) );
-
-        targetRegistry.addRepositoryTarget( t3 );
-
-        applicationConfiguration.saveConfiguration();
-    }
-
     @Test
     public void testSimpleM2()
     {
@@ -150,96 +91,6 @@ public class DefaultTargetRegistryTest
         assertNotNull( ts );
 
         assertEquals( 0, ts.getMatches().size() );
-    }
-
-    private Function<Target, String> toIds = new Function<Target, String>()
-    {
-        @Override
-        public String apply( Target input )
-        {
-            checkNotNull( input );
-            return input.getId();
-        }
-    };
-
-    private static final int OPERATIONS = 2000;
-
-    private static final int THREADS = OPERATIONS / 10;
-
-    public void single( final int ref )
-        throws Exception
-    {
-        List<String> ids = Lists.newArrayList();
-        for ( int j = 0; j < 5; j++ )
-        {
-
-            String id = Long.toHexString( System.nanoTime() + ref + j + ref * j );
-            Target target = new Target( id, "name" + id, j % 3 == 0 ? maven1 : maven2, Arrays.asList( ".*/" + id ) );
-            targetRegistry.addRepositoryTarget( target );
-            ids.add( id );
-        }
-
-        applicationConfiguration.saveConfiguration();
-
-        for ( String id : ids )
-        {
-            Target t = targetRegistry.getRepositoryTarget( id );
-            assertThat( t, notNullValue() );
-            assertThat( t.getId(), equalTo( id ) );
-            assertThat( t.getName(), equalTo( "name" + id ) );
-        }
-
-        Collection<String> targets = transform( targetRegistry.getRepositoryTargets(), toIds );
-        targets.containsAll( ids );
-
-        for ( String id : ids )
-        {
-            targetRegistry.removeRepositoryTarget( id );
-            // I really wanna try to break this
-            applicationConfiguration.saveConfiguration();
-        }
-
-        targets = transform( targetRegistry.getRepositoryTargets(), toIds );
-        for ( String id : ids )
-        {
-            Target t = targetRegistry.getRepositoryTarget( id );
-            assertThat( "ref: " + ref + " ids: " + ids, t, nullValue() );
-            assertThat( "ref: " + ref + " ids: " + ids, targets, not( containsInAnyOrder( id ) ) );
-        }
-    }
-
-    @Test
-    public void testConcurrency()
-        throws Exception
-    {
-        List<FutureTask<String>> calls = Lists.newArrayList();
-        for ( int i = 0; i < OPERATIONS; i++ )
-        {
-            final int j = i;
-            Callable<String> c = new Callable<String>()
-            {
-                @Override
-                public String call()
-                    throws Exception
-                {
-                    single( j );
-
-                    return "ok";
-                }
-            };
-            calls.add( new FutureTask<String>( c ) );
-        }
-
-        Executor executor = Executors.newFixedThreadPool (THREADS);
-        for ( FutureTask<String> futureTask : calls )
-        {
-            executor.execute( futureTask );
-        }
-
-        for ( FutureTask<String> futureTask : calls )
-        {
-            assertThat( futureTask.get(), equalTo( "ok" ) );
-        }
     }
 
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
@@ -12,11 +12,25 @@
  */
 package org.sonatype.nexus.proxy.target;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Collections2.transform;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
 
 import org.junit.Test;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
@@ -25,7 +39,9 @@ import org.sonatype.nexus.proxy.maven.maven1.Maven1ContentClass;
 import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
 import org.sonatype.nexus.proxy.registry.ContentClass;
 import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 
 public class DefaultTargetRegistryTest
     extends AbstractNexusTestCase
@@ -134,6 +150,96 @@ public class DefaultTargetRegistryTest
         assertNotNull( ts );
 
         assertEquals( 0, ts.getMatches().size() );
+    }
+
+    private Function<Target, String> toIds = new Function<Target, String>()
+    {
+        @Override
+        public String apply( Target input )
+        {
+            checkNotNull( input );
+            return input.getId();
+        }
+    };
+
+    private static final int OPERATIONS = 2000;
+
+    private static final int THREADS = OPERATIONS / 10;
+
+    public void single( final int ref )
+        throws Exception
+    {
+        List<String> ids = Lists.newArrayList();
+        for ( int j = 0; j < 5; j++ )
+        {
+
+            String id = Long.toHexString( System.nanoTime() + ref + j + ref * j );
+            Target target = new Target( id, "name" + id, j % 3 == 0 ? maven1 : maven2, Arrays.asList( ".*/" + id ) );
+            targetRegistry.addRepositoryTarget( target );
+            ids.add( id );
+        }
+
+        applicationConfiguration.saveConfiguration();
+
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( t, notNullValue() );
+            assertThat( t.getId(), equalTo( id ) );
+            assertThat( t.getName(), equalTo( "name" + id ) );
+        }
+
+        Collection<String> targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        targets.containsAll( ids );
+
+        for ( String id : ids )
+        {
+            targetRegistry.removeRepositoryTarget( id );
+            // I really wanna try to break this
+            applicationConfiguration.saveConfiguration();
+        }
+
+        targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( "ref: " + ref + " ids: " + ids, t, nullValue() );
+            assertThat( "ref: " + ref + " ids: " + ids, targets, not( containsInAnyOrder( id ) ) );
+        }
+    }
+
+    @Test
+    public void testConcurrency()
+        throws Exception
+    {
+        List<FutureTask<String>> calls = Lists.newArrayList();
+        for ( int i = 0; i < OPERATIONS; i++ )
+        {
+            final int j = i;
+            Callable<String> c = new Callable<String>()
+            {
+                @Override
+                public String call()
+                    throws Exception
+                {
+                    single( j );
+
+                    return "ok";
+                }
+            };
+            calls.add( new FutureTask<String>( c ) );
+        }
+
+        Executor executor = Executors.newFixedThreadPool (THREADS);
+        for ( FutureTask<String> futureTask : calls )
+        {
+            executor.execute( futureTask );
+        }
+
+        for ( FutureTask<String> futureTask : calls )
+        {
+            assertThat( futureTask.get(), equalTo( "ok" ) );
+        }
     }
 
 }


### PR DESCRIPTION
Originally I made my changes on at DefaultTargetRegistry.

But when multiple threads tried to create, delete and check if targets was sane concurrency exceptions started to pop everywhere.

This changes look ugly and verbose on my opinion.  And also other parts of nexus would need this "same" change.

May be we could come up with some annotations like @ReadLock, @WriteLock or something.  But I think that needs some discussion first.
