### PR TITLE
NXCM-3986: Improve logs

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -453,7 +453,7 @@ public class DefaultFSPeer
                         + " ms intervals " + hiddenTarget.getAbsolutePath() + " --> " + target.getAbsolutePath() );
 
                 throw new IOException( "Cannot rename file \"" + hiddenTarget.getAbsolutePath() + "\" to \""
-                    + target.getAbsolutePath() + "\"! " + e.getMessage() );
+                    + target.getAbsolutePath() + "\"! " + e.getMessage(), e );
             }
         }
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSPeer.java
@@ -39,6 +39,7 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.item.uid.IsItemAttributeMetacontentAttribute;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
+import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 import org.sonatype.nexus.util.ItemPathUtils;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 
@@ -110,9 +111,9 @@ public class DefaultFSPeer
                     hiddenTarget.delete();
                 }
 
-                throw new LocalStorageException( "Got exception during storing on path "
-                    + item.getRepositoryItemUid().toString() + " (while writing to hiddenTarget: "
-                    + hiddenTarget.getAbsolutePath() + ")", e );
+                throw new LocalStorageException( String.format(
+                    "Got exception during storing on path \"%s\" (while writing to hiddenTarget: \"%s\")",
+                    item.getRepositoryItemUid().toString(), hiddenTarget.getAbsolutePath() ), e );
             }
             finally
             {
@@ -164,8 +165,9 @@ public class DefaultFSPeer
                         item.getRepositoryItemUid().toString(), hiddenTarget.getAbsolutePath() );
                 }
 
-                throw new LocalStorageException( "Got exception during storing on path "
-                    + item.getRepositoryItemUid().toString() + " (while moving to final destination)", e );
+                throw new LocalStorageException( String.format(
+                    "Got exception during storing on path \"%s\" (while moving to final destination)",
+                    item.getRepositoryItemUid().toString() ), e );
             }
             finally
             {
@@ -196,16 +198,22 @@ public class DefaultFSPeer
             }
             catch ( IOException ex )
             {
-                throw new LocalStorageException( "Could not delete File in repository \"" + repository.getName()
-                    + "\" (id=\"" + repository.getId() + "\") from path " + target.getAbsolutePath(), ex );
+                throw new LocalStorageException( String.format(
+                    "Could not delete directory in repository %s from path \"%s\"",
+                    RepositoryStringUtils.getHumanizedNameString( repository ), target.getAbsolutePath() ), ex );
             }
         }
         else if ( target.isFile() )
         {
-            if ( !target.delete() )
+            try
             {
-                throw new LocalStorageException( "Could not delete File in repository \"" + repository.getName()
-                    + "\" (id=\"" + repository.getId() + "\") from path " + target.getAbsolutePath() );
+                FileUtils.forceDelete( target );
+            }
+            catch ( IOException ex )
+            {
+                throw new LocalStorageException( String.format(
+                    "Could not delete file in repository %s from path \"%s\"",
+                    RepositoryStringUtils.getHumanizedNameString( repository ), target.getAbsolutePath() ) );
             }
         }
         else
@@ -302,7 +310,8 @@ public class DefaultFSPeer
             }
             else
             {
-                getLogger().warn( "Cannot list directory " + target.getAbsolutePath() );
+                getLogger().warn( "Cannot list directory in repository {}, path \"{}\"",
+                    RepositoryStringUtils.getHumanizedNameString( repository ), target.getAbsolutePath() );
             }
 
             return result;
@@ -343,9 +352,9 @@ public class DefaultFSPeer
             // re-check is it really a "good" parent?
             if ( !target.getParentFile().isDirectory() )
             {
-                throw new LocalStorageException( "Could not create the directory hiearchy in repository \""
-                    + repository.getName() + "\" (id=\"" + repository.getId() + "\") to write "
-                    + target.getAbsolutePath() );
+                throw new LocalStorageException( String.format(
+                    "Could not create the directory hiearchy in repository %s to write \"%s\"",
+                    RepositoryStringUtils.getHumanizedNameString( repository ), target.getAbsolutePath() ) );
             }
         }
     }
