### PR TITLE
NEXUS-4904 and related ones

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
@@ -52,6 +52,7 @@ import org.sonatype.nexus.configuration.validator.ApplicationValidationContext;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.plugins.RepositoryType;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
+import org.sonatype.nexus.proxy.cache.CacheManager;
 import org.sonatype.nexus.proxy.events.VetoFormatter;
 import org.sonatype.nexus.proxy.events.VetoFormatterRequest;
 import org.sonatype.nexus.proxy.registry.RepositoryRegistry;
@@ -86,6 +87,16 @@ public class DefaultNexusConfiguration
 {
     @Requirement
     private ApplicationEventMulticaster applicationEventMulticaster;
+
+    /**
+     * The path cache is referenced here only for UTs sake. At deploy/runtime, this does not matter, as CacheManager is
+     * already part of component dependency graph. This reference here is merely for UTs, as almost all of them (from
+     * nexus-app module onwards) does "awake" this component, and hence, by having this reference here, we actually pull
+     * and have Plexus manage the "lifecycle" of CacheManager component (and indirectly, EhCacheManager lifecycle).
+     */
+    @Requirement
+    @SuppressWarnings( "unused" )
+    private CacheManager pathCache;
 
     @Requirement( hint = "file" )
     private ApplicationConfigurationSource configurationSource;

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/SimpleLdapServer.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/SimpleLdapServer.java
@@ -10,28 +10,29 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 
-
-public class SimpleLdapServer extends AbstractLdapTestEnvironment
+public class SimpleLdapServer
+    extends AbstractLdapTest
 {
 
     /**
      * @param args
-     * @throws Exception 
+     * @throws Exception
      */
-    public static void main( String[] args ) throws Exception
+    public static void main( String[] args )
+        throws Exception
     {
         try
         {
-        SimpleLdapServer server = new SimpleLdapServer();
-        server.setUp();
+            SimpleLdapServer server = new SimpleLdapServer();
+            server.setUp();
         }
         finally
         {
-//        System.exit( 0 );
+            // System.exit( 0 );
         }
-        
+
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/DynamicGroupsTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/DynamicGroupsTest.java
@@ -21,10 +21,10 @@ import javax.naming.Context;
 import javax.naming.ldap.InitialLdapContext;
 
 import org.junit.Test;
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 
 public class DynamicGroupsTest
-    extends AbstractLdapTestEnvironment
+    extends AbstractLdapTest
 {
 
     @Test

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/LdapGroupDAOTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/LdapGroupDAOTest.java
@@ -21,10 +21,10 @@ import javax.naming.Context;
 import javax.naming.ldap.InitialLdapContext;
 
 import org.junit.Test;
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 
 public class LdapGroupDAOTest
-    extends AbstractLdapTestEnvironment
+    extends AbstractLdapTest
 {
 
     @Test
@@ -47,7 +47,7 @@ public class LdapGroupDAOTest
         Map<String, Object> env = new HashMap<String, Object>();
         // Create a new context pointing to the overseas partition
         env.put( Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory" );
-        env.put( Context.PROVIDER_URL, "ldap://localhost:" + this.getLdapServer().getPort() + "/o=sonatype" );
+        env.put( Context.PROVIDER_URL, "ldap://localhost:" + getLdapServer().getPort() + "/o=sonatype" );
         env.put( Context.SECURITY_PRINCIPAL, "uid=admin,ou=system" );
         env.put( Context.SECURITY_CREDENTIALS, "secret" );
         env.put( Context.SECURITY_AUTHENTICATION, "simple" );

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/LdapUserDAOTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/dao/LdapUserDAOTest.java
@@ -20,10 +20,10 @@ import javax.naming.Context;
 import javax.naming.ldap.InitialLdapContext;
 
 import org.junit.Test;
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 
 public class LdapUserDAOTest
-    extends AbstractLdapTestEnvironment
+    extends AbstractLdapTest
 {
 
     @Test

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/realms/MultipleAccessLdapConfigTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/realms/MultipleAccessLdapConfigTest.java
@@ -21,13 +21,13 @@ import junit.framework.Assert;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 import org.codehaus.plexus.context.Context;
 import org.junit.Test;
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 import org.sonatype.security.ldap.realms.persist.InvalidConfigurationException;
 import org.sonatype.security.ldap.realms.persist.LdapConfiguration;
 import org.sonatype.security.ldap.realms.persist.model.CConnectionInfo;
 
 public class MultipleAccessLdapConfigTest
-    extends AbstractLdapTestEnvironment
+    extends AbstractLdapTest
 {
 
     private LdapContextFactory ldapContextFactory;
@@ -45,8 +45,20 @@ public class MultipleAccessLdapConfigTest
     }
 
     @Override
+    public void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+
+        // delete the ldap.xml file
+        File confFile = new File( getBasedir() + "/target/test-classes/not-configured/", "ldap.xml" );
+        confFile.delete();
+    }
+
+    @Override
     protected void customizeContext( Context context )
     {
+        super.customizeContext( context );
         context.put( "application-conf", getBasedir() + "/target/test-classes/not-configured/" );
     }
 
@@ -78,17 +90,6 @@ public class MultipleAccessLdapConfigTest
         // now we should be able to get a valid configuration
         ldapContextFactory.getSystemLdapContext();
 
-    }
-
-    @Override
-    public void tearDown()
-        throws Exception
-    {
-        super.tearDown();
-
-        // delete the ldap.xml file
-        File confFile = new File( getBasedir() + "/target/test-classes/not-configured/", "ldap.xml" );
-        confFile.delete();
     }
 
 }

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerNotConfiguredTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerNotConfiguredTest.java
@@ -12,54 +12,35 @@
  */
 package org.sonatype.security.ldap.usermanagement;
 
-import java.io.File;
 import java.io.FileOutputStream;
 
 import junit.framework.Assert;
 
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.junit.Test;
-import org.sonatype.ldaptestsuite.AbstractLdapTestEnvironment;
+import org.sonatype.security.ldap.AbstractLdapTest;
 import org.sonatype.security.usermanagement.UserManager;
 
 public class LdapUserManagerNotConfiguredTest
-    extends AbstractLdapTestEnvironment
+    extends AbstractLdapTest
 {
-
-    public static final String SECURITY_CONFIG_KEY = "security-xml-file";
-
-    public static final String LDAP_CONFIGURATION_KEY = "application-conf";
-
-    protected static final File PLEXUS_HOME = new File( getBasedir(), "target/plexus-home" );
-
-    protected static final File CONF_HOME = new File( PLEXUS_HOME, "conf" );
-
-    @Override
-    protected void customizeContext( Context ctx )
-    {
-        ctx.put( SECURITY_CONFIG_KEY, new File( CONF_HOME, "security.xml" ).getAbsolutePath() );
-        ctx.put( LDAP_CONFIGURATION_KEY, CONF_HOME.getAbsolutePath() );
-    }
-
     @Override
     public void setUp()
         throws Exception
     {
-        FileUtils.deleteDirectory( CONF_HOME );
-        CONF_HOME.mkdirs();
+        super.setUp();
+
         IOUtil.copy( getClass().getResourceAsStream( "/test-conf/conf/security-configuration-no-ldap.xml" ),
-            new FileOutputStream( new File( CONF_HOME, "security.xml" ) ) );
+            new FileOutputStream( getNexusSecurityConfiguration() ) );
 
         IOUtil.copy( getClass().getResourceAsStream( "/test-conf/conf/security-configuration.xml" ),
-            new FileOutputStream( new File( CONF_HOME, "security-configuration.xml" ) ) );
+            new FileOutputStream( getSecurityConfiguration() ) );
+        
+        getLdapRealmConfig().delete();
 
         // IOUtil.copy(
         // getClass().getResourceAsStream( "/test-conf/conf/ldap.xml" ),
         // new FileOutputStream( new File( CONF_HOME, "ldap.xml" ) ) );
-
-        super.setUp();
     }
 
     @Test

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerTest.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.security.ldap.usermanagement;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,8 +20,6 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
-import org.codehaus.plexus.ContainerConfiguration;
-import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.util.IOUtil;
 import org.junit.Test;
 import org.sonatype.security.SecuritySystem;
@@ -38,21 +35,13 @@ public class LdapUserManagerTest
     extends AbstractLdapTest
 {
     @Override
-    protected void customizeContainerConfiguration( ContainerConfiguration configuration )
-    {
-        configuration.setAutoWiring( true );
-        configuration.setClassPathScanning( PlexusConstants.SCANNING_CACHE );
-    }   
-
-    @Override
     public void setUp()
         throws Exception
     {
         super.setUp();
 
-        this.copyResourceToFile("/test-conf/conf/security-users-in-both-realms.xml", new File( CONF_HOME, "security.xml" ) );
-        
-        this.copyResourceToFile("/test-conf/conf/security-configuration.xml", new File( CONF_HOME, "security-configuration.xml" ) );
+        copyResourceToFile( "/test-conf/conf/security-users-in-both-realms.xml", getNexusSecurityConfiguration() );
+        copyResourceToFile( "/test-conf/conf/security-configuration.xml", getSecurityConfiguration() );
     }
 
     private SecuritySystem getSecuritySystem()
@@ -203,9 +192,8 @@ public class LdapUserManagerTest
     public void testOrderOfUserSearch()
         throws Exception
     {
-        IOUtil.copy(
-            getClass().getResourceAsStream( "/test-conf/conf/security-users-in-both-realms.xml" ),
-            new FileOutputStream( new File( CONF_HOME, "security.xml" ) ) );
+        IOUtil.copy( getClass().getResourceAsStream( "/test-conf/conf/security-users-in-both-realms.xml" ),
+            new FileOutputStream( getNexusSecurityConfiguration() ) );
 
         SecuritySystem securitySystem = this.getSecuritySystem();
         securitySystem.start();

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/AbstractNexusLdapTestCase.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/AbstractNexusLdapTestCase.java
@@ -31,6 +31,7 @@ import org.sonatype.nexus.security.ldap.realms.api.dto.LdapConnectionInfoDTO;
 import org.sonatype.nexus.test.NexusTestSupport;
 import org.sonatype.plexus.rest.resource.error.ErrorMessage;
 import org.sonatype.plexus.rest.resource.error.ErrorResponse;
+import org.sonatype.sisu.ehcache.CacheManagerComponent;
 
 public abstract class AbstractNexusLdapTestCase
     extends NexusTestSupport
@@ -96,23 +97,27 @@ public abstract class AbstractNexusLdapTestCase
         this.copyDefaultLdapConfigToPlace();
     }
 
-    protected String getErrorString( ErrorResponse errorResponse, int index )
-    {
-        return ( (ErrorMessage) errorResponse.getErrors().get( index ) ).getMsg();
-    }
-
     @Override
     protected void tearDown()
         throws Exception
     {
-        ldapServer.stop();
-
-        ldapServer = null;
+        lookup( CacheManagerComponent.class ).shutdown();
+        
+        if ( ldapServer != null )
+        {
+            ldapServer.stop();
+            ldapServer = null;
+        }
 
         // configure the logging
         SLF4JBridgeHandler.uninstall();
 
         super.tearDown();
+    }
+
+    protected String getErrorString( ErrorResponse errorResponse, int index )
+    {
+        return ( (ErrorMessage) errorResponse.getErrors().get( index ) ).getMsg();
     }
 
     protected void validateConnectionDTO( LdapConnectionInfoDTO expected, LdapConnectionInfoDTO actual )

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/LdapNexusTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/LdapNexusTest.java
@@ -12,16 +12,13 @@
  */
 package org.sonatype.nexus;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.junit.Assert;
+import org.junit.Test;
 import org.sonatype.nexus.security.ldap.realms.NexusLdapAuthenticationRealm;
 import org.sonatype.security.SecuritySystem;
 import org.sonatype.security.authentication.AuthenticationException;
-
-import org.sonatype.security.ldap.realms.AbstractLdapAuthenticatingRealm;
 
 public class LdapNexusTest
     extends AbstractNexusLdapTestCase

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/MultipleRealmsLdapNotConfiguredTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/MultipleRealmsLdapNotConfiguredTest.java
@@ -13,13 +13,11 @@
 package org.sonatype.nexus;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.util.IOUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.sonatype.nexus.security.ldap.realms.NexusLdapAuthenticationRealm;

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/security/ldap/realms/api/LdapConnMd5Test.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/security/ldap/realms/api/LdapConnMd5Test.java
@@ -13,7 +13,6 @@
 package org.sonatype.nexus.security.ldap.realms.api;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/security/ldap/realms/api/MarshalUnmarchalTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/src/test/java/org/sonatype/nexus/security/ldap/realms/api/MarshalUnmarchalTest.java
@@ -12,10 +12,7 @@
  */
 package org.sonatype.nexus.security.ldap.realms.api;
 
-import java.text.SimpleDateFormat;
-
 import org.codehaus.plexus.util.StringUtils;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,9 +33,6 @@ import com.thoughtworks.xstream.XStream;
 
 public class MarshalUnmarchalTest
 {
-
-    private SimpleDateFormat dateFormat = new SimpleDateFormat( "MM/dd/yyyy" );
-
     private XStream xstreamXML;
 
     private XStream xstreamJSON;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
@@ -12,25 +12,42 @@
  */
 package org.sonatype.nexus.proxy.cache;
 
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.appcontext.AppContext;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.sisu.ehcache.CacheManagerComponent;
+import org.sonatype.sisu.ehcache.CacheManagerLifecycleHandler;
+
+import com.google.common.base.Preconditions;
 
 /**
  * The Class EhCacheCacheManager is a thin wrapper around EhCache, just to make things going.
  * 
  * @author cstamas
  */
-@Component( role = CacheManager.class )
+@Singleton
+@Named
 public class EhCacheCacheManager
     extends AbstractLoggingComponent
     implements CacheManager
 {
-    @Requirement
-    private CacheManagerComponent cacheManagerComponent;
+    private final CacheManagerComponent cacheManagerComponent;
 
     public static final String SINGLE_PATH_CACHE_NAME = "path-cache";
+
+    @Inject
+    public EhCacheCacheManager( final AppContext appContext, final CacheManagerComponent cacheManagerComponent )
+    {
+        this.cacheManagerComponent =
+            Preconditions.checkNotNull( cacheManagerComponent, "CacheManagerComponent have to be non-null!" );
+
+        // register it with Nexus' appContext
+        Preconditions.checkNotNull( appContext, "AppContext have to be non-null!" );
+        appContext.getLifecycleManager().registerManaged( new CacheManagerLifecycleHandler( cacheManagerComponent ) );
+    }
 
     public PathCache getPathCache( String cache )
     {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/cache/EhCacheCacheManager.java
@@ -12,42 +12,26 @@
  */
 package org.sonatype.nexus.proxy.cache;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
-import org.sonatype.appcontext.AppContext;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.sisu.ehcache.CacheManagerComponent;
-import org.sonatype.sisu.ehcache.CacheManagerLifecycleHandler;
-
-import com.google.common.base.Preconditions;
 
 /**
  * The Class EhCacheCacheManager is a thin wrapper around EhCache, just to make things going.
  * 
  * @author cstamas
  */
-@Singleton
-@Named
+@Component( role = CacheManager.class )
 public class EhCacheCacheManager
     extends AbstractLoggingComponent
-    implements CacheManager
+    implements CacheManager, Disposable
 {
-    private final CacheManagerComponent cacheManagerComponent;
+    @Requirement
+    private CacheManagerComponent cacheManagerComponent;
 
     public static final String SINGLE_PATH_CACHE_NAME = "path-cache";
-
-    @Inject
-    public EhCacheCacheManager( final AppContext appContext, final CacheManagerComponent cacheManagerComponent )
-    {
-        this.cacheManagerComponent =
-            Preconditions.checkNotNull( cacheManagerComponent, "CacheManagerComponent have to be non-null!" );
-
-        // register it with Nexus' appContext
-        Preconditions.checkNotNull( appContext, "AppContext have to be non-null!" );
-        appContext.getLifecycleManager().registerManaged( new CacheManagerLifecycleHandler( cacheManagerComponent ) );
-    }
 
     public PathCache getPathCache( String cache )
     {
@@ -59,5 +43,11 @@ public class EhCacheCacheManager
         }
 
         return new EhCachePathCache( cache, ehCacheManager.getEhcache( SINGLE_PATH_CACHE_NAME ) );
+    }
+
+    @Override
+    public void dispose()
+    {
+        cacheManagerComponent.shutdown();
     }
 }

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmTest.java
@@ -1,0 +1,14 @@
+package org.sonatype.security.realms;
+
+import org.sonatype.nexus.test.PlexusTestCaseSupport;
+
+/**
+ * Abstract class for "realm" related tests.
+ * 
+ * @author cstamas
+ */
+public class AbstractRealmTest
+    extends PlexusTestCaseSupport
+{
+
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.security.realms;
 
 import org.sonatype.nexus.test.PlexusTestCaseSupport;

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmWithSecuritySystemTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmWithSecuritySystemTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.security.realms;
 
 import java.io.File;

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmWithSecuritySystemTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/AbstractRealmWithSecuritySystemTest.java
@@ -1,0 +1,69 @@
+package org.sonatype.security.realms;
+
+import java.io.File;
+
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.context.Context;
+import org.sonatype.nexus.configuration.application.DefaultNexusConfiguration;
+import org.sonatype.security.SecuritySystem;
+import org.sonatype.sisu.ehcache.CacheManagerComponent;
+
+/**
+ * Abstract class for "realm" related tests that uses EHCache, and that does not bring up Nexus component only Security
+ * subsystem. Without Nexus (or better {@link DefaultNexusConfiguration} brought up, we have to manually manage EHCache
+ * manager component, and cleanly shut it down between tests as EHCache 2.5+ yells without it (violates the
+ * "one named manager per JVM").
+ * 
+ * @author cstamas
+ */
+public abstract class AbstractRealmWithSecuritySystemTest
+    extends AbstractRealmTest
+{
+    private SecuritySystem securitySystem;
+
+    private CacheManagerComponent cacheManagerComponent;
+
+    @Override
+    protected void customizeContainerConfiguration( final ContainerConfiguration configuration )
+    {
+        super.customizeContainerConfiguration( configuration );
+        configuration.setAutoWiring( true );
+        configuration.setClassPathScanning( PlexusConstants.SCANNING_ON );
+    }
+
+    @Override
+    protected void customizeContext( final Context ctx )
+    {
+        super.customizeContext( ctx );
+        ctx.put( "application-conf", getConfDir().getAbsolutePath() );
+        ctx.put( "security-xml-file", getConfDir().getAbsolutePath() + "/security.xml" );
+    }
+
+    @Override
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        securitySystem = lookup( SecuritySystem.class );
+        cacheManagerComponent = lookup( CacheManagerComponent.class );
+    }
+
+    protected void tearDown()
+        throws Exception
+    {
+        if ( securitySystem != null )
+        {
+            securitySystem.stop();
+        }
+        if ( cacheManagerComponent != null )
+        {
+            cacheManagerComponent.shutdown();
+        }
+        super.tearDown();
+    }
+
+    protected abstract File getConfDir();
+
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/MemoryAuthenticationOnlyRealmTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/MemoryAuthenticationOnlyRealmTest.java
@@ -17,10 +17,9 @@ import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.realm.Realm;
 import org.junit.Test;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
 
 public class MemoryAuthenticationOnlyRealmTest
-    extends PlexusTestCaseSupport
+    extends AbstractRealmTest
 {
     private MemoryAuthenticationOnlyRealm realm;
 

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/MemoryRealmTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/MemoryRealmTest.java
@@ -18,10 +18,9 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authz.permission.WildcardPermission;
 import org.apache.shiro.realm.Realm;
 import org.junit.Test;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
 
 public class MemoryRealmTest
-    extends PlexusTestCaseSupport
+    extends AbstractRealmTest
 {
     private MemoryRealm realm;
 

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleRoleLocatorTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleRoleLocatorTest.java
@@ -18,19 +18,19 @@ import java.util.Set;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
 import org.sonatype.security.authorization.AuthorizationManager;
 import org.sonatype.security.authorization.Role;
+import org.sonatype.security.realms.AbstractRealmTest;
 
 public class SimpleRoleLocatorTest
-    extends PlexusTestCaseSupport
+    extends AbstractRealmTest
 {
 
     @Test
     public void testListRoleIds()
         throws Exception
     {
-        AuthorizationManager roleLocator = this.lookup( AuthorizationManager.class, "Simple" );
+        AuthorizationManager roleLocator = lookup( AuthorizationManager.class, "Simple" );
 
         Set<String> roleIds = this.toIdSet( roleLocator.listRoles() );
         Assert.assertTrue( roleIds.contains( "role-xyz" ) );

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleUserLocatorTest.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleUserLocatorTest.java
@@ -17,28 +17,28 @@ import java.util.Set;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.sonatype.nexus.test.PlexusTestCaseSupport;
+import org.sonatype.security.realms.AbstractRealmTest;
 import org.sonatype.security.usermanagement.User;
 import org.sonatype.security.usermanagement.UserManager;
 import org.sonatype.security.usermanagement.UserSearchCriteria;
 
 public class SimpleUserLocatorTest
-    extends PlexusTestCaseSupport
+    extends AbstractRealmTest
 {
 
     @Test
     public void testLocatorLookup()
         throws Exception
     {
-        // a bit of plexus back ground, this is how you can look up a component from a test class
-        this.lookup( UserManager.class, "Simple" );
+        // a bit of Plexus background, this is how you can look up a component from a test class
+        lookup( UserManager.class, "Simple" );
     }
 
     @Test
     public void testSearch()
         throws Exception
     {
-        UserManager userLocator = this.lookup( UserManager.class, "Simple" );
+        UserManager userLocator = lookup( UserManager.class, "Simple" );
 
         Set<User> result = userLocator.searchUsers( new UserSearchCriteria( "adm" ) );
         Assert.assertEquals( 1, result.size() );
@@ -50,7 +50,7 @@ public class SimpleUserLocatorTest
     public void testIdList()
         throws Exception
     {
-        UserManager userLocator = this.lookup( UserManager.class, "Simple" );
+        UserManager userLocator = lookup( UserManager.class, "Simple" );
 
         Set<String> ids = userLocator.listUserIds();
 

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/AppContextModule.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/AppContextModule.java
@@ -18,7 +18,9 @@ import com.google.common.base.Preconditions;
 import com.google.inject.AbstractModule;
 
 /**
- * Module exposing AppContext as component.
+ * Module exposing AppContext as component. We intentionally directly reimplement the class to be found in appcontext
+ * 3.1+ as in Nexus bundle, we have appcontext at Jetty cloassloader level, and would explode as at that level there is
+ * no Guice available. Anyway, this class is a trivial one.
  * 
  * @author cstamas
  * @since 2.1

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -161,7 +161,7 @@
     <aspectj.version>1.6.11</aspectj.version>
     <commons-beanutils.version>1.7.0</commons-beanutils.version>
     <enunciate.version>1.20</enunciate.version>
-    <jetty.version>8.1.1.v20120215</jetty.version>
+    <jetty.version>8.1.2.v20120308</jetty.version>
     <jsw.binaries.version>3.2.3.5</jsw.binaries.version>
     <maven.version>3.0.4</maven.version>
     <micromailer.version>1.1.1</micromailer.version>
@@ -170,14 +170,14 @@
     <plexus-app-events.version>1.0.1</plexus-app-events.version>
     <plexus-cli.version>1.2</plexus-cli.version>
     <plexus-digest.version>1.1</plexus-digest.version>
-    <sisu-ehcache.version>1.0</sisu-ehcache.version>
+    <sisu-ehcache.version>1.1</sisu-ehcache.version>
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
-    <sisu-jetty8.version>1.0.1</sisu-jetty8.version>
+    <sisu-jetty8.version>1.1</sisu-jetty8.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.19</plexus.restlet.bridge.version>
-    <plexus-security.version>2.4</plexus-security.version>
+    <plexus-security.version>2.5-SNAPSHOT</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.6.0</plexus-task-scheduler.version>
     <plexus-velocity.version>1.1.7</plexus-velocity.version>
@@ -239,7 +239,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
       </dependency>
 
       <dependency>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -177,7 +177,7 @@
     <sisu-jetty8.version>1.1</sisu-jetty8.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.19</plexus.restlet.bridge.version>
-    <plexus-security.version>2.5-SNAPSHOT</plexus-security.version>
+    <plexus-security.version>2.5</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.6.0</plexus-task-scheduler.version>
     <plexus-velocity.version>1.1.7</plexus-velocity.version>


### PR DESCRIPTION
EHCache was bumped from 1.6.x to 2.5.1 in Nexus master branch. The new EHCache introduced multiple substantial changes in behavior, like
- It calls home, see issue NEXUS-4904
- It is way more stricter about having same named cache manager in one JVM (it results in error).

This change, together with security changes merged from branch (that bumps EHCache version) enables Nexus to fully function with new EHCache 2.5.1 and also use the fixed "factory" component SISU EHCache.

2nd commit is needed only to make Nexus workable in ITs, when it is bounced in same JVM. Without those, a "production" would still properly work (as EHCache would be cleaned up on JVM shutdown), but due to 2nd restriction above, "bounced" Nexus would belly up.

The rest of commits are actually helping UTs to work properly (by managing EhCache manager lifecycle, the one class change in 54ea34bb, and the rest is cleaning up the LDAP and other security related tests.

Smaller fixes includes fix for "basedir" property, making it absolute path, and have it shown correctly at Nexus boots, and a "dot" version bump for Jetty8 (from 8.1.1 to 8.1.2)

New CI job:
https://builds.sonatype.org/view/nexus/job/nexus-oss-its-feature/287/

Prev CI job (failed due EHCache problems fixed in new commits):
https://builds.sonatype.org/view/nexus/job/nexus-oss-its-feature/286/
