### PR TITLE
Sharing some debug utilities I had locally.

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
@@ -1,0 +1,111 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.events;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.util.SystemPropertiesHelper;
+import org.sonatype.plexus.appevents.Event;
+
+/**
+ * A simple "debug" event inspector that grabs all events sent to {@link EventInspector}s and simply dumps them as
+ * strings to logger at INFO level. Enable it by setting system property
+ * "org.sonatype.nexus.events.DebugEventInspector.enabled" have value of "true" and bouncing Nexus or simply over JMX
+ * (see {@link DebugEventInspectorMBean}).
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+@Component( role = EventInspector.class, hint = "DebugEventInspector" )
+public class DebugEventInspector
+    extends AbstractLoggingComponent
+    implements EventInspector, Disposable
+{
+    private static final String JMX_DOMAIN = "org.sonatype.nexus.events";
+
+    private final boolean ENABLED_DEFAULT = SystemPropertiesHelper.getBoolean(
+        "org.sonatype.nexus.events.DebugEventInspector.enabled", false );
+
+    private volatile boolean enabled;
+
+    private ObjectName jmxName;
+
+    public DebugEventInspector()
+    {
+        this.enabled = ENABLED_DEFAULT;
+
+        try
+        {
+            jmxName = ObjectName.getInstance( JMX_DOMAIN, "name", DebugEventInspector.class.getSimpleName() );
+            final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            server.registerMBean( new DefaultDebugEventInspectorMBean( this ), jmxName );
+        }
+        catch ( Exception e )
+        {
+            jmxName = null;
+            getLogger().warn( "Problem registering MBean for: " + getClass().getName(), e );
+        }
+    }
+
+    @Override
+    public void dispose()
+    {
+        if ( null != jmxName )
+        {
+            try
+            {
+                ManagementFactory.getPlatformMBeanServer().unregisterMBean( jmxName );
+            }
+            catch ( final Exception e )
+            {
+                getLogger().warn( "Problem unregistering MBean for: " + getClass().getName(), e );
+            }
+        }
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled( boolean enabled )
+    {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public boolean accepts( Event<?> evt )
+    {
+        if ( !enabled )
+        {
+            return false;
+        }
+
+        getLogger().info( String.valueOf( evt ) );
+
+        return false;
+    }
+
+    @Override
+    public void inspect( Event<?> evt )
+    {
+        // nop
+    }
+}

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DebugEventInspectorMBean.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DebugEventInspectorMBean.java
@@ -1,0 +1,36 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.events;
+
+/**
+ * The MBean management interface for {@link DebugEventInspector} management.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public interface DebugEventInspectorMBean
+{
+    /**
+     * Returns true if enabled.
+     * 
+     * @return
+     */
+    boolean isEnabled();
+
+    /**
+     * Enables or disables the event inspector.
+     * 
+     * @param val
+     */
+    void setEnabled( boolean val );
+}

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultDebugEventInspectorMBean.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/events/DefaultDebugEventInspectorMBean.java
@@ -1,0 +1,49 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.events;
+
+import javax.management.StandardMBean;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * The default implementation of MBean management interface for {@link DebugEventInspector} management.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class DefaultDebugEventInspectorMBean
+    extends StandardMBean
+    implements DebugEventInspectorMBean
+{
+    private final DebugEventInspector debugEventInspector;
+
+    public DefaultDebugEventInspectorMBean( final DebugEventInspector debugEventInspector )
+    {
+        super( DebugEventInspectorMBean.class, false );
+        this.debugEventInspector =
+            Preconditions.checkNotNull( debugEventInspector, "Managed DebugEventInspector cannot be null!" );
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return debugEventInspector.isEnabled();
+    }
+
+    @Override
+    public void setEnabled( boolean val )
+    {
+        debugEventInspector.setEnabled( val );
+    }
+}

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/DefaultLogManagerMBean.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/DefaultLogManagerMBean.java
@@ -1,0 +1,94 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.log;
+
+import java.io.IOException;
+
+import javax.management.StandardMBean;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Default implementation of LogManager MBean interface.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class DefaultLogManagerMBean
+    extends StandardMBean
+    implements LogManagerMBean
+{
+    private final LogManager logManager;
+
+    public DefaultLogManagerMBean( final LogManager logManager )
+    {
+        super( LogManagerMBean.class, false );
+        this.logManager = Preconditions.checkNotNull( logManager, "Managed LogManager instance cannot be null!" );
+    }
+
+    @Override
+    public String getRootLoggerLevel()
+        throws IOException
+    {
+        final LogConfiguration logConfiguration = logManager.getConfiguration();
+        return logConfiguration.getRootLoggerLevel();
+    }
+
+    @Override
+    public void makeRootLoggerLevelTrace()
+        throws IOException
+    {
+        setRootLoggerLevel( LoggerLevel.TRACE );
+    }
+
+    @Override
+    public void makeRootLoggerLevelDebug()
+        throws IOException
+    {
+        setRootLoggerLevel( LoggerLevel.DEBUG );
+    }
+
+    @Override
+    public void makeRootLoggerLevelInfo()
+        throws IOException
+    {
+        setRootLoggerLevel( LoggerLevel.INFO );
+    }
+
+    @Override
+    public void makeRootLoggerLevelWarn()
+        throws IOException
+    {
+        setRootLoggerLevel( LoggerLevel.WARN );
+    }
+
+    @Override
+    public void makeRootLoggerLevelDefault()
+        throws IOException
+    {
+        makeRootLoggerLevelInfo();
+    }
+
+    protected void setRootLoggerLevel( final LoggerLevel value )
+        throws IOException
+    {
+        final LogConfiguration oldConfiguration = logManager.getConfiguration();
+        final DefaultLogConfiguration newConfiguration = new DefaultLogConfiguration();
+
+        newConfiguration.setFileAppenderLocation( oldConfiguration.getFileAppenderLocation() );
+        newConfiguration.setFileAppenderPattern( oldConfiguration.getFileAppenderPattern() );
+        newConfiguration.setRootLoggerAppenders( oldConfiguration.getRootLoggerAppenders() );
+        newConfiguration.setRootLoggerLevel( value.name() );
+        logManager.setConfiguration( newConfiguration );
+    }
+}

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LogManagerMBean.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LogManagerMBean.java
@@ -1,0 +1,43 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.log;
+
+import java.io.IOException;
+
+/**
+ * LogManager MBean interface (intentionally narrowed to same as UI supports, as this is the only thing proven useful
+ * and used).
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public interface LogManagerMBean
+{
+    String getRootLoggerLevel()
+        throws IOException;
+
+    void makeRootLoggerLevelTrace()
+        throws IOException;
+
+    void makeRootLoggerLevelDebug()
+        throws IOException;
+
+    void makeRootLoggerLevelInfo()
+        throws IOException;
+
+    void makeRootLoggerLevelWarn()
+        throws IOException;
+
+    void makeRootLoggerLevelDefault()
+        throws IOException;
+}

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LoggerLevel.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LoggerLevel.java
@@ -1,0 +1,24 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.log;
+
+/**
+ * Logger levels supported.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public enum LoggerLevel
+{
+    TRACE, DEBUG, INFO, WARN;
+}


### PR DESCRIPTION
DebugEventInspector simply "spits" out the Nexus internal events
for easier debugging. It can be enabled via system properties
or JMX.

LogManager also exposed over JMX for easier management.

By having JConsole (or any JMX client), you can now easily tune
the DEBUGness of running nexus instance without even bouncing it,
and without even touching the UI (for logging level).
