### PR TITLE
NEXUS-4933 - Using version to decide if SnapshotVersion should be updated or not

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataUpdater.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/DefaultMetadataUpdater.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Plugin;
@@ -43,6 +44,7 @@ import org.sonatype.nexus.proxy.maven.metadata.operations.TimeUtil;
 import com.google.common.annotations.VisibleForTesting;
 
 @Named
+@Singleton
 public class DefaultMetadataUpdater
     extends AbstractLoggingComponent
     implements MetadataUpdater

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/SetSnapshotOperation.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/SetSnapshotOperation.java
@@ -105,18 +105,10 @@ public class SetSnapshotOperation
                 }
                 else
                 {
-                    try
+                    if ( new VersionComparator().compare( current.getVersion(), extra.getVersion() ) < 0 )
                     {
-                        if ( TimeUtil.compare( current.getUpdated(), extra.getUpdated() ) < 0 )
-                        {
-                            currents.remove( current );
-                            currents.add( extra );
-                        }
-                    }
-                    catch ( ParseException e )
-                    {
-                        throw new MetadataException( "Invalid timetamp: " + current.getUpdated() + "-"
-                            + extra.getUpdated(), e );
+                        currents.remove( current );
+                        currents.add( extra );
                     }
                 }
             }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/SetSnapshotOperation.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/SetSnapshotOperation.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.nexus.proxy.maven.metadata.operations;
 
-import java.text.ParseException;
 import java.util.List;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;


### PR DESCRIPTION
When metadata is rebuild from zero the 2 different SNAPSHOT may end with the same  timestamp and the SnapshotVersions end wrong.

Using timestamped version should handle this a bit better.
