### PR TITLE
NEXUS-4894: Fixes for TargetRegistry thread safety.

### DIFF
--- a/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
@@ -13,6 +13,7 @@
 package org.sonatype.scheduling;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import java.text.ParseException;
@@ -179,16 +180,10 @@ public class DefaultTaskConfigManagerTest
             defaultManager.addTask( task );
 
             // loadConfig();
-
-            assertEquals( 1, getTaskConfiguration().size() );
-
-            assertEquals( TaskState.SUBMITTED,
-                TaskState.valueOf( ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getStatus() ) );
-
-            assertEquals( TASK_NAME, ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getName() );
-
-            // assertTrue( typeClassMap.get( scheduleType ).isAssignableFrom(
-            // ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getSchedule().getClass() ) );
+            
+            assertThat( getTaskConfiguration().size(), equalTo( 1 ) );
+            assertThat( TaskState.valueOf( ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getStatus() ), equalTo( TaskState.SUBMITTED ) );
+            assertThat( ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getName(), equalTo( TASK_NAME ) );
 
             defaultManager.removeTask( task );
 

--- a/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
@@ -155,14 +155,14 @@ public class DefaultTaskConfigManagerTest
         cst.setType( TestNexusTask.class.getName() );
         cst.setNextRun( new SimpleDateFormat( "yyyy-MM-DD hh:mm:ss" ).parse( "2099-01-01 20:00:00" ).getTime() );
 
-        System.out.println(new Date(cst.getNextRun()));
+        System.out.println( new Date( cst.getNextRun() ) );
 
         final CScheduleConfig csc = new CScheduleConfig();
         csc.setType( SCHEDULE_TYPE_ADVANCED );
         csc.setCronCommand( "0 0 20 ? * TUE,THU,SAT" );
         cst.setSchedule( csc );
-        
-        defaultManager.initializeTasks( defaultScheduler, Arrays.asList( cst ));
+
+        defaultManager.initializeTasks( defaultScheduler, Arrays.asList( cst ) );
 
         final ScheduledTask<?> task = defaultScheduler.getTaskById( cst.getId() );
         assertThat( new Date( task.getNextRun().getTime() ), is( new Date( cst.getNextRun() ) ) );
@@ -180,12 +180,12 @@ public class DefaultTaskConfigManagerTest
 
             // loadConfig();
 
-            assertTrue( getTaskConfiguration().size() == 1 );
+            assertEquals( 1, getTaskConfiguration().size() );
 
-            assertTrue( TaskState.SUBMITTED.equals( TaskState.valueOf( ( (CScheduledTask) getTaskConfiguration()
-                .get( 0 ) ).getStatus() ) ) );
+            assertEquals( TaskState.SUBMITTED,
+                TaskState.valueOf( ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getStatus() ) );
 
-            assertTrue( TASK_NAME.equals( ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getName() ) );
+            assertEquals( TASK_NAME, ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getName() );
 
             // assertTrue( typeClassMap.get( scheduleType ).isAssignableFrom(
             // ( (CScheduledTask) getTaskConfiguration().get( 0 ) ).getSchedule().getClass() ) );
