### PR TITLE
Use velocity comments

### DIFF
--- a/nexus/nexus-rest-api/src/main/resources/templates/errorPageContentHtml.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/errorPageContentHtml.vm
@@ -1,4 +1,16 @@
 #*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.

--- a/nexus/nexus-rest-api/src/main/resources/templates/errorPageContentHtml.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/errorPageContentHtml.vm
@@ -1,4 +1,4 @@
-<!--
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.
@@ -11,7 +11,7 @@
     of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
--->
+*#
 <html>
   <head>
     <title>$statusCode - $statusName</title>

--- a/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
@@ -1,4 +1,16 @@
 #*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.

--- a/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
@@ -22,11 +22,11 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/gif" />
   <link rel="search" type="application/opensearchdescription+xml" href="$serviceBase/opensearch" title="Nexus" />
 
-  <!-- Plugin pre HEAD contributions start here -->
+  ## Plugin pre HEAD contributions start here
   #foreach( $pluginPreHeadContribution in $pluginPreHeadContributions )
     $pluginPreHeadContribution
   #end
-  <!-- Plugin pre HEAD contributions ends here -->
+  ## Plugin pre HEAD contributions ends here
 
   <link rel="stylesheet" href="ext-2.3/resources/css/ext-all.css" type="text/css" media="screen" charset="utf-8">
   <link rel="stylesheet" href="ext-2.3/resources/css/xtheme-gray.css" type="text/css" media="screen" charset="utf-8">
@@ -97,11 +97,11 @@
   <script src="js/repoServer/repoServer.RepoSummaryPanel.js?$nexusVersion" type="text/javascript" charset="utf-8"></script>
   <script src="js/repoServer/repoServer.Maven2InformationPanel.js?$nexusVersion" type="text/javascript" charset="utf-8"></script>
   
-  <!-- Plugin post HEAD contributions start here -->
+  ## Plugin post HEAD contributions start here
   #foreach( $pluginPostHeadContribution in $pluginPostHeadContributions )
     $pluginPostHeadContribution
   #end
-  <!-- Plugin post HEAD contributions ends here -->
+  ## Plugin post HEAD contributions ends here
 
   <script type="text/javascript" charset="utf-8">
     Ext.onReady(Sonatype.init);
@@ -110,11 +110,11 @@
 
 <body>
 
-<!-- Plugin pre BODY contributions start here -->
+## Plugin pre BODY contributions start here
 #foreach( $pluginPreBodyContribution in $pluginPreBodyContributions )
     $pluginPreBodyContribution
 #end
-<!-- Plugin pre BODY contributions ends here -->
+## Plugin pre BODY contributions ends here
 
 <div id="header">
   <div id="branding" class="left-side">
@@ -135,13 +135,13 @@
   <br/>
 </div>
 
-<!-- Plugin post BODY contributions start here -->
+## Plugin post BODY contributions start here
 #foreach( $pluginPostBodyContribution in $pluginPostBodyContributions )
     $pluginPostBodyContribution
 #end
-<!-- Plugin post BODY contributions ends here -->
+## Plugin post BODY contributions ends here
 
-<!-- Fields required for history management -->
+## Fields required for history management
 <form id="history-form" class="x-hidden">
     <input type="hidden" id="x-history-field" />
     <iframe id="x-history-frame"></iframe>

--- a/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index-debug.vm
@@ -1,4 +1,4 @@
-<!--
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.
@@ -11,7 +11,7 @@
     of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
--->
+*#
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/nexus/nexus-rest-api/src/main/resources/templates/index.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index.vm
@@ -1,4 +1,16 @@
 #*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.

--- a/nexus/nexus-rest-api/src/main/resources/templates/index.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index.vm
@@ -22,11 +22,11 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/gif" />
   <link rel="search" type="application/opensearchdescription+xml" href="$serviceBase/opensearch" title="Nexus" />
 
-  <!-- Plugin pre HEAD contributions start here -->
+  ## Plugin pre HEAD contributions start here
   #foreach( $pluginPreHeadContribution in $pluginPreHeadContributions )
     $pluginPreHeadContribution
   #end
