### PR TITLE
Redirect lookup requests for the 'nexus' RealmSecurityManager

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/NexusWebRealmSecurityManager.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/NexusWebRealmSecurityManager.java
@@ -29,24 +29,20 @@ import org.sonatype.security.web.WebRealmSecurityManager;
 
 /**
  * An extension of WebRealmSecurityManager used because we have a mix of POJO's and @Inject objects.
- * @deprecated use shiro-guice with @{link org.sonatype.security.web.guice.SecurityWebModule} instead.
+ * @deprecated replaced by applying the noSessionCreation filter from Shiro 1.2 to non-login services.
  */
 @Singleton
 @Typed( value = RealmSecurityManager.class )
-@Named( value = "nexus" )
+@Named( value = "stateless-and-stateful" )
 @Deprecated
 public class NexusWebRealmSecurityManager
     extends WebRealmSecurityManager
     implements org.apache.shiro.util.Initializable
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
-
     @Inject
     public NexusWebRealmSecurityManager( Map<String, RolePermissionResolver> rolePermissionResolverMap )
     {
         super( rolePermissionResolverMap );
-
-        logger.info( "@Deprecated use shiro-guice with org.sonatype.security.web.guice.SecurityWebModule instead" );
     }    
 
     public void init()

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/NexusWebModule.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/NexusWebModule.java
@@ -1,0 +1,53 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.web;
+
+import javax.servlet.ServletContext;
+
+import org.apache.shiro.mgt.RealmSecurityManager;
+import org.sonatype.security.web.guice.SecurityWebModule;
+
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+
+/**
+ * Custom {@link SecurityWebModule} for Nexus.
+ */
+public class NexusWebModule
+    extends SecurityWebModule
+{
+    public NexusWebModule( ServletContext servletContext )
+    {
+        super( servletContext, true );
+    }
+
+    @Override
+    protected void configureShiroWeb()
+    {
+        super.configureShiroWeb();
+
+        /*
+         * -----------------------------------------------------------------------------------------------------------
+         * Expose an explicit binding to replace the old stateless and stateful "nexus" RealmSecurityManager with the
+         * default RealmSecurityManager, since we now use the "noSessionCreation" filter in Shiro 1.2 on all services
+         * except the login service.
+         * -----------------------------------------------------------------------------------------------------------
+         * The NexusWebRealmSecurityManager is still available (if necessary) under the "stateless-and-stateful" hint.
+         * -----------------------------------------------------------------------------------------------------------
+         */
+
+        Named nexus = Names.named( "nexus" );
+        bind( RealmSecurityManager.class ).annotatedWith( nexus ).to( RealmSecurityManager.class );
+        expose( RealmSecurityManager.class ).annotatedWith( nexus );
+    }
+}

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
@@ -36,7 +36,6 @@ import org.sonatype.appcontext.Factory;
 import org.sonatype.appcontext.lifecycle.Stoppable;
 import org.sonatype.appcontext.source.PropertiesFileEntrySource;
 import org.sonatype.appcontext.source.StaticEntrySource;
-import org.sonatype.security.web.guice.SecurityWebModule;
 
 import com.google.inject.Module;
 
@@ -88,7 +87,7 @@ public class PlexusContainerContextListener
                         PlexusConstants.SCANNING_INDEX ).setComponentVisibility( PlexusConstants.GLOBAL_VISIBILITY );
 
                 final ArrayList<Module> modules = new ArrayList<Module>( 2 );
-                modules.add( new SecurityWebModule( sce.getServletContext(), true ) );
+                modules.add( new NexusWebModule( sce.getServletContext() ) );
                 modules.add( new AppContextModule( appContext ) );
 
                 final Module[] customModules = (Module[]) context.getAttribute( CUSTOM_MODULES );


### PR DESCRIPTION
We should redirect such requests to the default binding, since we now use the 'noSessionCreation' filter for non-login services. These requests are likely to come from old installations of Nexus that have 'nexus' as the securityManager setting in their security-configuration.xml. Note that Nexus will still work without this redirect, the old 'nexus' component is just doing unnecessary work determining the client (ie. stateless vs stateful).

Also note that the old stateless and stateful RealmSecurityManager is still available under the 'stateless-and-stateful' hint in case it is required for some reason.
