### PR TITLE
[NEXUS-5060] Avoid JS error for hosted repositories mirror tab selection

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.MirrorConfigPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.MirrorConfigPanel.js
@@ -273,7 +273,11 @@ Ext.extend(Sonatype.repoServer.AbstractMirrorPanel, Sonatype.ext.FormPanel, {
       },
 
       activateHandler : function(panel) {
-        this.predefinedMirrorDataStore.load();
+        // HACK: this.predefinedMirrorDataStore is only defined in ProxyMirrorEditor class, only attempt to call load() if the field exists
+        // HACK: Fix for NEXUS-5060, probably better way to fix however.
+        if (this.predefinedMirrorDataStore) {
+            this.predefinedMirrorDataStore.load();
+        }
 
         if (panel.payload.data.repoType == 'proxy')
         {


### PR DESCRIPTION
Avoids JS error, not sure if this is a proper fix to the problem however, as in not sure if there should have been a predefinedMirrorDataSource for HostedMirrorEditor or not.
