### PR TITLE
NEXUS-4902: update sisu-jetty8 (and plexus-jetty7) to pull-in shutdown fix

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -173,8 +173,8 @@
     <sisu-ehcache.version>1.0</sisu-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
-    <plexus-jetty7.version>1.2</plexus-jetty7.version>
-    <sisu-jetty8.version>1.0</sisu-jetty8.version>
+    <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
+    <sisu-jetty8.version>1.0.1</sisu-jetty8.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.18</plexus.restlet.bridge.version>
     <plexus-security.version>2.4</plexus-security.version>


### PR DESCRIPTION
CI voted +1: https://builds.sonatype.org/job/nexus-oss-its-feature/269/
