### PR TITLE
[NEXUS-4984] Reading digest form a zero bytes length file should not crash

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
@@ -41,6 +41,11 @@ public class MUtils
         {
             String raw = StringUtils.chomp( IOUtil.toString( inputStream, "UTF-8" ) ).trim();
 
+            if ( raw != null && StringUtils.isEmpty( raw ) )
+            {
+                return "";
+            }
+
             String digest;
             // digest string at end with separator, e.g.:
             // MD5 (pom.xml) = 68da13206e9dcce2db9ec45a9f7acd52

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
@@ -41,7 +41,7 @@ public class MUtils
         {
             String raw = StringUtils.chomp( IOUtil.toString( inputStream, "UTF-8" ) ).trim();
 
-            if ( raw != null && StringUtils.isEmpty( raw ) )
+            if ( StringUtils.isEmpty( raw ) )
             {
                 return "";
             }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/MUtilsTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/MUtilsTest.java
@@ -14,15 +14,20 @@ package org.sonatype.nexus.proxy.maven;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.Test;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
 
 public class MUtilsTest
+    extends TestSupport
 {
 
     private String[][] validDigests =
@@ -62,6 +67,20 @@ public class MUtilsTest
             assertThat( "MUtils did not accept " + test, digest, notNullValue() );
             assertThat( "MUtils did not accept " + test, digest, equalTo( expected ) );
         }
+    }
+
+    /**
+     * NEXUS-4984: Test that reading digest from a zero length file will not crash and digest is ampty string ("").
+     *
+     * @throws IOException unexpected
+     */
+    @Test
+    public void zeroLengthSha1()
+        throws IOException
+    {
+        final File sha1 = util.resolveFile( "target/test-classes/nexus-4984/zero-bytes-length.sha1" );
+        final String digest = MUtils.readDigestFromStream( new FileInputStream( sha1 ) );
+        assertThat( "Zero bites checksum file", digest, is( equalTo( "" ) ) );
     }
 
 }


### PR DESCRIPTION
but return empty string

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
