### PR TITLE
NXCM-3965: Adding new constructor to NoSuchRepositoryException

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/NoSuchRepositoryException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/NoSuchRepositoryException.java
@@ -22,9 +22,26 @@ public class NoSuchRepositoryException
 {
     private static final long serialVersionUID = 299346983704055394L;
 
-    public NoSuchRepositoryException( String repoId )
+    /**
+     * Constructs a new exception with message based on passed in Repository ID.
+     * 
+     * @param repoId
+     */
+    public NoSuchRepositoryException( final String repoId )
     {
-        super( "Repository", repoId );
+        super( "Repository with ID=\"" + repoId + "\" not found!" );
     }
 
+    /**
+     * Constructs a new exception with the specified detail message and cause. Usable in cases where repository ID is
+     * unknown from the current context, only the fact is known it is not (yet) present.
+     * 
+     * @param msg message
+     * @param t the cause
+     * @since 2.1
+     */
+    public NoSuchRepositoryException( final String msg, final Throwable t )
+    {
+        super( msg, t );
+    }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/NoSuchResourceStoreException.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/NoSuchResourceStoreException.java
@@ -22,16 +22,35 @@ public abstract class NoSuchResourceStoreException
 {
     private static final long serialVersionUID = 299346983704055394L;
 
-    public NoSuchResourceStoreException( String msg )
+    /**
+     * Constructs a new exception with the specified detail message.
+     * 
+     * @param msg message
+     */
+    public NoSuchResourceStoreException( final String msg )
     {
         super( msg );
     }
 
-    public NoSuchResourceStoreException( String msg, Throwable t )
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * 
+     * @param msg message
+     * @param t the cause
+     */
+    public NoSuchResourceStoreException( final String msg, final Throwable t )
     {
         super( msg, t );
     }
 
+    /**
+     * Deprecated constructor that pre-assembles a message that does not make sense in some cases.
+     * 
+     * @param type
+     * @param id
+     * @deprecated Use any other "usual" exception constructor instead.
+     */
+    @Deprecated
     public NoSuchResourceStoreException( String type, String id )
     {
         super( "ResourceStore of type " + type + " with id='" + id + "' not found!" );


### PR DESCRIPTION
There are cases when we do want to throw NoSuchRepositoryException
but the actual repository ID for some reason is unknown (and is
irrelevant actually).
