### PR TITLE
NEXUS-4985: AbstractGroupRepository#doRetrieveItem(ResourceStoreRequest) hides actual reason why something is not found in it's member

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ItemNotFoundException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ItemNotFoundException.java
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.proxy;
 
 import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * Thrown if the requested item is not found.
@@ -34,6 +35,7 @@ public class ItemNotFoundException
      * @param path
      * @deprecated use a constructor that accepts a request!
      */
+    @Deprecated
     public ItemNotFoundException( String path )
     {
         this( path, null );
@@ -46,50 +48,92 @@ public class ItemNotFoundException
      * @param cause
      * @deprecated use a constructor that accepts a request!
      */
+    @Deprecated
     public ItemNotFoundException( String path, Throwable cause )
     {
         super( "Item not found on path " + path, cause );
-
         this.repository = null;
-
         this.request = null;
     }
 
-    public ItemNotFoundException( ResourceStoreRequest request )
+    /**
+     * Constructor. To be used in places where no Repository exists yet in context (like in a Router).
+     * 
+     * @param request
+     */
+    public ItemNotFoundException( final ResourceStoreRequest request )
     {
         this( request, null, null );
     }
 
-    public ItemNotFoundException( ResourceStoreRequest request, Repository repository )
-    {
-        this( request, repository, null );
-    }
-
-    public ItemNotFoundException( ResourceStoreRequest request, Throwable cause )
+    /**
+     * Constructor. To be used in places where no Repository exists yet in context (like in a Router).
+     * 
+     * @param request
+     * @param cause
+     */
+    public ItemNotFoundException( final ResourceStoreRequest request, final Throwable cause )
     {
         this( request, null, cause );
     }
 
-    public ItemNotFoundException( ResourceStoreRequest request, Repository repository, Throwable cause )
+    /**
+     * Constructor. To be used in places whenever there IS a Repository in context.
+     * 
+     * @param request
+     * @param repository
+     */
+    public ItemNotFoundException( final ResourceStoreRequest request, final Repository repository )
     {
-        this( repository != null ? "Item not found on path \"" + request.toString() + "\" in repository \""
-            + repository.getId() + "\"!" : "Item not found on path \"" + request.toString() + "\"!", request,
-            repository, cause );
+        this( request, repository, null );
     }
 
-    public ItemNotFoundException( String message, ResourceStoreRequest request, Repository repository )
+    /**
+     * Constructor. To be used in places whenever there IS a Repository in context.
+     * 
+     * @param request
+     * @param repository
+     * @param cause
+     */
+    public ItemNotFoundException( final ResourceStoreRequest request, final Repository repository, final Throwable cause )
+    {
+        this( repository != null ? "Item not found for request \"" + String.valueOf( request ) + "\" in repository \""
+            + RepositoryStringUtils.getHumanizedNameString( repository ) + "\"!" : "Item not found for request \""
+            + String.valueOf( request ) + "\"!", request, repository, cause );
+    }
+    
+    // ==
+
+    /**
+     * Protected constructor, to be used by this class and subclass constructors.
+     * 
+     * @param message
+     * @param request
+     * @param repository
+     */
+    protected ItemNotFoundException( final String message, final ResourceStoreRequest request,
+                                     final Repository repository )
     {
         this( message, request, repository, null );
     }
 
-    public ItemNotFoundException( String message, ResourceStoreRequest request, Repository repository, Throwable cause )
+    /**
+     * Protected constructor, to be used by this class and subclass constructors.
+     * 
+     * @param message
+     * @param request
+     * @param repository
+     * @param cause
+     */
+    protected ItemNotFoundException( final String message, final ResourceStoreRequest request,
+                                     final Repository repository, final Throwable cause )
     {
         super( message, cause );
-
         this.request = request;
-
         this.repository = repository;
     }
+
+    // ==
 
     public Repository getRepository()
     {

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RepositoryNotAvailableException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RepositoryNotAvailableException.java
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.proxy;
 
 import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * Thrown if the repository involved in processing is not available.
@@ -28,8 +29,7 @@ public class RepositoryNotAvailableException
 
     public RepositoryNotAvailableException( Repository repository )
     {
-        super( "Repository with ID='" + repository.getId() + "' is not available!" );
-
+        super( "Repository " + RepositoryStringUtils.getHumanizedNameString( repository ) + " is not available!" );
         this.repository = repository;
     }
 
@@ -37,5 +37,4 @@ public class RepositoryNotAvailableException
     {
         return repository;
     }
-
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -346,8 +346,14 @@ public class ResourceStoreRequest
         return appliedMappings;
     }
 
+    @Override
     public String toString()
     {
-        return getRequestPath();
+        StringBuffer sb = new StringBuffer( "ResourceStoreRequest(" );
+        sb.append( getRequestPath() );
+        sb.append( ") " );
+        sb.append( super.toString() );
+
+        return sb.toString();
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -352,8 +352,7 @@ public class ResourceStoreRequest
         StringBuffer sb = new StringBuffer( getClass().getSimpleName() );
         sb.append( "(requestPath=\"" );
         sb.append( getRequestPath() );
-        sb.append( "\") " );
-        sb.append( super.toString() );
+        sb.append( "\")" );
         return sb.toString();
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -349,11 +349,11 @@ public class ResourceStoreRequest
     @Override
     public String toString()
     {
-        StringBuffer sb = new StringBuffer( "ResourceStoreRequest(" );
+        StringBuffer sb = new StringBuffer( getClass().getSimpleName() );
+        sb.append( "(requestPath=\"" );
         sb.append( getRequestPath() );
-        sb.append( ") " );
+        sb.append( "\") " );
         sb.append( super.toString() );
-
         return sb.toString();
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -349,7 +349,7 @@ public class ResourceStoreRequest
     @Override
     public String toString()
     {
-        StringBuffer sb = new StringBuffer( getClass().getSimpleName() );
+        StringBuilder sb = new StringBuilder( getClass().getSimpleName() );
         sb.append( "(requestPath=\"" );
         sb.append( getRequestPath() );
         sb.append( "\")" );

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/GroupItemNotFoundException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/GroupItemNotFoundException.java
@@ -1,0 +1,64 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.repository;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sonatype.nexus.proxy.ItemNotFoundException;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+
+/**
+ * Thrown by the {@link GroupRepository#retrieveItem(ResourceStoreRequest)},
+ * {@link GroupRepository#retrieveItem(boolean, ResourceStoreRequest)} and
+ * {@link GroupRepository#doRetrieveItems(ResourceStoreRequest)} methods only, when all the members and group repository
+ * itself failed to retrieve item corresponding to request in non-hard-fail (ie. some internal error or some other
+ * condition that stops group processing immediately) way.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class GroupItemNotFoundException
+    extends ItemNotFoundException
+{
+    private static final long serialVersionUID = -863009398540333419L;
+
+    private final Map<Repository, Throwable> memberReasons;
+
+    /**
+     * Constructor for group thrown "not found" exception providing information about whole tree being processed and
+     * reasons why the grand total result is "not found.
+     * 
+     * @param request
+     * @param repository
+     */
+    public GroupItemNotFoundException( final ResourceStoreRequest request, final GroupRepository repository,
+                                       final Map<Repository, Throwable> memberReasons )
+    {
+        super( request, repository );
+        // copy it and make it unmodifiable
+        this.memberReasons = Collections.unmodifiableMap( new HashMap<Repository, Throwable>( memberReasons ) );
+    }
+
+    @Override
+    public GroupRepository getRepository()
+    {
+        return (GroupRepository) super.getRepository();
+    }
+
+    public Map<Repository, Throwable> getMemberReasons()
+    {
+        return memberReasons;
+    }
+}

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/GroupRepository.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/GroupRepository.java
@@ -91,13 +91,14 @@ public interface GroupRepository
 
     /**
      * Returns the list of available items in the group for same path. The resulting list keeps the order of reposes
-     * queried for path.
+     * queried for path. Never returns {@code null}, if nothing found, {@link GroupItemNotFoundException} is thrown.
      * 
      * @param uid
      * @param context
      * @return
      * @throws StorageException
+     * @throws GroupItemNotFoundException
      */
     List<StorageItem> doRetrieveItems( ResourceStoreRequest request )
-        throws StorageException;
+        throws GroupItemNotFoundException, StorageException;
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/storage/remote/RemoteItemNotFoundException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/storage/remote/RemoteItemNotFoundException.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.proxy.storage.remote;
 
 import org.sonatype.nexus.proxy.ItemNotFoundException;

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/storage/remote/RemoteItemNotFoundException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/storage/remote/RemoteItemNotFoundException.java
@@ -1,0 +1,38 @@
+package org.sonatype.nexus.proxy.storage.remote;
+
+import org.sonatype.nexus.proxy.ItemNotFoundException;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.repository.ProxyRepository;
+
+/**
+ * Thrown by RemoteRepositoryStorage if the requested item is not found for some reason that is part of internal
+ * implementation of that same RemoteRepositoryStorage.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class RemoteItemNotFoundException
+    extends ItemNotFoundException
+{
+    private static final long serialVersionUID = 8422409141417737154L;
+
+    /**
+     * Creates a "not found" exception with customized message, where RemoteRepositoryStorage may explain why it throw
+     * this exception.
+     * 
+     * @param message
+     * @param request
+     * @param repository
+     */
+    public RemoteItemNotFoundException( final String message, final ResourceStoreRequest request,
+                                        final ProxyRepository repository )
+    {
+        super( message, request, repository );
+    }
+
+    @Override
+    public ProxyRepository getRepository()
+    {
+        return (ProxyRepository) super.getRepository();
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreHelper.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreHelper.java
@@ -323,8 +323,7 @@ public class ArtifactStoreHelper
 
             if ( gav == null )
             {
-                throw new ItemNotFoundException( "GAV: " + gavRequest.getGroupId() + " : " + gavRequest.getArtifactId()
-                    + " : " + gavRequest.getVersion(), gavRequest, repository );
+                throw new ItemNotFoundException( gavRequest, repository );
             }
 
             return gav;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
@@ -89,7 +89,8 @@ public class ArtifactStoreRequest
     @Override
     public String toString()
     {
-        StringBuffer sb = new StringBuffer( "ArtifactStoreRequest(" );
+        StringBuffer sb = new StringBuffer( super.toString() );
+        sb.append( "(GAVCE=" );
         sb.append( getGroupId() );
         sb.append( ":" );
         sb.append( getArtifactId() );
@@ -99,10 +100,9 @@ public class ArtifactStoreRequest
         sb.append( getClassifier() );
         sb.append( ":e=" );
         sb.append( getExtension() );
-        sb.append( ") " );
+        sb.append( ", for " );
         sb.append( RepositoryStringUtils.getHumanizedNameString( getMavenRepository() ) );
-        sb.append( " " );
-        sb.append( super.toString() );
+        sb.append( ") " );
 
         return sb.toString();
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
@@ -89,7 +89,7 @@ public class ArtifactStoreRequest
     @Override
     public String toString()
     {
-        StringBuffer sb = new StringBuffer( super.toString() );
+        StringBuilder sb = new StringBuilder( super.toString() );
         sb.append( "(GAVCE=" );
         sb.append( getGroupId() );
         sb.append( ":" );

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreRequest.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.proxy.maven;
 
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.maven.gav.Gav;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 public class ArtifactStoreRequest
     extends ResourceStoreRequest
@@ -88,7 +89,8 @@ public class ArtifactStoreRequest
     @Override
     public String toString()
     {
-        StringBuffer sb = new StringBuffer( getGroupId() );
+        StringBuffer sb = new StringBuffer( "ArtifactStoreRequest(" );
+        sb.append( getGroupId() );
         sb.append( ":" );
         sb.append( getArtifactId() );
         sb.append( ":" );
@@ -97,6 +99,10 @@ public class ArtifactStoreRequest
         sb.append( getClassifier() );
         sb.append( ":e=" );
         sb.append( getExtension() );
+        sb.append( ") " );
+        sb.append( RepositoryStringUtils.getHumanizedNameString( getMavenRepository() ) );
+        sb.append( " " );
+        sb.append( super.toString() );
 
         return sb.toString();
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.proxy.repository;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -197,6 +198,7 @@ public abstract class AbstractGroupRepository
 
         final boolean isRequestGroupLocalOnly =
             request.isRequestGroupLocalOnly() || uid.getBooleanAttributeValue( IsGroupLocalOnlyAttribute.class );
+        final HashMap<Repository, Throwable> memberThrowables = new HashMap<Repository, Throwable>();
 
         if ( !isRequestGroupLocalOnly )
         {
@@ -207,20 +209,22 @@ public abstract class AbstractGroupRepository
                     try
                     {
                         addItems( names, result, repo.list( false, request ) );
-
                         found = true;
                     }
                     catch ( ItemNotFoundException e )
                     {
-                        // ignored
+                        // ignored, but bookkeeping happens now
+                        memberThrowables.put( repo, e );
                     }
                     catch ( IllegalOperationException e )
                     {
-                        // ignored
+                        // ignored, but bookkeeping happens now
+                        memberThrowables.put( repo, e );
                     }
                     catch ( StorageException e )
                     {
-                        // ignored
+                        // ignored, but bookkeeping happens now
+                        memberThrowables.put( repo, e );
                     }
                 }
                 else
@@ -239,7 +243,7 @@ public abstract class AbstractGroupRepository
 
         if ( !found )
         {
-            throw new ItemNotFoundException( request, this );
+            throw new GroupItemNotFoundException( request, this, memberThrowables );
         }
 
         return result;
@@ -277,6 +281,8 @@ public abstract class AbstractGroupRepository
         {
             request.getRequestContext().put( AccessManager.REQUEST_AUTHORIZED, Boolean.TRUE );
         }
+
+        final HashMap<Repository, Throwable> memberThrowables = new HashMap<Repository, Throwable>();
 
         try
         {
@@ -351,19 +357,24 @@ public abstract class AbstractGroupRepository
                             }
                             catch ( IllegalOperationException e )
                             {
-                                // ignored
+                                // ignored, but bookkeeping happens now
+                                memberThrowables.put( repo, e );
                             }
                             catch ( ItemNotFoundException e )
                             {
-                                // ignored
+                                // ignored, but bookkeeping happens now
+                                memberThrowables.put( repo, e );
                             }
                             catch ( StorageException e )
                             {
-                                // ignored
+                                // ignored, but bookkeeping happens now
+                                memberThrowables.put( repo, e );
                             }
                             catch ( AccessDeniedException e )
                             {
                                 // cannot happen, since we add/check for AccessManager.REQUEST_AUTHORIZED flag
+                                // ignored, but bookkeeping happens now
+                                memberThrowables.put( repo, e );
                             }
                         }
                         else
@@ -389,7 +400,7 @@ public abstract class AbstractGroupRepository
             }
         }
 
-        throw new ItemNotFoundException( request, this );
+        throw new GroupItemNotFoundException( request, this, memberThrowables );
     }
 
     public List<String> getMemberRepositoryIds()
@@ -502,7 +513,7 @@ public abstract class AbstractGroupRepository
     }
 
     public List<StorageItem> doRetrieveItems( ResourceStoreRequest request )
-        throws StorageException
+        throws GroupItemNotFoundException, StorageException
     {
         ArrayList<StorageItem> items = new ArrayList<StorageItem>();
 
@@ -510,6 +521,8 @@ public abstract class AbstractGroupRepository
 
         final boolean isRequestGroupLocalOnly =
             request.isRequestGroupLocalOnly() || uid.getBooleanAttributeValue( IsGroupLocalOnlyAttribute.class );
+        
+        final HashMap<Repository, Throwable> memberThrowables = new HashMap<Repository, Throwable>();
 
         if ( !isRequestGroupLocalOnly )
         {
@@ -570,7 +583,8 @@ public abstract class AbstractGroupRepository
                         }
                         catch ( ItemNotFoundException e )
                         {
-                            // that's okay
+                            // ignored, but bookkeeping happens now
+                            memberThrowables.put( repository, e );
                         }
                         catch ( RepositoryNotAvailableException e )
                         {
@@ -580,6 +594,8 @@ public abstract class AbstractGroupRepository
                                     RepositoryStringUtils.getFormattedMessage(
                                         "Member repository %s is not available, request failed.", e.getRepository() ) );
                             }
+                            // ignored, but bookkeeping happens now
+                            memberThrowables.put( repository, e );
                         }
                         catch ( StorageException e )
                         {
@@ -588,6 +604,8 @@ public abstract class AbstractGroupRepository
                         catch ( IllegalOperationException e )
                         {
                             getLogger().warn( "Member repository request failed", e );
+                            // ignored, but bookkeeping happens now
+                            memberThrowables.put( repository, e );
                         }
                     }
                     else
@@ -603,6 +621,11 @@ public abstract class AbstractGroupRepository
                     }
                 }
             }
