### PR TITLE
NEXUS-4986: Get rid of duplicated classes for parsing Artifact Versions

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/ComparableVersion.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/ComparableVersion.java
@@ -68,7 +68,9 @@ import java.util.Stack;
  * @author <a href="mailto:kenney@apache.org">Kenney Westerhof</a>
  * @author <a href="mailto:hboutemy@apache.org">Hervé Boutemy</a>
  * @version $Id: ComparableVersion.java 958295 2010-06-26 23:16:18Z hboutemy $
+ * @deprecated Use class {@link org.sonatype.nexus.proxy.maven.version.Version} and related ones instead of this one.
  */
+@Deprecated
 public class ComparableVersion
     implements Comparable<ComparableVersion>
 {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/VersionComparator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/VersionComparator.java
@@ -14,27 +14,52 @@ package org.sonatype.nexus.proxy.maven.metadata.operations;
 
 import java.util.Comparator;
 
+import org.sonatype.nexus.proxy.maven.version.GenericVersionParser;
+import org.sonatype.nexus.proxy.maven.version.InvalidVersionSpecificationException;
+import org.sonatype.nexus.proxy.maven.version.Version;
+import org.sonatype.nexus.proxy.maven.version.VersionParser;
+
 /**
  * version comparator used elsewhere to keep version collections sorted
- *
+ * 
  * @author Oleg Gusakov
  * @version $Id: VersionComparator.java 744245 2009-02-13 21:23:44Z hboutemy $
  */
 public class VersionComparator
     implements Comparator<String>
 {
+    private final VersionParser versionParser;
 
-    public int compare( String v1, String v2 )
+    public VersionComparator()
+    {
+        this.versionParser = new GenericVersionParser();
+    }
+
+    public int compare( final String v1, final String v2 )
     {
         if ( v1 == null || v2 == null )
         {
             throw new IllegalArgumentException();
         }
 
-        ComparableVersion av1 = new ComparableVersion( v1 );
-        ComparableVersion av2 = new ComparableVersion( v2 );
+        final Version av1 = parseVersion( v1 );
+        final Version av2 = parseVersion( v2 );
 
         return av1.compareTo( av2 );
+    }
+
+    protected Version parseVersion( final String v )
+    {
+        try
+        {
+            return versionParser.parseVersion( v );
+        }
+        catch ( InvalidVersionSpecificationException e )
+        {
+            // from implementation (coming from Aether) we know today this will never happen
+            // but is here probably for future. Also, we do not deal with ranges, only single version strings
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Metadata VersionComparator "redirected" to proper class, other one
deprecated.

Some context: the deprecated class came along with other Mercury (pre-Aether library) classes, as they were lifted into Nexus core.

The proper class came into core with Nexus 2.0, and is copied from Aether (see Javadoc) and is present as long as Maven support gets out of Core (Maven support should be in plugin just like any other repo implementations, keeping Core thin).
