### PR TITLE
o [NEXUS-4815] Let log appender pattern field have a default value

### DIFF
--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
@@ -79,6 +79,8 @@ public class LogbackLogManager
 
     private static final String LOG_CONF_PROPS = "logback.properties";
 
+    private static final String LOG_CONF_PROPS_RESOURCE = "/META-INF/log/" + LOG_CONF_PROPS;
+
     @Requirement
     private Logger logger;
 
@@ -154,11 +156,34 @@ public class LogbackLogManager
         Properties logProperties = loadConfigurationProperties();
 
         logProperties.setProperty( KEY_ROOT_LEVEL, configuration.getRootLoggerLevel() );
-        logProperties.setProperty( KEY_APPENDER_PATTERN, configuration.getFileAppenderPattern() );
+        String pattern = configuration.getFileAppenderPattern();
+
+        if ( pattern == null )
+        {
+            pattern = getDefaultProperties().getProperty( KEY_APPENDER_PATTERN );
+        }
+
+        logProperties.setProperty( KEY_APPENDER_PATTERN, pattern );
 
         saveConfigurationProperties( logProperties );
         // TODO this will do a reconfiguration but would be just enough to "touch" logback.xml"
         reconfigure();
+    }
+
+    private Properties getDefaultProperties()
+        throws IOException
+    {
+        Properties properties = new Properties();
+        final InputStream stream = this.getClass().getResourceAsStream( LOG_CONF_PROPS_RESOURCE );
+        try
+        {
+            properties.load( stream );
+        }
+        finally
+        {
+            stream.close();
+        }
+        return properties;
     }
 
     public Collection<NexusStreamResponse> getApplicationLogFiles()
@@ -307,7 +332,7 @@ public class LogbackLogManager
         {
             try
             {
-                URL configUrl = this.getClass().getResource( "/META-INF/log/" + LOG_CONF_PROPS );
+                URL configUrl = this.getClass().getResource( LOG_CONF_PROPS_RESOURCE );
 
                 FileUtils.copyURLToFile( configUrl, logConfigPropsFile );
             }

--- a/nexus/nexus-logging-extras/src/test/java/org/sonatype/nexus/log/internal/LogbackLogManagerTest.java
+++ b/nexus/nexus-logging-extras/src/test/java/org/sonatype/nexus/log/internal/LogbackLogManagerTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Set;
 
 import org.codehaus.plexus.context.Context;
@@ -91,6 +92,16 @@ public class LogbackLogManagerTest
         Set<File> logFiles = manager.getLogFiles();
         assertThat( "Logfiles set is not null", logFiles, is( notNullValue() ) );
         assertThat( "Logfiles set contains elements", logFiles.size(), is( equalTo( 1 ) ) );
+    }
+    
+    @Test
+    public void testConfigDefaultAppender()
+        throws IOException
+    {
+        final DefaultLogConfiguration configuration = (DefaultLogConfiguration) manager.getConfiguration();
+        configuration.setFileAppenderPattern( null );
+        manager.setConfiguration( configuration );
+        assertThat( manager.getConfiguration().getFileAppenderPattern(), notNullValue() );
     }
 
 }

--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.LogEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.LogEditPanel.js
@@ -78,10 +78,10 @@ Sonatype.repoServer.LogEditPanel = function(config) {
                   }, {
                     xtype : 'textfield',
                     fieldLabel : 'File Appender Pattern',
-                    itemCls : 'required-field',
-                    allowBlank : false,
+                    allowBlank : true,
                     helpText : ht.fileAppenderPattern,
                     name : 'fileAppenderPattern',
+                    emptyText : "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n",
                     anchor : Sonatype.view.FIELD_OFFSET
                   }, {
                     xtype : 'textfield',


### PR DESCRIPTION
As commented on the issue by @bdemers, this commit makes the log pattern be optional with the default value used for an 'empty' field.
