### PR TITLE
NEXUS-5049: Partial backport to Nexus 2.0.x

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
@@ -142,16 +142,32 @@ public class NexusHttpAuthenticationFilter
 
         if ( isLoginAttempt( request, response ) )
         {
-            try
+            // NEXUS-5049: Check is this an attempt with "anonymous" user?
+            // We do not allow logins with anonymous user if anon access is disabled
+            final AuthenticationToken token = createToken( request, response );
+            final String anonymousUsername = getNexusConfiguration().getAnonymousUsername();
+            final String loginUsername = token.getPrincipal().toString();
+            if ( !getNexusConfiguration().isAnonymousAccessEnabled()
+                && StringUtils.equals( anonymousUsername, loginUsername ) )
             {
-                loggedIn = executeLogin( request, response );
-            }
-            // if no username or password is supplied, an IllegalStateException (runtime)
-            // is thrown, so if anything fails in executeLogin just assume failed login
-            catch ( Exception e )
-            {
-                getLogger().error( "Unable to login", e );
+                getLogger().info(
+                    "Login attempt with username \"" + anonymousUsername
+                        + "\" (used for Anonymous Access) while Anonymous Access is disabled." );
                 loggedIn = false;
+            }
+            else
+            {
+                try
+                {
+                    loggedIn = executeLogin( request, response );
+                }
+                // if no username or password is supplied, an IllegalStateException (runtime)
+                // is thrown, so if anything fails in executeLogin just assume failed login
+                catch ( Exception e )
+                {
+                    getLogger().error( "Unable to login", e );
+                    loggedIn = false;
+                }
             }
         }
         else


### PR DESCRIPTION
This is the "C" change from the overall changes made as
part of issue.

It simply _bans_ username used for AA when AA is disabled.

Locally built, UT/IT pass.