@@ -214,22 +214,22 @@ public class DefaultTaskConfigManagerTest
         }
         else if ( SCHEDULE_TYPE_DAILY.equals( type ) )
         {
-            return new DailySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ), (Date) properties
-                .get( PROPERTY_KEY_END_DATE ) );
+            return new DailySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ),
+                (Date) properties.get( PROPERTY_KEY_END_DATE ) );
         }
         else if ( SCHEDULE_TYPE_WEEKLY.equals( type ) )
         {
             Set<Integer> daysToRun = new HashSet<Integer>();
             daysToRun.add( new Integer( 1 ) );
-            return new WeeklySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ), (Date) properties
-                .get( PROPERTY_KEY_END_DATE ), daysToRun );
+            return new WeeklySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ),
+                (Date) properties.get( PROPERTY_KEY_END_DATE ), daysToRun );
         }
         else if ( SCHEDULE_TYPE_MONTHLY.equals( type ) )
         {
             Set<Integer> daysToRun = new HashSet<Integer>();
             daysToRun.add( new Integer( 1 ) );
-            return new MonthlySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ), (Date) properties
-                .get( PROPERTY_KEY_END_DATE ), daysToRun );
+            return new MonthlySchedule( (Date) properties.get( PROPERTY_KEY_START_DATE ),
+                (Date) properties.get( PROPERTY_KEY_END_DATE ), daysToRun );
         }
         else if ( SCHEDULE_TYPE_ADVANCED.equals( type ) )
         {
@@ -242,14 +242,9 @@ public class DefaultTaskConfigManagerTest
     private ScheduledTask<Integer> createScheduledTask( Schedule schedule )
     {
         TestCallable callable = new TestCallable();
-        return new DefaultScheduledTask<Integer>(
-            "1",
-            TASK_NAME,
-            callable.getClass().getSimpleName(),
-            //TODO this is only use for testing, but we are expecting that the TaskHint matches the Classname.
-            defaultScheduler,
-            callable,
-            schedule );
+        return new DefaultScheduledTask<Integer>( "1", TASK_NAME, callable.getClass().getSimpleName(),
+        // TODO this is only use for testing, but we are expecting that the TaskHint matches the Classname.
+            defaultScheduler, callable, schedule );
     }
 
     private List<CScheduledTask> getTaskConfiguration()

--- a/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/scheduling/DefaultTaskConfigManagerTest.java
@@ -156,7 +156,7 @@ public class DefaultTaskConfigManagerTest
         cst.setType( TestNexusTask.class.getName() );
         cst.setNextRun( new SimpleDateFormat( "yyyy-MM-DD hh:mm:ss" ).parse( "2099-01-01 20:00:00" ).getTime() );
 
-        System.out.println( new Date( cst.getNextRun() ) );
+        // System.out.println( new Date( cst.getNextRun() ) );
 
         final CScheduleConfig csc = new CScheduleConfig();
         csc.setType( SCHEDULE_TYPE_ADVANCED );

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CGlobalHttpProxySettingsCoreConfiguration.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CGlobalHttpProxySettingsCoreConfiguration.java
@@ -52,7 +52,7 @@ public class CGlobalHttpProxySettingsCoreConfiguration
         setChangedConfiguration( null );
 
         setOriginalConfiguration( null );
-        
+
         nullified = true;
     }
 
@@ -92,16 +92,17 @@ public class CGlobalHttpProxySettingsCoreConfiguration
 
         nullified = false;
     }
-    
+
     @Override
     protected void copyTransients( Object source, Object destination )
     {
         super.copyTransients( source, destination );
-        
-        // we need to manually set the authentication to null here, because of flawed overlay, where null objects do NOT overwrite non-null objects
-        if ( ( ( CRemoteHttpProxySettings ) source ).getAuthentication() == null )
+
+        // we need to manually set the authentication to null here, because of flawed overlay, where null objects do NOT
+        // overwrite non-null objects
+        if ( ( (CRemoteHttpProxySettings) source ).getAuthentication() == null )
         {
-            ( ( CRemoteHttpProxySettings ) destination ).setAuthentication( null );
+            ( (CRemoteHttpProxySettings) destination ).setAuthentication( null );
         }
     }
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CRepositoryCoreConfiguration.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CRepositoryCoreConfiguration.java
@@ -134,6 +134,8 @@ public class CRepositoryCoreConfiguration
         }
 
         // ID uniqueness
