### PR TITLE
Use the eventually GA found plugin not the passed in GAV

### DIFF
--- a/nexus/nexus-plugins/nexus-plugin-manager/src/main/java/org/sonatype/nexus/plugins/DefaultNexusPluginManager.java
+++ b/nexus/nexus-plugins/nexus-plugin-manager/src/main/java/org/sonatype/nexus/plugins/DefaultNexusPluginManager.java
@@ -272,18 +272,18 @@ public class DefaultNexusPluginManager
         final GAVCoordinate activatedGav = getActivatedPluginGav( gav, strict );
         if ( activatedGav == null )
         {
-            final PluginManagerResponse response = new PluginManagerResponse( gav, PluginActivationRequest.ACTIVATE );
+            GAVCoordinate actualGAV = null;
+            if ( !strict )
+            {
+                actualGAV = findInstalledPluginByGA( installedPluginsFilteredByGA, gav );
+            }
+            if ( actualGAV == null )
+            {
+                actualGAV = gav;
+            }
+            final PluginManagerResponse response = new PluginManagerResponse( actualGAV, PluginActivationRequest.ACTIVATE );
             try
             {
-                GAVCoordinate actualGAV = null;
-                if ( !strict )
-                {
-                    actualGAV = findInstalledPluginByGA( installedPluginsFilteredByGA, gav );
-                }
-                if ( actualGAV == null )
-                {
-                    actualGAV = gav;
-                }
                 activatePlugin(
                     repositoryManager.resolveArtifact( actualGAV ), response, installedPluginsFilteredByGA
                 );
@@ -344,7 +344,7 @@ public class DefaultNexusPluginManager
                 gav, false, installedPluginsFilteredByGA
             );
             response.addPluginManagerResponse( dependencyActivationResponse );
-            importList.add( gav );
+            importList.add( dependencyActivationResponse.getOriginator() );
             resolvedList.add( dependencyActivationResponse.getOriginator() );
         }
         descriptor.setImportedPlugins( importList );


### PR DESCRIPTION
The bug related to booting in case that a plugin dependeing on another version of another plugin then the one in plugin-repository seems as not fixed by the previous try. This because the version that we returned and used later on to create the injector was the one expressed in plugin dependency and not the one founded by GA.

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
