### PR TITLE
o [NEXUS-5024] Set system properties on proxy settings change and fix problem reporting to use those.

### DIFF
--- a/nexus/nexus-app/pom.xml
+++ b/nexus/nexus-app/pom.xml
@@ -108,6 +108,12 @@
       <groupId>org.codehaus.swizzle</groupId>
       <artifactId>swizzle-jira</artifactId>
       <version>1.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xmlrpc</groupId>
+          <artifactId>xmlrpc-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Testing -->

--- a/nexus/nexus-app/pom.xml
+++ b/nexus/nexus-app/pom.xml
@@ -94,7 +94,20 @@
           <groupId>javax.inject</groupId>
           <artifactId>javax.inject</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.sonatype.sisu</groupId>
+          <artifactId>sisu-xmlrpc-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.swizzle</groupId>
+          <artifactId>swizzle-jira</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.swizzle</groupId>
+      <artifactId>swizzle-jira</artifactId>
+      <version>1.4</version>
     </dependency>
 
     <!-- Testing -->
@@ -144,7 +157,7 @@
       <groupId>org.apache.xmlrpc</groupId>
       <artifactId>xmlrpc-client</artifactId>
       <version>3.1.3</version>
-      <scope>test</scope>
+      <scope>compile</scope>
       <exclusions>
         <exclusion>
           <artifactId>junit</artifactId>

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/error/reporting/SetProxyPropertiesInspector.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/error/reporting/SetProxyPropertiesInspector.java
@@ -1,0 +1,151 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.error.reporting;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Properties;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.base.Joiner;
+import org.sonatype.nexus.configuration.application.GlobalHttpProxySettings;
+import org.sonatype.nexus.configuration.application.events.GlobalHttpProxySettingsChangedEvent;
+import org.sonatype.nexus.logging.AbstractLoggingComponent;
+import org.sonatype.nexus.proxy.events.EventInspector;
+import org.sonatype.nexus.proxy.events.NexusStartedEvent;
+import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
+import org.sonatype.nexus.proxy.repository.UsernamePasswordRemoteAuthenticationSettings;
+import org.sonatype.plexus.appevents.Event;
+
+/**
+ * This inspector sets system properties according to the Nexus proxy settings.
+ * Only username/password authentication is supported.
+ */
+@Named
+@Singleton
+public class SetProxyPropertiesInspector
+    extends AbstractLoggingComponent
+    implements EventInspector
+{
+
+    private final GlobalHttpProxySettings globalHttpProxySettings;
+
+    @Inject
+    public SetProxyPropertiesInspector( final GlobalHttpProxySettings globalHttpProxySettings )
+    {
+        this.globalHttpProxySettings = checkNotNull( globalHttpProxySettings );
+    }
+
+    @Override
+    public boolean accepts( final Event<?> evt )
+    {
+        return evt instanceof GlobalHttpProxySettingsChangedEvent
+            || evt instanceof NexusStartedEvent;
+    }
+
+    @Override
+    public void inspect( final Event<?> evt )
+    {
+        if ( !accepts( evt ) )
+        {
+            return;
+        }
+
+        if ( globalHttpProxySettings.isEnabled() )
+        {
+            String username = null;
+            String password = null;
+
+            final RemoteAuthenticationSettings authentication = globalHttpProxySettings.getProxyAuthentication();
+
+            if ( authentication != null
+                && UsernamePasswordRemoteAuthenticationSettings.class.isAssignableFrom( authentication.getClass() ) )
+            {
+                username = ( (UsernamePasswordRemoteAuthenticationSettings) authentication ).getUsername();
+                password = ( (UsernamePasswordRemoteAuthenticationSettings) authentication ).getPassword();
+            }
+
+            final String hostname = globalHttpProxySettings.getHostname();
+            final int port = globalHttpProxySettings.getPort();
+            final Set<String> nonProxyHosts = globalHttpProxySettings.getNonProxyHosts();
+
+            getLogger().debug(
+                "Configure proxy using global http proxy settings: hostname={}, port={}, username={}, nonProxyHosts={}",
+                new Object[]{ hostname, port, username, nonProxyHosts }
+            );
+
+            setProperties( true, hostname, port, username, password, nonProxyHosts );
+        }
+        else
+        {
+            getLogger().debug( "No global http proxy settings. Resetting proxy properties." );
+            setProperties( false, null, -1, null, null, null );
+        }
+    }
+
+    private void setProperties( final boolean proxiesEnabled, final String hostname, final int port,
+                                final String username, final String password,
+                                final Set<String> nonProxyHosts )
+    {
+        Properties properties = System.getProperties();
+        setProperties( proxiesEnabled, hostname, port, username, password, nonProxyHosts, properties, "http." );
+        setProperties( proxiesEnabled, hostname, port, username, password, nonProxyHosts, properties, "https." );
+    }
+
+    private void setProperties( final boolean proxiesEnabled, final String hostname, final int port,
+                                final String username, final String password, final Set<String> nonProxyHosts,
+                                final Properties properties, final String prefix )
+    {
+        if ( !proxiesEnabled || hostname == null || hostname.equals( "" ) )
+        {
+            properties.remove( prefix + "proxySet" );
+            properties.remove( prefix + "proxyHost" );
+            properties.remove( prefix + "proxyPort" );
+            properties.remove( prefix + "nonProxyHosts" );
+            properties.remove( prefix + "proxyUser" );
+            properties.remove( prefix + "proxyUserName" );
+            properties.remove( prefix + "proxyPassword" );
+        }
+        else
+        {
+            properties.put( prefix + "proxySet", "true" );
+            properties.put( prefix + "proxyHost", hostname );
+            if ( port == -1 )
+            {
+                properties.remove( prefix + "proxyPort" );
+            }
+            else
+            {
+                properties.put( prefix + "proxyPort", String.valueOf( port ) );
+            }
+            properties.put( prefix + "nonProxyHosts", Joiner.on( "|" ).join( nonProxyHosts ) );
+
+            if ( username == null || password == null || username.length() == 0 || password.length() == 0 )
+            {
+                properties.remove( prefix + "proxyUser" );
+                properties.remove( prefix + "proxyUserName" );
+                properties.remove( prefix + "proxyPassword" );
+            }
+            else
+            {
+                properties.put( prefix + "proxyUser", username );
+                properties.put( prefix + "proxyUserName", username );
+                properties.put( prefix + "proxyPassword", password );
+            }
+        }
+    }
+
+}

