### PR TITLE
NEXUS-4893: Make Jetty use real logger

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -298,6 +298,13 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
       <type>jar</type>

--- a/nexus/nexus-logging-extras/pom.xml
+++ b/nexus/nexus-logging-extras/pom.xml
@@ -52,6 +52,11 @@
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/nexus/nexus-oss-webapp/pom.xml
+++ b/nexus/nexus-oss-webapp/pom.xml
@@ -49,6 +49,18 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
 
     <!--  The Jetty itself -->
     <dependency>

--- a/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
+++ b/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
@@ -104,6 +104,8 @@
         <include>org.codehaus.plexus:*</include>
         <include>org.sonatype.sisu:*</include>
         <include>org.sonatype.appcontext:*</include>
+        <include>org.slf4j:*</include>
+        <include>ch.qos.logback:*</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
       <unpack>false</unpack>

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
@@ -48,6 +48,12 @@
       <Arg><Ref id="Contexts"/></Arg>
       <Arg>${nexus-webapp}</Arg>
       <Arg>${nexus-webapp-context-path}</Arg>
+      <Set name="serverClasses">
+        <Array type="java.lang.String">
+          <Item>org.slf4j.</Item>
+          <Item>ch.qos.logback.</Item>
+        </Array>
+      </Set>
       <Set name="extractWAR">false</Set>
     </New>
     

--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2012 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<!-- This configuration added to prevent logback default of DEBUG output -->
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
+    </encoder>
+  </appender>
+  <root level="${nexus.log.level:-INFO}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -667,6 +667,13 @@
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+        <type>jar</type>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
         <type>jar</type>


### PR DESCRIPTION
SLF4J and it's logback "backend" (is not backend but direct implementation)
moved into bundle. But, to avoid problems already described, logging
related packages are made "server classes", classes hidden from WAR,
as Nexus deliver the same stuff, and extends those by adding custom
appender implementations.

This change does/fixes:
- the original issue, as at "server level" it is not the SrdErrLogger trivial implementation used by Jetty to log (server logs and servlet logs) but logback (with Jetty's preferred native SLF4J support).
- the Jetty -- based on that item above -- now uses Slf4j and does not break the log "layout" (there was a similar issue, as pattern Jetty's logger used was different than Nexus pattern, making logs hard to read and parse)
- logging related classes are made "server classes" to not impose any requirements against Nexus WAR, hence, Nexus WAR wrt it's dependencies it ships in /lib folder are unchanged, it's still "fully functional" (and will not log to "noop" logger).