+        }
+
+        if ( items.isEmpty() )
+        {
+            throw new GroupItemNotFoundException( request, this, memberThrowables );
         }
 
         return items;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -234,10 +234,10 @@ public abstract class AbstractProxyRepository
                     throw e;
                 }
             }
-            
-            if( getLogger().isDebugEnabled() )
+
+            if ( getLogger().isDebugEnabled() )
             {
-                if( expireCacheWalkerProcessor.isCacheAltered() )
+                if ( expireCacheWalkerProcessor.isCacheAltered() )
                 {
                     getLogger().info(
                         String.format( "Proxy cache was expired for repository %s from path=\"%s\"",
@@ -1726,7 +1726,8 @@ public abstract class AbstractProxyRepository
                 {
                     if ( !getProxyMode().shouldCheckRemoteStatus() )
                     {
-                        setRemoteStatus( RemoteStatus.UNAVAILABLE, new ItemNotFoundException( request ) );
+                        setRemoteStatus( RemoteStatus.UNAVAILABLE, new ItemNotFoundException( request,
+                            AbstractProxyRepository.this ) );
                     }
                     else
                     {
@@ -1736,7 +1737,7 @@ public abstract class AbstractProxyRepository
                         }
                         else
                         {
-                            autoBlockProxying( new ItemNotFoundException( request ) );
+                            autoBlockProxying( new ItemNotFoundException( request, AbstractProxyRepository.this ) );
                         }
                     }
                 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1149,7 +1149,7 @@ public abstract class AbstractRepository
                                 + " is in NFC and still active, throwing ItemNotFoundException." );
                     }
 
-                    throw new ItemNotFoundException( request );
+                    throw new ItemNotFoundException( request, this );
                 }
             }
         }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractShadowRepository.java