-  <!-- Plugin pre HEAD contributions ends here -->
+  ## Plugin pre HEAD contributions ends here
 
   <link rel="stylesheet" href="ext-2.3/resources/css/ext-all.css" type="text/css" media="screen" charset="utf-8">
   <link rel="stylesheet" href="ext-2.3/resources/css/xtheme-gray.css" type="text/css" media="screen" charset="utf-8">
@@ -34,11 +34,11 @@
 
   <script src="js/sonatype-all.js?$nexusVersion" type="text/javascript" charset="utf-8"></script>
   
-  <!-- Plugin post HEAD contributions start here -->
+  ## Plugin post HEAD contributions start here
   #foreach( $pluginPostHeadContribution in $pluginPostHeadContributions )
     $pluginPostHeadContribution
   #end
-  <!-- Plugin post HEAD contributions ends here -->
+  ## Plugin post HEAD contributions ends here
 
   <script type="text/javascript" charset="utf-8">
     Ext.onReady(Sonatype.init);
@@ -47,11 +47,11 @@
 
 <body>
 
-<!-- Plugin pre BODY contributions start here -->
+## Plugin pre BODY contributions start here
 #foreach( $pluginPreBodyContribution in $pluginPreBodyContributions )
     $pluginPreBodyContribution
 #end
-<!-- Plugin pre BODY contributions ends here -->
+## Plugin pre BODY contributions ends here
 
 <div id="header">
   <div id="branding" class="left-side">
@@ -72,13 +72,13 @@
   <br/>
 </div>
 
-<!-- Plugin post BODY contributions start here -->
+## Plugin post BODY contributions start here
 #foreach( $pluginPostBodyContribution in $pluginPostBodyContributions )
     $pluginPostBodyContribution
 #end
-<!-- Plugin post BODY contributions ends here -->
+## Plugin post BODY contributions ends here
 
-<!-- Fields required for history management -->
+## Fields required for history management
 <form id="history-form" class="x-hidden">
     <input type="hidden" id="x-history-field" />
     <iframe id="x-history-frame"></iframe>

--- a/nexus/nexus-rest-api/src/main/resources/templates/index.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index.vm
@@ -1,4 +1,4 @@
-<!--
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.
@@ -11,7 +11,7 @@
     of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
--->
+*#
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/nexus/nexus-rest-api/src/main/resources/templates/opensearch.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/opensearch.vm
@@ -1,4 +1,16 @@
 #*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.

--- a/nexus/nexus-rest-api/src/main/resources/templates/opensearch.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/opensearch.vm
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.
@@ -12,7 +11,9 @@
     of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
--->
+*#
+<?xml version="1.0" encoding="UTF-8"?>
+
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"  xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>Nexus (${nexusHost})</ShortName>
   <Description>Maven artifact search with Sonatype Nexus.</Description>

--- a/nexus/nexus-rest-api/src/main/resources/templates/repositoryContentHtml.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/repositoryContentHtml.vm
@@ -1,4 +1,16 @@
 #*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.

--- a/nexus/nexus-rest-api/src/main/resources/templates/repositoryContentHtml.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/repositoryContentHtml.vm
@@ -1,4 +1,4 @@
-<!--
+#*
 
     Sonatype Nexus (TM) Open Source Version
     Copyright (c) 2007-2012 Sonatype, Inc.
@@ -11,7 +11,7 @@
     of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
--->
+*#
 <html>
   <head>
     <title>Index of $request.resourceRef.path</title>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
               <exclude>**/sandbox/**</exclude>
             </excludes>
             <mapping>
-              <vm>XML_STYLE</vm>
+              <vm>SHARPSTAR_STYLE</vm>
               <groovy>JAVADOC_STYLE</groovy>
               <aj>JAVADOC_STYLE</aj>
             </mapping>


### PR DESCRIPTION
Uses #\* *# velocity comments to avoid rendering copyright headers.  Reduces ~785 pointless bytes from response stream.
