### PR TITLE
Support filtering of repositories by user-agent

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractStagingMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractStagingMojo.java
@@ -37,7 +37,7 @@ public abstract class AbstractStagingMojo
 
     /**
      * If provided, and this repository is available for selection, use it.
-     *
+     * 
      * @parameter expression="${nexus.repositoryId}"
      */
     private String repositoryId;
@@ -46,12 +46,12 @@ public abstract class AbstractStagingMojo
 
     /**
      * Filter opened staging repositories using the provided user agent
-     *
+     * 
      * @parameter expression="${nexus.userAgent}"
      */
     private String userAgent;
 
-		public AbstractStagingMojo()
+    public AbstractStagingMojo()
     {
         super();
     }
@@ -109,14 +109,15 @@ public abstract class AbstractStagingMojo
             if ( groupId != null )
             {
                 repos = getClient().getClosedStageRepositoriesForUser( groupId, artifactId, version );
-                builder.append( String.format( " for: '%s:%s:%s', user-agent: '%s'", groupId, artifactId, version, userAgent ) );
+                builder.append( String.format( " for: '%s:%s:%s', user-agent: '%s'", groupId, artifactId, version,
+                    getUserAgent() ) );
             }
             else
             {
                 repos = getClient().getClosedStageRepositories();
-                builder.append( String.format( " for user-agent: '%s'", userAgent ) );
+                builder.append( String.format( " for user-agent: '%s'", getUserAgent() ) );
             }
-            repos = filterUserAgent(repos);
+            repos = filterUserAgent( repos );
             builder.append( ": " );
         }
         catch ( RESTLightClientException e )
@@ -158,10 +159,8 @@ public abstract class AbstractStagingMojo
             builder.append( "\n   Description: " ).append( repo.getDescription() );
         }
 
-        builder.append( String.format(
-            "\n   Details: (user: %s, ip: %s, user agent: %s)",
-            repo.getUser(), repo.getIpAddress(), repo.getUserAgent() )
-        );
+        builder.append( String.format( "\n   Details: (user: %s, ip: %s, user agent: %s)", repo.getUser(),
+            repo.getIpAddress(), repo.getUserAgent() ) );
 
         return builder;
     }
@@ -170,10 +169,8 @@ public abstract class AbstractStagingMojo
     {
         StringBuilder builder = new StringBuilder();
 
-        builder
-            .append( "Id: " ).append( profile.getProfileId() )
-            .append( "\tname: " ).append( profile.getName() )
-            .append( "\tmode: " ).append( profile.getMode() );
+        builder.append( "Id: " ).append( profile.getProfileId() ).append( "\tname: " ).append( profile.getName() ).append(
+            "\tmode: " ).append( profile.getMode() );
 
         return builder;
     }
@@ -252,10 +249,14 @@ public abstract class AbstractStagingMojo
         }
     }
 
-
     public String getUserAgent()
     {
         return userAgent;
+    }
+
+    public void setUserAgent( final String userAgent )
+    {
+        this.userAgent = userAgent;
     }
 
     public String getRepositoryId()
@@ -270,6 +271,7 @@ public abstract class AbstractStagingMojo
 
     /**
      * Create an error message from a staging rule failure's XML document.
+     * 
      * @throws NullPointerException if the given document is {@code null}
      */
     protected String ruleFailureMessage( final Document document )
@@ -288,7 +290,8 @@ public abstract class AbstractStagingMojo
             }
         }
 
-        final StringBuilder msg = new StringBuilder( "There were failed staging rules when finishing the repository.\n" );
+        final StringBuilder msg =
+            new StringBuilder( "There were failed staging rules when finishing the repository.\n" );
 
         final Element failuresNode = document.getRootElement().getChild( "failures" );
         if ( failuresNode == null )
@@ -300,8 +303,8 @@ public abstract class AbstractStagingMojo
 
         for ( Element entry : failures )
         {
-            msg.append(" * ").append( entry.getChild( "ruleName" ).getText() ).append( "\n" );
-            final Element messageList = entry.getChild("messages");
+            msg.append( " * " ).append( entry.getChild( "ruleName" ).getText() ).append( "\n" );
+            final Element messageList = entry.getChild( "messages" );
             List<Element> messages = (List<Element>) messageList.getChildren();
             for ( Element message : messages )
             {
@@ -314,13 +317,15 @@ public abstract class AbstractStagingMojo
         // staging rules return HTML markup in their results. Get rid of it.
         // Usually this should not be done with a regular expression (b/c HTML is not a regular language)
         // but this is (to date...) just stuff like '<b>$item</b>', so all will be well.
-        // FIXME we should change staging rules etc. server-side to return all the necessary information to build messages.
+        // FIXME we should change staging rules etc. server-side to return all the necessary information to build
+        // messages.
         return StringEscapeUtils.unescapeHtml( htmlString.replaceAll( "<[^>]*>", "" ) );
     }
 
     /**
-     * Log the detailed error document if it's available, return MojoExecutionException with appropriate message and cause.
-     *
+     * Log the detailed error document if it's available, return MojoExecutionException with appropriate message and
+     * cause.
+     * 
      * @throws NullPointerException if the given exception is null
      */
     protected MojoExecutionException logErrorDetailAndCreateException( final RESTLightClientException e,
@@ -346,7 +351,7 @@ public abstract class AbstractStagingMojo
                 }
                 catch ( IOException e1 )
                 {
-                    //  cannot write to StringWriter - unlikely, but we cannot do anything here anyway.
+                    // cannot write to StringWriter - unlikely, but we cannot do anything here anyway.
                 }
             }
 
