### PR TITLE
NEXUS-5011: Member change detection fixed.

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -90,11 +90,11 @@ public abstract class AbstractGroupRepository
     public void onEvent( Event<?> evt )
     {
         // we must do this before the super.onEvent() call!
+        // members changed if config was dirty AND the "old" and "new" member ID list (List<String>) are NOT equal
         boolean membersChanged =
             getCurrentCoreConfiguration().isDirty()
-                && ( getExternalConfiguration( false ).getMemberRepositoryIds().size() != getExternalConfiguration(
-                    true ).getMemberRepositoryIds().size() || !getExternalConfiguration( false ).getMemberRepositoryIds().containsAll(
-                    getExternalConfiguration( true ).getMemberRepositoryIds() ) );
+                && !getExternalConfiguration( false ).getMemberRepositoryIds().equals(
+                    getExternalConfiguration( true ).getMemberRepositoryIds() );
 
         List<String> currentMemberIds = Collections.emptyList();
         List<String> newMemberIds = Collections.emptyList();


### PR DESCRIPTION
The original implementation was flawed, it was not detecting
the order change among two lists, since it was checking for subset only.

https://issues.sonatype.org/browse/NEXUS-5011