--- a/nexus/nexus-app/src/test/java/org/sonatype/nexus/error/reporting/SetProxyPropertiesInspectorTest.java
+++ b/nexus/nexus-app/src/test/java/org/sonatype/nexus/error/reporting/SetProxyPropertiesInspectorTest.java
@@ -1,0 +1,150 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.error.reporting;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.sonatype.nexus.configuration.application.GlobalHttpProxySettings;
+import org.sonatype.nexus.configuration.application.events.GlobalHttpProxySettingsChangedEvent;
+import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
+import org.sonatype.nexus.proxy.repository.UsernamePasswordRemoteAuthenticationSettings;
+import org.sonatype.plexus.appevents.Event;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+/**
+ * Tests for {@link SetProxyPropertiesInspector}.
+ */
+public class SetProxyPropertiesInspectorTest
+    extends TestSupport
+{
+
+    @Mock
+    private GlobalHttpProxySettings cfg;
+
+    @Mock
+    private GlobalHttpProxySettingsChangedEvent evt;
+
+    @Mock
+    private UsernamePasswordRemoteAuthenticationSettings auth;
+
+    private SetProxyPropertiesInspector underTest;
+
+    private static Properties sysProps = System.getProperties();
+
+    @Before
+    public void setup()
+    {
+        underTest = new SetProxyPropertiesInspector( cfg );
+    }
+
+    @Before
+    public void prepareSysProps()
+    {
+        System.setProperties( new Properties( sysProps ) );
+    }
+
+    @After
+    public void restoreSysProps()
+    {
+        System.setProperties( sysProps );
+    }
+
+    @Test
+    public void testNoSettings()
+    {
+        underTest.inspect( evt );
+        assertThat( System.getProperty( "http.proxyHost" ), nullValue() );
+    }
+
+    @Test
+    public void testBasicSettings()
+    {
+        when( cfg.isEnabled() ).thenReturn( true );
+        when( cfg.getHostname() ).thenReturn( "host" );
+        when( cfg.getPort() ).thenReturn( 1234 );
+
+        underTest.inspect( evt );
+
+        assertThat( System.getProperty( "http.proxyHost" ), is( "host" ) );
+        assertThat( System.getProperty( "http.proxyPort" ), is( "1234" ) );
+        assertThat( System.getProperty( "http.nonProxyHosts" ), is( "" ) );
+    }
+
+    @Test
+    public void testNoProxyHosts()
+    {
+        when( cfg.isEnabled() ).thenReturn( true );
+        when( cfg.getHostname() ).thenReturn( "host" );
+        when( cfg.getPort() ).thenReturn( 1234 );
+        when( cfg.getNonProxyHosts() ).thenReturn( Sets.newTreeSet(Sets.newHashSet( "host1", "host2" ) ) );
+
+        underTest.inspect( evt );
+
+        assertThat( System.getProperty( "http.proxyHost" ), is( "host" ) );
+        assertThat( System.getProperty( "http.proxyPort" ), is( "1234" ) );
+        assertThat( System.getProperty( "http.nonProxyHosts" ), is( "host1|host2" ) );
+    }
+
+    @Test
+    public void testAuth()
+    {
+        when( cfg.isEnabled() ).thenReturn( true );
+        when( cfg.getHostname() ).thenReturn( "host" );
+        when( cfg.getPort() ).thenReturn( 1234 );
+        when( cfg.getProxyAuthentication() ).thenReturn( auth );
+        when( auth.getUsername() ).thenReturn( "user" );
+        when( auth.getPassword() ).thenReturn( "password" );
+
+        underTest.inspect( evt );
+
+        assertThat( System.getProperty( "http.proxyHost" ), is( "host" ) );
+        assertThat( System.getProperty( "http.proxyPort" ), is( "1234" ) );
+        assertThat( System.getProperty( "http.proxyUser" ), is( "user" ) );
+        assertThat( System.getProperty( "http.proxyUserName" ), is( "user" ) );
+        assertThat( System.getProperty( "http.proxyPassword" ), is( "password" ) );
+    }
+
+    @Test
+    public void testAllHttpsProps()
+    {
+        when( cfg.isEnabled() ).thenReturn( true );
+        when( cfg.getHostname() ).thenReturn( "host" );
+        when( cfg.getPort() ).thenReturn( 1234 );
+        when( cfg.getProxyAuthentication() ).thenReturn( auth );
+        when( auth.getUsername() ).thenReturn( "user" );
+        when( auth.getPassword() ).thenReturn( "password" );
+        when( cfg.getNonProxyHosts() ).thenReturn( Sets.newTreeSet(Sets.newHashSet( "host1", "host2" ) ) );
+
+        underTest.inspect( evt );
+
+        assertThat( System.getProperty( "https.proxyHost" ), is( "host" ) );
+        assertThat( System.getProperty( "https.proxyPort" ), is( "1234" ) );
+        assertThat( System.getProperty( "https.proxyUser" ), is( "user" ) );
+        assertThat( System.getProperty( "https.proxyUserName" ), is( "user" ) );
+        assertThat( System.getProperty( "https.proxyPassword" ), is( "password" ) );
+        assertThat( System.getProperty( "https.nonProxyHosts" ), is( "host1|host2" ) );
+    }
+}


### PR DESCRIPTION
That this ever worked was a side effect of the p2 plugin. p2 runtime sets the well-known http.proxy\* system properties, which got picked up by the xmlrpc transport. A change in that transport (newest swizzle uses async-http-client, which does not use those properties by default) broke proxy settings even when p2 plugin was present.