+        /* This is totally flawed, but this is NOT THE ONLY ONE of the places we did uniqueness check!
+         * But this one in certainly not the place to do this.
         List<CRepository> repositories = getApplicationConfiguration().getConfigurationModel().getRepositories();
 
         for ( CRepository other : repositories )
@@ -148,6 +150,7 @@ public class CRepositoryCoreConfiguration
                 }
             }
         }
+        */
 
         // Name
         if ( StringUtils.isBlank( cfg.getName() ) )

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CRepositoryGroupingCoreConfiguration.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/model/CRepositoryGroupingCoreConfiguration.java
@@ -46,8 +46,8 @@ public class CRepositoryGroupingCoreConfiguration
     @Override
     public ValidationResponse doValidateChanges( Object changedConfiguration )
     {
-        CRepositoryGrouping settings = (CRepositoryGrouping)changedConfiguration;
-        
+        CRepositoryGrouping settings = (CRepositoryGrouping) changedConfiguration;
+
         ValidationResponse response = new ApplicationValidationResponse();
 
         ApplicationValidationContext context = (ApplicationValidationContext) response.getContext();
@@ -107,8 +107,8 @@ public class CRepositoryGroupingCoreConfiguration
 
         if ( StringUtils.isEmpty( item.getId() )
             || "0".equals( item.getId() )
-            || ( context.getExistingPathMappingIds() != null && context.getExistingPathMappingIds()
-                .contains( item.getId() ) ) )
+            || ( context.getExistingPathMappingIds() != null && context.getExistingPathMappingIds().contains(
+                item.getId() ) ) )
         {
             String newId = generateId();
 
@@ -123,9 +123,8 @@ public class CRepositoryGroupingCoreConfiguration
         {
             item.setGroupId( CPathMappingItem.ALL_GROUPS );
 
-            response
-                .addValidationWarning( "Fixed route without groupId set, set to ALL_GROUPS to keep backward comp, ID='"
-                    + item.getId() + "'." );
+            response.addValidationWarning( "Fixed route without groupId set, set to ALL_GROUPS to keep backward comp, ID='"
+                + item.getId() + "'." );
 
             response.setModified( true );
         }

--- a/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/DefaultGlobalRestApiConfigurationTest.java
+++ b/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/DefaultGlobalRestApiConfigurationTest.java
@@ -15,7 +15,6 @@ package org.sonatype.nexus.configuration.application;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.nexus.configuration.AbstractNexusTestCase;
 
 public class DefaultGlobalRestApiConfigurationTest
@@ -24,9 +23,9 @@ public class DefaultGlobalRestApiConfigurationTest
 
     @Test
     public void testNoConfiguration()
-        throws ConfigurationException
+        throws Exception
     {
-        DefaultGlobalRestApiSettings settings = new DefaultGlobalRestApiSettings();
+        final GlobalRestApiSettings settings = lookup( GlobalRestApiSettings.class );
         SimpleApplicationConfiguration cfg = new SimpleApplicationConfiguration();
         cfg.getConfigurationModel().setRestApi( null );
         settings.configure( cfg );

--- a/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
+++ b/nexus/nexus-configuration/src/test/java/org/sonatype/nexus/configuration/application/SimpleApplicationConfiguration.java
@@ -118,7 +118,7 @@ public class SimpleApplicationConfiguration
         return dir;
     }
 
-    public void saveConfiguration()
+    public synchronized void saveConfiguration()
         throws IOException
     {
         // send events out, but nothing else

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/AbstractDefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/AbstractDefaultTargetRegistryTest.java
@@ -1,0 +1,67 @@
+package org.sonatype.nexus.proxy.target;
+
+import java.util.Arrays;
+
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.proxy.AbstractNexusTestCase;
+import org.sonatype.nexus.proxy.maven.maven1.Maven1ContentClass;
+import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
+import org.sonatype.nexus.proxy.registry.ContentClass;
+
+/**
+ * Support class for DefaultTargetRegistry testing
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public abstract class AbstractDefaultTargetRegistryTest
+    extends AbstractNexusTestCase
+{
+
+    protected ApplicationConfiguration applicationConfiguration;
+
+    protected TargetRegistry targetRegistry;
+
+    protected ContentClass maven1;
+
+    protected ContentClass maven2;
+
+    public AbstractDefaultTargetRegistryTest()
+    {
+        super();
+    }
+
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        applicationConfiguration = lookup( ApplicationConfiguration.class );
+
+        maven1 = new Maven1ContentClass();
+
+        maven2 = new Maven2ContentClass();
+
+        targetRegistry = lookup( TargetRegistry.class );
+
+        // adding two targets
+        Target t1 =
+            new Target( "maven2-public", "Maven2 (public)", maven2,
+                Arrays.asList( new String[] { "/org/apache/maven/((?!sources\\.).)*" } ) );
+
+        targetRegistry.addRepositoryTarget( t1 );
+
+        Target t2 =
+            new Target( "maven2-with-sources", "Maven2 sources", maven2,
+                Arrays.asList( new String[] { "/org/apache/maven/.*" } ) );
+
+        targetRegistry.addRepositoryTarget( t2 );
+
+        Target t3 =
+            new Target( "maven1", "Maven1", maven1, Arrays.asList( new String[] { "/org\\.apache\\.maven.*" } ) );
+
+        targetRegistry.addRepositoryTarget( t3 );
+
+        applicationConfiguration.saveConfiguration();
+    }
+
+}

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
@@ -37,7 +37,12 @@ import com.google.common.collect.Lists;
 
 /**
  * Long run test that tries DefaultTargetRegistry with 100 threads and more then a thousand operations looking for
- * concurrency exceptions
+ * concurrency exceptions.
+ * <p>
+ * Note: this class contains one test method that is actually ignored on purpose. It's ignored, as it tests a thing
+ * known that will not work -- and cannot work -- with current configuration framework: simultaneous changes made by
+ * multiple threads of same component. The simple culprit is that "dirty" (the changed configuration) is kept as member
+ * variable, hence, is shared and modified by all changing threads causing all kinds of problems.
  * 
  * @author Marvin Froeder ( velo at sonatype.com )
  */

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryLRTest.java
@@ -1,0 +1,138 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.target;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Collections2.transform;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+/**
+ * Long run test that tries DefaultTargetRegistry with 100 threads and more then a thousand operations looking for
+ * concurrency exceptions
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public class DefaultTargetRegistryLRTest
+    extends AbstractDefaultTargetRegistryTest
+{
+    private Function<Target, String> toIds = new Function<Target, String>()
+    {
+        @Override
+        public String apply( Target input )
+        {
+            checkNotNull( input );
+            return input.getId();
+        }
+    };
+
+    private static final int OPERATIONS = 200;
+
+    private static final int THREADS = OPERATIONS / 10;
+
+    public void single( final int ref )
+        throws Exception
+    {
+        List<String> ids = Lists.newArrayList();
+        for ( int j = 0; j < 5; j++ )
+        {
+
+            String id = Integer.toString( ref ) + "-" + Integer.toString( j );
+            // Long.toHexString( System.nanoTime() + ref + j + ref * j );
+            Target target = new Target( id, "name" + id, j % 3 == 0 ? maven1 : maven2, Arrays.asList( ".*/" + id ) );
+            targetRegistry.addRepositoryTarget( target );
+            ids.add( id );
+        }
+        applicationConfiguration.saveConfiguration();
+
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( t, notNullValue() );
+            assertThat( t.getId(), equalTo( id ) );
+            assertThat( t.getName(), equalTo( "name" + id ) );
+        }
+
+        Collection<String> targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        targets.containsAll( ids );
+
+        for ( String id : ids )
+        {
+            targetRegistry.removeRepositoryTarget( id );
+            // I really wanna try to break this
+            applicationConfiguration.saveConfiguration();
+        }
+
+        targets = transform( targetRegistry.getRepositoryTargets(), toIds );
+        for ( String id : ids )
+        {
+            Target t = targetRegistry.getRepositoryTarget( id );
+            assertThat( "ref: " + ref + " ids: " + ids, t, nullValue() );
+            assertThat( "ref: " + ref + " ids: " + ids, targets, not( containsInAnyOrder( id ) ) );
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testConcurrency()
+        throws Exception
+    {
+        List<FutureTask<String>> calls = Lists.newArrayList();
+        for ( int i = 0; i < OPERATIONS; i++ )
+        {
+            final int j = i;
+            Callable<String> c = new Callable<String>()
+            {
+                @Override
+                public String call()
+                    throws Exception
+                {
+                    single( j );
+
+                    return "ok";
+                }
+            };
+            calls.add( new FutureTask<String>( c ) );
+        }
+
+        Executor executor = Executors.newFixedThreadPool( THREADS );
+        for ( FutureTask<String> futureTask : calls )
+        {
+            executor.execute( futureTask );
+        }
+
+        for ( FutureTask<String> futureTask : calls )
+        {
+            assertThat( futureTask.get(), equalTo( "ok" ) );
+        }
+    }
+
+}

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
@@ -15,7 +15,9 @@ package org.sonatype.nexus.proxy.target;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.Test;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -36,34 +38,29 @@ public class DefaultTargetRegistryTest
 
         replay( repository );
 