@@ -356,8 +361,16 @@ public abstract class AbstractStagingMojo
         return new MojoExecutionException( msg + ": " + e.getMessage(), e );
     }
 
-    protected List<StageRepository> filterUserAgent(List<StageRepository> repos)
+    /**
+     * Returns the list of staging repositories filtered by user agent. It returns the same list of no userAgent
+     * provided.
+     * 
+     * @param repos the list of staging repositories to be filtered.
+     * @return the filtered list of staging repositories or the passed in list if no userAgent explicitly defined.
+     */
+    protected List<StageRepository> filterUserAgent( List<StageRepository> repos )
     {
+        final String userAgent = getUserAgent();
         List<StageRepository> filteredRepos;
         if ( userAgent == null )
         {
@@ -366,11 +379,11 @@ public abstract class AbstractStagingMojo
         else
         {
             filteredRepos = new ArrayList<StageRepository>();
-            for (StageRepository stageRepository : repos)
+            for ( StageRepository stageRepository : repos )
             {
-                if (userAgent.equals(stageRepository.getUserAgent()))
+                if ( userAgent.equals( stageRepository.getUserAgent() ) )
                 {
-                    filteredRepos.add(stageRepository);
+                    filteredRepos.add( stageRepository );
                 }
             }
         }

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/CloseStageRepositoryMojo.java
@@ -85,7 +85,7 @@ public class CloseStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getOpenStageRepositoriesForUser( groupId, artifactId, version );
+            repos = filterUserAgent( client.getOpenStageRepositoriesForUser( groupId, artifactId, version ) );
         }
         catch ( RESTLightClientException e )
         {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/DropStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/DropStageRepositoryMojo.java
@@ -53,7 +53,7 @@ public class DropStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositoriesForUser();
+            repos = filterUserAgent( client.getClosedStageRepositoriesForUser() );
         }
         catch ( RESTLightClientException e )
         {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
@@ -50,7 +50,15 @@ public class ListStageRepositoriesMojo
         if ( repos != null )
         {
             StringBuilder builder = new StringBuilder();
-            builder.append( String.format( "The following OPEN staging repositories were found for user-agent: '%s'", getUserAgent() ) );
+            if ( getUserAgent() == null )
+            {
+                builder.append( "The following OPEN staging repositories were found: " );
+            }
+            else
+            {
+                builder.append( String.format(
+                    "The following OPEN staging repositories were found for user-agent: '%s'", getUserAgent() ) );
+            }
 
             if ( !repos.isEmpty() )
             {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojo.java
@@ -40,7 +40,7 @@ public class ListStageRepositoriesMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getOpenStageRepositories();
+            repos = filterUserAgent( client.getOpenStageRepositories() );
         }
         catch ( RESTLightClientException e )
         {
@@ -50,7 +50,7 @@ public class ListStageRepositoriesMojo
         if ( repos != null )
         {
             StringBuilder builder = new StringBuilder();
-            builder.append( "The following OPEN staging repositories were found: " );
+            builder.append( String.format( "The following OPEN staging repositories were found for user-agent: '%s'", getUserAgent() ) );
 
             if ( !repos.isEmpty() )
             {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/PromoteToStageProfileMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/PromoteToStageProfileMojo.java
@@ -73,7 +73,7 @@ public class PromoteToStageProfileMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositories();
+            repos = filterUserAgent( client.getClosedStageRepositories() );
             Collections.sort( repos, new BeanComparator( "repositoryId" ) );
         }
         catch ( RESTLightClientException e )

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ReleaseStageRepositoryMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/ReleaseStageRepositoryMojo.java
@@ -59,7 +59,7 @@ public class ReleaseStageRepositoryMojo
         List<StageRepository> repos;
         try
         {
-            repos = client.getClosedStageRepositoriesForUser();
+            repos = filterUserAgent( client.getClosedStageRepositoriesForUser() );
         }
         catch ( RESTLightClientException e )
         {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojoTest.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/ListStageRepositoriesMojoTest.java
@@ -250,8 +250,6 @@ public class ListStageRepositoriesMojoTest
     private void usingUAFilter( final String userAgent, String... expectedRepoIds )
         throws JDOMException, IOException, RESTLightClientException, MojoExecutionException
     {
-        printTestName();
-
         ListStageRepositoriesMojo mojo = newMojo();
         mojo.setUsername( getExpectedUser() );
         mojo.setPassword( getExpectedPassword() );

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/StringBuilderLog.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/StringBuilderLog.java
@@ -1,0 +1,110 @@
+package org.sonatype.nexus.plugin;
+
+import org.apache.maven.plugin.logging.Log;
+
+public class StringBuilderLog
+    implements Log
+{
+    private final StringBuilder stringBuilder;
+
+    private Log log;
+
+    public StringBuilderLog( final Log log )
+    {
+        this.stringBuilder = new StringBuilder();
+        this.log = log;
+    }
+
+    public String getLoggedOutput()
+    {
+        return stringBuilder.toString();
+    }
+
+    public boolean isDebugEnabled()
+    {
+        return log.isDebugEnabled();
+    }
+
+    public void debug( CharSequence content )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.debug( content );
+    }
+
+    public void debug( CharSequence content, Throwable error )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.debug( content, error );
+    }
+
+    public void debug( Throwable error )
+    {
+        log.debug( error );
+    }
+
+    public boolean isInfoEnabled()
+    {
+        return log.isInfoEnabled();
+    }
+
+    public void info( CharSequence content )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.info( content );
+    }
+
+    public void info( CharSequence content, Throwable error )
+    {
+        stringBuilder.append( content ).append( "\n" );
+   log.info( content, error );
+    }
+
+    public void info( Throwable error )
+    {
+        log.info( error );
+    }
+
+    public boolean isWarnEnabled()
+    {
+        return log.isWarnEnabled();
+    }
+
+    public void warn( CharSequence content )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.warn( content );
+    }
+
+    public void warn( CharSequence content, Throwable error )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.warn( content, error );
+    }
+
+    public void warn( Throwable error )
+    {
+        log.warn( error );
+    }
+
+    public boolean isErrorEnabled()
+    {
+        return log.isErrorEnabled();
+    }
+
+    public void error( CharSequence content )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.error( content );
+    }
+
+    public void error( CharSequence content, Throwable error )
+    {
+        stringBuilder.append( content ).append( "\n" );
+        log.error( content, error );
+    }
+
+    public void error( Throwable error )
+    {
+        log.error( error );
+    }
+}

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/resources/list/profile-list.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/resources/list/profile-list.xml
@@ -15,6 +15,9 @@
       <stagingRepositoryIds>
         <string>tp1-001</string>
         <string>tp1-003</string>
+        <string>tp1-004</string>
+        <string>tp1-005</string>
+        <string>tp1-006</string>
       </stagingRepositoryIds>
       <stagedRepositoryIds/>
       <targetGroups>

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/resources/list/profile-repo-list.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/resources/list/profile-repo-list.xml
@@ -22,5 +22,27 @@
       <ipAddress>127.0.0.1</ipAddress>
       <repositoryURI>http://localhost:8082/nexus/content/repositories/tp1-003</repositoryURI>
     </stagingProfileRepository>
+    <stagingProfileRepository>
+      <profileId>112cc490b91265a1</profileId>
+      <repositoryId>tp1-005</repositoryId>
+      <repositoryName>tp1--005 (u:otheruser, a:127.0.0.1)</repositoryName>
+      <type>open</type>
+      <policy>release</policy>
+      <userId>testuser</userId>
+      <userAgent>Apache-Maven/3.0.2</userAgent>
+      <ipAddress>127.0.0.1</ipAddress>
+      <repositoryURI>http://localhost:8082/nexus/content/repositories/tp1-005</repositoryURI>
+    </stagingProfileRepository>
+    <stagingProfileRepository>
+      <profileId>112cc490b91265a1</profileId>
+      <repositoryId>tp1-006</repositoryId>
+      <repositoryName>tp1--006 (u:testuser, a:127.0.0.1)</repositoryName>
+      <type>open</type>
+      <policy>release</policy>
+      <userId>testuser</userId>
+      <userAgent>Apache-Maven/3.0.3</userAgent>
+      <ipAddress>127.0.0.1</ipAddress>
+      <repositoryURI>http://localhost:8082/nexus/content/repositories/tp1-006</repositoryURI>
+    </stagingProfileRepository>
   </data>
 </stagingRepositories>


### PR DESCRIPTION
Replaces incomplete pull request:
https://github.com/sonatype/nexus/pull/104

In some use cases I have, I may have concurrent deployment of 2 versions of the same g:a.
For instance, 1.1 and 2.0 can be staged at the same time.

To be sure that 2 different staging repositories get allocated, I use a specific user-agent for deployment that is unique to each build.

This change allows to filter all operations of the nexus-maven-plugin using a user-agent.

US: https://issues.sonatype.org/browse/NEXUS-5017
