### PR TITLE
Making references canonical.

### DIFF
--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
@@ -33,6 +33,7 @@ import org.sonatype.appcontext.AppContext;
 import org.sonatype.appcontext.AppContextException;
 import org.sonatype.appcontext.AppContextRequest;
 import org.sonatype.appcontext.Factory;
+import org.sonatype.appcontext.lifecycle.Startable;
 import org.sonatype.appcontext.lifecycle.Stoppable;
 import org.sonatype.appcontext.source.PropertiesFileEntrySource;
 import org.sonatype.appcontext.source.StaticEntrySource;
@@ -117,6 +118,9 @@ public class PlexusContainerContextListener
 
                 throw new IllegalStateException( "Could not start Plexus container!", e );
             }
+
+            // fire startable
+            appContext.getLifecycleManager().invokeHandler( Startable.class );
         }
     }
 

--- a/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
+++ b/nexus/nexus-web-utils/src/main/java/org/sonatype/nexus/web/PlexusContainerContextListener.java
@@ -13,7 +13,7 @@
 package org.sonatype.nexus.web;
 
 import java.io.File;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -111,7 +111,7 @@ public class PlexusContainerContextListener
 
                 throw new IllegalStateException( "Could not start Plexus container!", e );
             }
-            catch ( MalformedURLException e )
+            catch ( IOException e )
             {
                 sce.getServletContext().log( "Could not start Plexus container!", e );
 
@@ -135,7 +135,7 @@ public class PlexusContainerContextListener
     // ==
 
     protected AppContext createContainerContext( final ServletContext context, final AppContext parent )
-        throws AppContextException
+        throws AppContextException, IOException
     {
         if ( parent == null )
         {
@@ -153,7 +153,7 @@ public class PlexusContainerContextListener
 
         if ( !StringUtils.isEmpty( baseDirProperty ) )
         {
-            basedirFile = new File( baseDirProperty ).getAbsoluteFile();
+            basedirFile = new File( baseDirProperty ).getCanonicalFile();
             // Nexus as bundle case
             context.log( "Setting Plexus basedir context variable to (pre-set in System properties): "
                 + basedirFile.getAbsolutePath() );
@@ -163,7 +163,7 @@ public class PlexusContainerContextListener
 
         if ( !StringUtils.isEmpty( warWebInfFilePath ) )
         {
-            warWebInfFile = new File( warWebInfFilePath ).getAbsoluteFile();
+            warWebInfFile = new File( warWebInfFilePath ).getCanonicalFile();
 
             if ( basedirFile == null )
             {

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -239,7 +239,7 @@
       <dependency>
         <groupId>org.sonatype.appcontext</groupId>
         <artifactId>appcontext</artifactId>
-        <version>3.1</version>
+        <version>3.2-SNAPSHOT</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Consumed JD's change but added more to it.

Changes from canonical-references branch are consumed, and added more to it.

AppContext bump is needed due to a bug in AppContext, that did not allow for a child to override a value if parent already had it.

This makes it almost 100% except the ".." bit in "nexus-work" in the dump at the boot (later, the canonical path is used, but Appcontext is unaware what those strings represent, hence, is not canonicalizing it).