-        TargetSet ts = targetRegistry.getTargetsForRepositoryPath(
-            repository,
-            "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom" );
+        TargetSet ts =
+            targetRegistry.getTargetsForRepositoryPath( repository,
+                "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom" );
 
-        assertNotNull( ts );
+        assertThat( ts, notNullValue() );
+        assertThat( ts.getMatches().size(), equalTo( 2 ) );
+        assertThat( ts.getMatchedRepositoryIds().size(), equalTo( 1 ) );
+        assertThat( ts.getMatchedRepositoryIds().iterator().next(), equalTo( "dummy" ) );
 
-        assertEquals( 2, ts.getMatches().size() );
+        TargetSet ts1 =
+            targetRegistry.getTargetsForRepositoryPath( repository,
+                "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar" );
 
-        assertEquals( 1, ts.getMatchedRepositoryIds().size() );
-
-        assertEquals( "dummy", ts.getMatchedRepositoryIds().iterator().next() );
-
-        TargetSet ts1 = targetRegistry.getTargetsForRepositoryPath(
-            repository,
-            "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar" );
-
-        assertNotNull( ts1 );
-
-        assertEquals( 1, ts1.getMatches().size() );
-
-        assertEquals( "maven2-with-sources", ts1.getMatches().iterator().next().getTarget().getId() );
+        assertThat( ts1, notNullValue() );
+        assertThat( ts1.getMatches().size(), equalTo( 1 ) );
+        assertThat( ts1.getMatches().iterator().next().getTarget().getId(), equalTo( "maven2-with-sources" ) );
 
         // adding them
         ts.addTargetSet( ts1 );
 
