### PR TITLE
Dependency cleanup

### DIFF
--- a/nexus-runtime-platform/pom.xml
+++ b/nexus-runtime-platform/pom.xml
@@ -121,7 +121,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>2.1</version>
+        <version>3.0</version>
         <scope>compile</scope>
       </dependency>
     </dependencies>

--- a/nexus/nexus-core-plugins/nexus-groovy-console-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-groovy-console-plugin/pom.xml
@@ -134,14 +134,6 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>5.11</version>
-      <classifier>jdk15</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/pom.xml
@@ -33,31 +33,6 @@
     </dependency>
 
     <dependency>
-      <groupId>emma</groupId>
-      <artifactId>emma</artifactId>
-      <version>2.0.5312</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>apache-maven</artifactId>
-      <version>2.0.9</version>
-      <type>tar.gz</type>
-      <classifier>bin</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-test-harness-launcher</artifactId>
       <version>${project.version}</version>

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
@@ -124,7 +124,6 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.3.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-environment-maven-plugin/pom.xml
@@ -12,7 +12,8 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -51,23 +52,16 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>1.0-alpha-11</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-common-artifact-filters</artifactId>
       <version>1.0</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-project</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-container-default</artifactId>
@@ -81,13 +75,16 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
-      <version>1.0-beta-3-SONATYPE-682132</version>
+      <version>1.0</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-project</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-container-default</artifactId>
@@ -115,6 +112,10 @@
       <version>1.2.1</version>
       <type>${mavenPluginType}</type>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-project</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-container-default</artifactId>

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/pom.xml
@@ -130,14 +130,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.1.1</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -366,6 +366,21 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-archiver</artifactId>
+        <version>2.1.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-component-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.sonatype.plexus</groupId>
         <artifactId>plexus-cipher</artifactId>
         <version>1.5</version>
@@ -995,6 +1010,18 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>6.1.1</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>1.3.RC2</version>
@@ -1020,6 +1047,14 @@
         <version>1.9.0-rc1</version>
         <type>jar</type>
         <scope>test</scope>
+      </dependency>
+      <!-- Needed for proper convergence (mockito needs 1.0, and powermock pulled in litmus 1.2) -->
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>1.2</version>
+        <type>jar</type>
+        <!-- scope>test</scope -->
       </dependency>
       <dependency>
         <groupId>org.uncommons</groupId>
@@ -1319,11 +1354,11 @@
             </configuration>
           </execution>
           <execution>
+            <id>enforce-dependencies</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <!-- we don't need these until JUST BEFORE integration testing, so moving to a later phase to get out of the way of m2eclipse. <phase>compile</phase> -->
-            <id>enforce-dependencies</id>
             <configuration>
               <rules>
                 <bannedDependencies>


### PR DESCRIPTION
Some cleanup wrt variety of versions for same artifacts we use
across Nexus.

Is good to be merged, but eyeballs needed.

Got inspired by
http://www.jasonwhaley.com/blog/2012/03/21/dependency-convergence-in-maven/

Modules up to "lightweight" client is cleaned up (hence, Core is cleaned).

The enforcer is not quite working (light client deps), so did not include it here. Just the results it "caught".