@@ -219,7 +219,7 @@ public abstract class AbstractShadowRepository
         catch ( AccessDeniedException e )
         {
             // if client has no access to content over shadow, we just hide the fact
-            throw new ItemNotFoundException( request, e );
+            throw new ItemNotFoundException( request, this, e );
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/charger/AbstractRetrieveCallable.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/charger/AbstractRetrieveCallable.java
@@ -1,0 +1,78 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.repository.charger;
+
+import java.util.concurrent.Callable;
+
+import org.codehaus.plexus.logging.Logger;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.item.StorageItem;
+import org.sonatype.nexus.proxy.repository.Repository;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Callable that retrieves an item from a repository, as part of a group request. Used in
+ * org.sonatype.nexus.proxy.repository.AbstractGroupRepository.doRetrieveItem(ResourceStoreRequest). All exceptions are
+ * supressed by this same class (it implements ExceptionHandler).
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public abstract class AbstractRetrieveCallable<I extends StorageItem>
+    implements Callable<I>
+{
+    private final Logger logger;
+
+    private final Repository repository;
+
+    private final ResourceStoreRequest request;
+
+    private Throwable processingException;
+
+    public AbstractRetrieveCallable( final Logger logger, final Repository repository,
+                                     final ResourceStoreRequest request )
+    {
+        this.logger = Preconditions.checkNotNull( logger );
+        this.repository = Preconditions.checkNotNull( repository );
+        this.request = Preconditions.checkNotNull( request );
+        this.processingException = null;
+    }
+
+    public Throwable getProcessingException()
+    {
+        return processingException;
+    }
+
+    // ==
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
+
+    protected Repository getRepository()
+    {
+        return repository;
+    }
+
+    protected ResourceStoreRequest getRequest()
+    {
+        return request;
+    }
+
+    protected void setProcessingException( final Throwable processingException )
+    {
+        this.processingException = processingException;
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/CommonsHttpClientRemoteStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/CommonsHttpClientRemoteStorage.java
@@ -55,6 +55,7 @@ import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
 import org.sonatype.nexus.proxy.storage.remote.AbstractHTTPRemoteRepositoryStorage;
 import org.sonatype.nexus.proxy.storage.remote.DefaultRemoteStorageContext.BooleanFlagHolder;
+import org.sonatype.nexus.proxy.storage.remote.RemoteItemNotFoundException;
 import org.sonatype.nexus.proxy.storage.remote.RemoteRepositoryStorage;
 import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
 import org.sonatype.nexus.proxy.utils.UserAgentBuilder;
@@ -113,7 +114,6 @@ public class CommonsHttpClientRemoteStorage
 
         if ( response == HttpStatus.SC_OK )
         {
-
             if ( method.getPath().endsWith( "/" ) )
             {
                 // this is a collection and not a file!
@@ -122,7 +122,7 @@ public class CommonsHttpClientRemoteStorage
                 // give us URL with ending "/"
                 method.releaseConnection();
 
-                throw new ItemNotFoundException(
+                throw new RemoteItemNotFoundException(
                     "The remoteURL we got to looks like is a collection, and Nexus cannot fetch collections over plain HTTP (remoteUrl=\""
                         + remoteURL.toString() + "\")", request, repository );
             }
@@ -194,14 +194,14 @@ public class CommonsHttpClientRemoteStorage
 
             if ( response == HttpStatus.SC_NOT_FOUND )
             {
-                throw new ItemNotFoundException(
+                throw new RemoteItemNotFoundException(
                     "The remoteURL we requested does not exists on remote server (remoteUrl=\"" + remoteURL.toString()
-                        + "\")", request, repository );
+                        + "\", response code is 404)", request, repository );
             }
             else
             {
                 throw new RemoteStorageException( "The method execution returned result code " + response
-                    + ". [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                    + " (expected 200). [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
                     + "\", remoteUrl=\"" + remoteURL.toString() + "\"]" );
             }
         }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
@@ -53,6 +53,7 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
 import org.sonatype.nexus.proxy.storage.remote.AbstractHTTPRemoteRepositoryStorage;
+import org.sonatype.nexus.proxy.storage.remote.RemoteItemNotFoundException;
 import org.sonatype.nexus.proxy.storage.remote.RemoteRepositoryStorage;
 import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
 import org.sonatype.nexus.proxy.utils.UserAgentBuilder;
@@ -143,7 +144,7 @@ class HttpClientRemoteStorage
                 // _should_
                 // give us URL with ending "/"
                 release( httpResponse );
-                throw new ItemNotFoundException(
+                throw new RemoteItemNotFoundException(
                     "The remoteURL we got to looks like is a collection, and Nexus cannot fetch collections over plain HTTP (remoteUrl=\""
                         + remoteURL.toString() + "\")", request, repository );
             }
@@ -195,17 +196,15 @@ class HttpClientRemoteStorage
             release( httpResponse );
             if ( httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND )
             {
-                throw new ItemNotFoundException(
+                throw new RemoteItemNotFoundException(
                     "The remoteURL we requested does not exists on remote server (remoteUrl=\"" + remoteURL.toString()
-                        + "\")", request, repository );
+                        + "\", response code is 404)", request, repository );
             }
             else
             {
-                throw new RemoteStorageException( "The method execution returned result code "
-                                                      + httpResponse.getStatusLine().getStatusCode()
-                                                      + ". [repositoryId=\"" + repository.getId() + "\", requestPath=\""
-                                                      + request.getRequestPath()
-                                                      + "\", remoteUrl=\"" + remoteURL.toString() + "\"]" );
+                throw new RemoteStorageException( "The method execution returned result code " + httpResponse.getStatusLine().getStatusCode()
+                    + " (expected 200). [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                    + "\", remoteUrl=\"" + remoteURL.toString() + "\"]" );
             }
         }
     }

--- a/nexus/nexus-rest-api-model/src/main/mdo/vos.xml
+++ b/nexus/nexus-rest-api-model/src/main/mdo/vos.xml
@@ -2554,6 +2554,64 @@
             <annotation>@javax.xml.bind.annotation.XmlElement( name = "sourceItem" )</annotation>
           </annotations>
         </field>
+        <field>
+          <name>notFoundReasoning</name>
+          <version>1.0.0+</version>
+          <association>
+            <type>NotFoundReasoning</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <required>false</required>
+          <description>Tree of reasons why something was not found.</description>
+          <annotations>
+            <annotation>@javax.xml.bind.annotation.XmlElementWrapper( name = "notFoundReasoning" )</annotation>
+            <annotation>@javax.xml.bind.annotation.XmlElement( name = "notFoundReasoningItem" )</annotation>
+          </annotations>
+        </field>
+      </fields>
+    </class>
+
+    <class>
+      <name>NotFoundReasoning</name>
+      <version>1.0.0+</version>
+      <description>REST Response object for reasoning why something is not found.</description>
+      <annotations>
+        <annotation>@javax.xml.bind.annotation.XmlType( name = "content-list-describe-response-resource-not-found" )</annotation>
+        <annotation>@javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)</annotation>
+      </annotations>
+      <fields>
+        <field>
+          <name>repositoryId</name>
+          <version>1.0.0+</version>
+          <type>String</type>
+          <required>true</required>
+        </field>
+        <field>
+          <name>throwableType</name>
+          <version>1.0.0+</version>
+          <type>String</type>
+          <required>true</required>
+        </field>
+        <field>
+          <name>reasonMessage</name>
+          <version>1.0.0+</version>
+          <type>String</type>
+          <required>true</required>
+        </field>
+        <field>
+          <name>notFoundReasoning</name>
+          <version>1.0.0+</version>
+          <association>
+            <type>NotFoundReasoning</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <required>false</required>
+          <description>If this is a composite item, the list of sources that this item was generated from.</description>
+          <annotations>
+            <annotation>@javax.xml.bind.annotation.XmlElementWrapper( name = "notFoundReasoning" )</annotation>
+            <annotation>@javax.xml.bind.annotation.XmlElement( name = "notFoundReasoningItem" )</annotation>
+          </annotations>
+        </field>
       </fields>
     </class>
 

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/artifact/ArtifactResolvePlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/artifact/ArtifactResolvePlexusResource.java
@@ -136,8 +136,7 @@ public class ArtifactResolvePlexusResource
 
             if ( resolvedGav == null )
             {
-                throw new ItemNotFoundException( "GAV: " + gavRequest.getGroupId() + " : " + gavRequest.getArtifactId()
-                    + " : " + gavRequest.getVersion(), gavRequest, mavenRepository );
+                throw new ItemNotFoundException( gavRequest, mavenRepository );
             }
 
             String repositoryPath = mavenRepository.getGavCalculator().gavToPath( resolvedGav );


### PR DESCRIPTION
Changes:
- introduced "bookkeeping" for groups, made them not "swallow" member exceptions anymore
- REST API ?describe method changed to make use of this new information
- improvements for some exception messages
- improvements for some toString() methods (simply for easier debug)
