### PR TITLE
NEXUS-4955 - expand the prefix when it is too short

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/RepositoryDependentException.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/RepositoryDependentException.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.configuration.application;
 
 import static java.lang.String.format;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -56,6 +56,8 @@ public class DefaultFSPeer
 {
     private static final String HIDDEN_TARGET_SUFFIX = ".nx-upload";
 
+    private static final String APPENDIX = "nx-tmp";
+
     public boolean isReachable( Repository repository, ResourceStoreRequest request, File target )
         throws LocalStorageException
     {
@@ -339,7 +341,7 @@ public class DefaultFSPeer
 
         if ( prefix.length() < 3 )
         {
-            prefix = prefix + System.nanoTime();
+            prefix = prefix + APPENDIX;
         }
 
         return prefix;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.proxy.storage.local.fs;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileOutputStream;
@@ -318,14 +320,29 @@ public class DefaultFSPeer
     protected File getHiddenTarget( final File target, final StorageItem item )
         throws LocalStorageException
     {
+        checkNotNull( target );
+
         try
         {
-            return File.createTempFile( target.getName(), HIDDEN_TARGET_SUFFIX, target.getParentFile() );
+            String prefix = expandPrefix( target.getName() );
+            return File.createTempFile( prefix, HIDDEN_TARGET_SUFFIX, target.getParentFile() );
         }
         catch ( IOException e )
         {
             throw new LocalStorageException( e.getMessage(), e );
         }
+    }
+
+    private String expandPrefix( String prefix )
+    {
+        checkNotNull( prefix );
+
+        if ( prefix.length() < 3 )
+        {
+            prefix = prefix + System.nanoTime();
+        }
+
+        return prefix;
     }
 
     protected void mkParentDirs( Repository repository, File target )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -326,25 +326,13 @@ public class DefaultFSPeer
 
         try
         {
-            String prefix = expandPrefix( target.getName() );
-            return File.createTempFile( prefix, HIDDEN_TARGET_SUFFIX, target.getParentFile() );
+            // NEXUS-4955 add APPENDIX to make sure prefix is bigger the 3 chars
+            return File.createTempFile( target.getName() + APPENDIX, HIDDEN_TARGET_SUFFIX, target.getParentFile() );
         }
         catch ( IOException e )
         {
             throw new LocalStorageException( e.getMessage(), e );
         }
-    }
-
-    private String expandPrefix( String prefix )
-    {
-        checkNotNull( prefix );
-
-        if ( prefix.length() < 3 )
-        {
-            prefix = prefix + APPENDIX;
-        }
-
-        return prefix;
     }
 
     protected void mkParentDirs( Repository repository, File target )

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeerTest.java
@@ -1,0 +1,39 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.storage.local.fs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.sonatype.sisu.litmus.testsupport.hamcrest.FileMatchers.exists;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class DefaultFSPeerTest
+{
+
+    @Test
+    public void testGetHiddenTarget()
+        throws Exception
+    {
+        File base = new File( "target/a/b/c/d" );
+        base.getParentFile().mkdirs();
+        base.createNewFile();
+
+        File created = new DefaultFSPeer().getHiddenTarget( base, null );
+        assertThat( created, notNullValue() );
+        assertThat( created, exists() );
+    }
+
+}

--- a/nexus/nexus-test-harness/nexus-test-harness-its/resources/nexus4955/files/content.txt
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/resources/nexus4955/files/content.txt
@@ -1,0 +1,1 @@
+any content

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4955/NEXUS4955UploadWOExtensionIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4955/NEXUS4955UploadWOExtensionIT.java
@@ -1,0 +1,37 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.integrationtests.nexus4955;
+
+import java.io.File;
+
+import org.sonatype.nexus.integrationtests.AbstractNexusIntegrationTest;
+import org.testng.annotations.Test;
+
+/**
+ * try to upload (deploy it) a file like "id" (no extension, just file name "id") into repo, nexus will die, it was
+ * reported by user on mailing list
+ * 
+ * @author Marvin Froeder ( velo at sonatype.com )
+ */
+public class NEXUS4955UploadWOExtensionIT
+    extends AbstractNexusIntegrationTest
+{
+    @Test
+    public void deploy()
+        throws Exception
+    {
+        File file = getTestFile( "content.txt" );
+        getDeployUtils().deployWithWagon( "http", getRepositoryUrl( REPO_TEST_HARNESS_REPO ), file,
+            "nxcm4955/test/1.0/id" );
+    }
+}


### PR DESCRIPTION
This issue was reported on user list.

Basically File.createTempFile() fail if prefix is too short, what may happen when the file name we are uploading is too short.

I just append System.nanotime() to it, but we can append anything else.
