### PR TITLE
NEXUS-4968: Simple fix.

### DIFF
--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtilTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/commonshttpclient/HttpClientProxyUtilTest.java
@@ -153,7 +153,7 @@ public class HttpClientProxyUtilTest
         // get last changed
         long lastChanged = ctx.getLastChanged();
         // making sure we will have subtraction result grater than 0
-        Thread.sleep( 5 );
+        Thread.sleep( 15 );
 
         // 1st invocation, should modify it
         HttpClientProxyUtil.applyProxyToHttpClient( httpClient, ctx, logger );
@@ -162,7 +162,7 @@ public class HttpClientProxyUtilTest
         // get last changed
         lastChanged = ctx.getLastChanged();
         // making sure we will have subtraction result grater than 0
-        Thread.sleep( 5 );
+        Thread.sleep( 15 );
 
         // now 2nd invocation, should not change
         HttpClientProxyUtil.applyProxyToHttpClient( httpClient, ctx, logger );


### PR DESCRIPTION
It seems Java running on VM Windows platform is known to
"over sleep" but also "under sleep". Also, in links below
it is mentioned that "slice size on Windows" is 10ms, but might
be worse when running in Hypervisor.

This fix simply raises the sleep time over the "slice size" to
make it more plausible to "over sleep" instead to "under sleep".

See issue comments and links in them:
https://issues.sonatype.org/browse/NEXUS-4968
