### PR TITLE
NEXUS-4901: Undoing some changes making impossible Shadows to be "lazy"

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepository.java
@@ -45,7 +45,7 @@ public abstract class AbstractShadowRepository
 {
     @Requirement
     private RepositoryRegistry repositoryRegistry;
-    
+
     protected RepositoryRegistry getRepositoryRegistry()
     {
         return repositoryRegistry;
@@ -73,7 +73,8 @@ public abstract class AbstractShadowRepository
     @Override
     public String getMasterRepositoryId()
     {
-        return getMasterRepository().getId();
+        // NEXUS-4901: this change is to lessen the logging noise, that is otherwise harmless but ugly
+        return getExternalConfiguration( false ).getMasterRepositoryId();
     }
 
     @Deprecated

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepositoryConfigurator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepositoryConfigurator.java
@@ -41,7 +41,13 @@ public abstract class AbstractShadowRepositoryConfigurator
 
         try
         {
-            shadowRepository.setMasterRepository( getRepositoryRegistry().getRepository( extConf.getMasterRepositoryId() ) );
+            // undone change made in https://github.com/sonatype/nexus/commit/64fb67dc16ef2e18300d3df3eb4f87d419b584cc
+            // original change was for NEXUS-4715
+            // undone due to NEXUS-4901
+            // ultimate fix will come with NEXUS-4909 
+            // that will get rid among other thing, tricks like this one below
+            // https://github.com/sonatype/nexus/blob/master/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java#L557
+            shadowRepository.setMasterRepositoryId( extConf.getMasterRepositoryId() );
         }
         catch ( IncompatibleMasterRepositoryException e )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/ShadowRepositoryEventInspector.java
@@ -55,7 +55,8 @@ public class ShadowRepositoryEventInspector
 
             for ( ShadowRepository shadow : shadows )
             {
-                if ( shadow.getMasterRepository().getId().equals( ievt.getRepository().getId() ) )
+                // NEXUS-4901: this change is to lessen the logging noise, that is otherwise harmless but ugly
+                if ( shadow.getMasterRepositoryId().equals( ievt.getRepository().getId() ) )
                 {
                     shadow.onRepositoryItemEvent( ievt );
                 }


### PR DESCRIPTION
Change in 64fb67dc16ef2e18300d3df3eb4f87d419b584cc was too "eager"
and introduced some changes that made shadows unable to perform "lazy",
and be pointed at groups for example.