-        assertEquals( 2, ts.getMatches().size() );
-
-        assertEquals( 1, ts.getMatchedRepositoryIds().size() );
+        assertThat( ts, notNullValue() );
+        assertThat( ts.getMatches().size(), equalTo( 2 ) );
+        assertThat( ts.getMatchedRepositoryIds().size(), equalTo( 1 ) );
     }
 
     @Test
@@ -76,21 +73,18 @@ public class DefaultTargetRegistryTest
 
         replay( repository );
 
-        TargetSet ts = targetRegistry.getTargetsForRepositoryPath(
-            repository,
-            "/org.apache.maven/jars/maven-model-v3-2.0.jar" );
+        TargetSet ts =
+            targetRegistry.getTargetsForRepositoryPath( repository, "/org.apache.maven/jars/maven-model-v3-2.0.jar" );
 
-        assertNotNull( ts );
+        assertThat( ts, notNullValue() );
+        assertThat( ts.getMatches().size(), equalTo( 1 ) );
 
-        assertEquals( 1, ts.getMatches().size() );
+        ts =
+            targetRegistry.getTargetsForRepositoryPath( repository,
+                "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar" );
 
-        ts = targetRegistry.getTargetsForRepositoryPath(
-            repository,
-            "/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9-sources.jar" );
-
-        assertNotNull( ts );
-
-        assertEquals( 0, ts.getMatches().size() );
+        assertThat( ts, notNullValue() );
+        assertThat( ts.getMatches().size(), equalTo( 0 ) );
     }
 
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/target/DefaultTargetRegistryTest.java
@@ -16,59 +16,16 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 
-import java.util.Arrays;
 
 import org.junit.Test;