@@ -411,9 +420,8 @@ public class DefaultFSPeer
         // if retries enabled go ahead and start the retry process
         for ( int i = 1; success == false && i <= getRenameRetryCount(); i++ )
         {
-            getLogger().debug(
-                "Rename operation attempt " + i + "failed on " + hiddenTarget.getAbsolutePath() + " --> "
-                    + target.getAbsolutePath() + " will wait " + getRenameRetryDelay() + " milliseconds and try again" );
+            getLogger().debug( "Rename operation attempt {} failed on {} --> {}, will wait {} ms and try again",
+                new Object[] { i, hiddenTarget.getAbsolutePath(), target.getAbsolutePath(), getRenameRetryDelay() } );
 
             try
             {
@@ -434,9 +442,8 @@ public class DefaultFSPeer
 
             if ( success )
             {
-                getLogger().info(
-                    "Rename operation succeeded after " + i + " retries on " + hiddenTarget.getAbsolutePath() + " --> "
-                        + target.getAbsolutePath() );
+                getLogger().info( "Rename operation succeeded after {} retries on {} --> {}",
+                    new Object[] { i, hiddenTarget.getAbsolutePath(), target.getAbsolutePath() } );
             }
         }
 
@@ -449,11 +456,12 @@ public class DefaultFSPeer
             catch ( IOException e )
             {
                 getLogger().error(
-                    "Rename operation failed after " + getRenameRetryCount() + " retries in " + getRenameRetryDelay()
-                        + " ms intervals " + hiddenTarget.getAbsolutePath() + " --> " + target.getAbsolutePath() );
+                    "Rename operation failed after {} retries in {} ms intervals {} --> {}",
+                    new Object[] { getRenameRetryCount(), getRenameRetryDelay(), hiddenTarget.getAbsolutePath(),
+                        target.getAbsolutePath() } );
 
-                throw new IOException( "Cannot rename file \"" + hiddenTarget.getAbsolutePath() + "\" to \""
-                    + target.getAbsolutePath() + "\"! " + e.getMessage(), e );
+                throw new IOException( String.format( "Cannot rename file \"%s\" to \"%s\"! Message: %s",
+                    hiddenTarget.getAbsolutePath(), target.getAbsolutePath(), e.getMessage() ), e );
             }
         }
     }

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
@@ -859,15 +859,6 @@ public abstract class AbstractResourceStoreContentPlexusResource
             {
                 challengeIfNeeded( req, res, (AccessDeniedException) t );
             }
-            else if ( t instanceof IOException )
-            {
-                // StorageException is subclass of IOEx, it will be catched here
-
-                // Internal error, we force it to log
-                shouldLogInfoStackTrace = true;
-
-                throw new ResourceException( Status.SERVER_ERROR_INTERNAL, t );
-            }
             else
             {
                 // Internal error, we force it to log

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
@@ -823,10 +823,6 @@ public abstract class AbstractResourceStoreContentPlexusResource
             {
                 throw new ResourceException( Status.CLIENT_ERROR_BAD_REQUEST, t );
             }
-            else if ( t instanceof StorageException )
-            {
-                throw new ResourceException( Status.SERVER_ERROR_INTERNAL, t );
-            }
             else if ( t instanceof RepositoryNotAvailableException )
             {
                 throw new ResourceException( Status.SERVER_ERROR_SERVICE_UNAVAILABLE, t );
@@ -862,6 +858,15 @@ public abstract class AbstractResourceStoreContentPlexusResource
             else if ( t instanceof AccessDeniedException )
             {
                 challengeIfNeeded( req, res, (AccessDeniedException) t );
+            }
+            else if ( t instanceof IOException )
+            {
+                // StorageException is subclass of IOEx, it will be catched here
+
+                // Internal error, we force it to log
+                shouldLogInfoStackTrace = true;
+
+                throw new ResourceException( Status.SERVER_ERROR_INTERNAL, t );
             }
             else
             {


### PR DESCRIPTION
There is a complex set of conditions when to log what, when to log
stack traces and when not to log stack traces. This would need a fix/cleanup
but for now, this change simply makes to log all HTTP 500 Internal
error responses _with_ stack trace, as previously they were logged
without it, and it did not make any sense and caused information loss.

This seems a long outstanding issue, as original commit implementing
this was unchanged for a long time, and it was causing that all
StorageException (that subclass IOException) gets logged _without_
stack trace, that is bad:

Change introduced in:
fcd4ccf26ad3e963d62e6e45ef06b8428f0d7608

We do have server side logs of the NXCM-3986, but as the cause was
not logged (no stack trace), we lost information why the rename
failed (clearly, it was some sort of FS related problem)
