### PR TITLE
Read locking code moved to better place.

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -849,17 +849,6 @@ public abstract class AbstractRepository
                     throw new ItemNotFoundException( request, this );
                 }
             }
-            // plain file? wrap it
-            else if ( item instanceof StorageFileItem )
-            {
-                StorageFileItem file = (StorageFileItem) item;
-
-                // wrap the content locator if needed
-                if ( !( file.getContentLocator() instanceof ReadLockingContentLocator ) )
-                {
-                    file.setContentLocator( new ReadLockingContentLocator( uid, file.getContentLocator() ) );
-                }
-            }
 
             getApplicationEventMulticaster().notifyEventListeners( new RepositoryItemEventRetrieve( this, item ) );
 
@@ -1358,6 +1347,19 @@ public abstract class AbstractRepository
         try
         {
             localItem = getLocalStorage().retrieveItem( this, request );
+
+            // plain file? wrap it
+            if ( localItem instanceof StorageFileItem )
+            {
+                StorageFileItem file = (StorageFileItem) localItem;
+
+                // wrap the content locator if needed
+                if ( !( file.getContentLocator() instanceof ReadLockingContentLocator ) )
+                {
+                    final RepositoryItemUid uid = createUid( request.getRequestPath() );
+                    file.setContentLocator( new ReadLockingContentLocator( uid, file.getContentLocator() ) );
+                }
+            }
 
             if ( getLogger().isDebugEnabled() )
             {


### PR DESCRIPTION
"Closer" to local storage. Also, we had issues regarding "wrong method invoked, hence
no locking in place" in relation to shadows and P2 repositories already. Moreover,
reading the code reveals same problems affects shadow, group and webSite repositories
too.

Hence, the whole block doing the locator swap is "moved down" to this method.

This pull is related to [NXCM-3986](https://issues.sonatype.org/browse/NXCM-3986) and it's pull request (that does not fixes anything but will give us more information on next failure) [#365](https://github.com/sonatype/nexus/pull/365), as it makes obvious some file locking problems are present (visible on Windows platform only, and the test did fail consistently on Win slave only), and code reading revealed the problem fixed in this pull: a "read" access to file contents was easily possible while UID locks were avoided (hence, UID locking in FSPeer does not help, as "counterpart", while reading did not acquire shared lock).