-import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
-import org.sonatype.nexus.proxy.AbstractNexusTestCase;
-import org.sonatype.nexus.proxy.maven.maven1.Maven1ContentClass;
-import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
-import org.sonatype.nexus.proxy.registry.ContentClass;
 import org.sonatype.nexus.proxy.repository.Repository;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
 
+/**
+ * Simple DefaultTargetRegistry creation test
+ */
 public class DefaultTargetRegistryTest
-    extends AbstractNexusTestCase
+    extends AbstractDefaultTargetRegistryTest
 {
-    protected ApplicationConfiguration applicationConfiguration;
-
-    protected TargetRegistry targetRegistry;
-
-    protected ContentClass maven1;
-
-    protected ContentClass maven2;
-
-    protected void setUp()
-        throws Exception
-    {
-        super.setUp();
-
-        applicationConfiguration = lookup( ApplicationConfiguration.class );
-
-        maven1 = new Maven1ContentClass();
-
-        maven2 = new Maven2ContentClass();
-
-        targetRegistry = lookup( TargetRegistry.class );
-
-        // adding two targets
-        Target t1 = new Target( "maven2-public", "Maven2 (public)", maven2, Arrays
-            .asList( new String[] { "/org/apache/maven/((?!sources\\.).)*" } ) );
-
-        targetRegistry.addRepositoryTarget( t1 );
-
-        Target t2 = new Target( "maven2-with-sources", "Maven2 sources", maven2, Arrays
-            .asList( new String[] { "/org/apache/maven/.*" } ) );
-
-        targetRegistry.addRepositoryTarget( t2 );
-
-        Target t3 = new Target( "maven1", "Maven1", maven1, Arrays.asList( new String[] { "/org\\.apache\\.maven.*" } ) );
-
-        targetRegistry.addRepositoryTarget( t3 );
-
-        applicationConfiguration.saveConfiguration();
-    }
-
     @Test
     public void testSimpleM2()
     {


### PR DESCRIPTION
Multiple problems, as this is one of the oldest unchanged class in core it seems.
- looking for target by ID is very, very, VERY often done by Security, but it was done
  in a "linear search" manner, by iterating over a list and constructing object(s) on the fly
- a "cache view" (list) was present (but unused in case above, unsure why) but was only
  nullified in case of configuration change, and was "lazily" rebuilt on lookups/gets. This was not only
  thread unsafe (see related issue), but also caused slow-downs for target getter (most certainly
  security). Now, the "cache view" is a map, keyed by Target ID and eagerly rebuilt on config
  changes.
- other minor improvements

Now we ensure that the "cache view" is rebuilt on config change (in config changing thread,
where through-output is not a concern). Also, this excludes the thread safety problem
of lazily creating the "cache view" and stealing CPU cycles from security.

Also, this makes a get-target-by-ID faster by orders of magnitude, as the "cache view"
is now a map that already contains pre created "live" object (no object creation on the fly)
keyed by target id (no linear search).

CI build:
https://builds.sonatype.org/view/nexus/job/nexus-oss-its-feature/272/
