### PR TITLE
NEXUS-4904 explicitly turn updateCheck off for ehcache

### DIFF
--- a/nexus/nexus-app/src/test/resources/ehcache.xml
+++ b/nexus/nexus-app/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="false">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/resources/ehcache.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="false">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/src/test/resources/ehcache.xml
+++ b/nexus/nexus-core-plugins/nexus-maven-bridge-plugin/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="false">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-proxy/src/main/resources/ehcache-default.xml
+++ b/nexus/nexus-proxy/src/main/resources/ehcache-default.xml
@@ -13,7 +13,7 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-<ehcache>
+<ehcache updateCheck="false">
 
     <!-- All ${...} is replaced by plexus if know to it! -->
     <!-- NO MORE DISK CACHE !!! 

--- a/nexus/nexus-proxy/src/main/resources/ehcache-failsafe.xml
+++ b/nexus/nexus-proxy/src/main/resources/ehcache-failsafe.xml
@@ -13,7 +13,7 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-<ehcache>
+<ehcache updateCheck="false">
     <!--
     DiskStore configuration
 

--- a/nexus/nexus-proxy/src/test/resources/ehcache.xml
+++ b/nexus/nexus-proxy/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="false">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-rest-api/src/test/resources/ehcache.xml
+++ b/nexus/nexus-rest-api/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache updateCheck="fale">
+<ehcache updateCheck="false">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-rest-api/src/test/resources/ehcache.xml
+++ b/nexus/nexus-rest-api/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache updateCheck="true">
+<ehcache updateCheck="fale">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-rest-api/src/test/resources/ehcache.xml
+++ b/nexus/nexus-rest-api/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="true">
     
     <defaultCache
             maxElementsInMemory="1000"

--- a/nexus/nexus-web-utils/src/test/resources/ehcache.xml
+++ b/nexus/nexus-web-utils/src/test/resources/ehcache.xml
@@ -1,4 +1,4 @@
-<ehcache>
+<ehcache updateCheck="false">
 
     <!-- Only ${basedir} is replaced by plexus! -->
     <diskStore path="${basedir}/target/ehcache"/>

--- a/nexus/nexus-webapp/src/main/resources/ehcache.xml
+++ b/nexus/nexus-webapp/src/main/resources/ehcache.xml
@@ -13,7 +13,7 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-<ehcache>
+<ehcache updateCheck="false">
 
     <!-- All ${...} is replaced by plexus if know to it! -->
     <!-- NO MORE DISK CACHE !!! 


### PR DESCRIPTION
despite nexus code using sisu-ehcache which turns update check off via a component, make double sure we
don't have ehcache calling home in tests or otherwise by setting same in ehcache.xml files
