### PR TITLE
NXCM-4046: Fixing the logback warning at Nexus bundle boot

### DIFF
--- a/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
+++ b/nexus/nexus-oss-webapp/src/main/assembly/bundle.xml
@@ -91,6 +91,7 @@
         <excludes>
           <exclude>META-INF/**</exclude>
           <exclude>WEB-INF/lib/appcontext*.jar</exclude>
+          <exclude>WEB-INF/classes/logback.xml</exclude>
         </excludes>
       </unpackOptions>
       <useTransitiveDependencies>false</useTransitiveDependencies>


### PR DESCRIPTION
Nexus WAR contains the logback.xml, but also our "container"
has one too (on server classpath) as Jetty uses logback for
logging too.

The solution is not to take out the logback.xml from WAR,
as in that case we screw users of WAR, but instead, when
we _embed_ our WAR into our container (and have logging
already present on it), we simply leave out the WAR logback
config from WAR as logback is set up already at container
level, and during boot, Nexus will set up logging with it's
own means anyway.

This change modifies the module creating the _bundle_, by simply
leaving out the logback.xml from WAR when assembling. 
WAR remains intact and same as before.
