### PR TITLE
o [NXCM-3914] Defer loading of predefined repos until Mirrors tab is activated

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.MirrorConfigPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.MirrorConfigPanel.js
@@ -273,6 +273,8 @@ Ext.extend(Sonatype.repoServer.AbstractMirrorPanel, Sonatype.ext.FormPanel, {
       },
 
       activateHandler : function(panel) {
+        this.predefinedMirrorDataStore.load();
+
         if (panel.payload.data.repoType == 'proxy')
         {
           Ext.TaskMgr.start(this.mirrorStatusTask);
@@ -317,8 +319,7 @@ Sonatype.repoServer.ProxyMirrorEditor = function(config) {
         sortInfo : {
           field : 'url',
           direction : 'ASC'
-        },
-        autoLoad : true
+        }
       });
 
   Sonatype.repoServer.ProxyMirrorEditor.superclass.constructor.call(this, {


### PR DESCRIPTION
Eagerly loading the predefined repos will cause the p2 proxy to hit all mirrors with a request for '/.meta/repository-metadata.xml'. This will still happen, but only when the mirros tab is actually selected. There is some underlying bug that needs to get fixed, but we could 'cure' the symptom with this pull request.
