### PR TITLE
NEXUS-5049: Backporting to 2.0.x branch (take 2)

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/DefaultNexusConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.codehaus.plexus.component.annotations.Component;
@@ -68,6 +69,12 @@ import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
 import org.sonatype.nexus.tasks.descriptors.ScheduledTaskDescriptor;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 import org.sonatype.security.SecuritySystem;
+import org.sonatype.security.authentication.AuthenticationException;
+import org.sonatype.security.usermanagement.NoSuchUserManagerException;
+import org.sonatype.security.usermanagement.User;
+import org.sonatype.security.usermanagement.UserNotFoundException;
+import org.sonatype.security.usermanagement.UserStatus;
+import org.sonatype.security.usermanagement.xml.SecurityXmlUserManager;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
@@ -508,6 +515,137 @@ public class DefaultNexusConfiguration
         return getSecuritySystem() != null && getSecuritySystem().isAnonymousAccessEnabled();
     }
 
+    public void setAnonymousAccess( final boolean enabled, final String username, final String password )
+        throws InvalidConfigurationException
+    {
+        if ( enabled )
+        {
+            if ( StringUtils.isBlank( username ) || StringUtils.isBlank( password ) )
+            {
+                throw new InvalidConfigurationException(
+                    "Anonymous access is getting enabled without valid username and/or password!" );
+            }
+
+            final String oldUsername = getSecuritySystem().getAnonymousUsername();
+            final String oldPassword = getSecuritySystem().getAnonymousPassword();
+
+            // try to enable the "anonymous" user defined in XML realm, but ignore any problem (users might
+            // delete
+            // or already disabled it, or completely removed XML realm)
+            // this is needed as below we will try a login
+            final boolean statusChanged = setAnonymousUserEnabled( username, true );
+
+            // detect change
+            if ( !StringUtils.equals( oldUsername, username ) || !StringUtils.equals( oldPassword, password ) )
+            {
+                try
+                {
+                    // test authc with changed credentials
+                    try
+                    {
+                        // try to "log in" with supplied credentials
+                        // the anon user a) should exists
+                        securitySystem.getUser( username );
+                        // b) the pwd must work
+                        securitySystem.authenticate( new UsernamePasswordToken( username, password ) );
+                    }
+                    catch ( UserNotFoundException e )
+                    {
+                        final String msg = "User \"" + username + "'\" does not exist.";
+                        getLogger().warn(
+                            "Nexus refused to apply configuration, the supplied anonymous information is wrong: " + msg,
+                            e );
+                        throw new InvalidConfigurationException( msg, e );
+                    }
+                    catch ( AuthenticationException e )
+                    {
+                        final String msg = "The password of user \"" + username + "\" is incorrect.";
+                        getLogger().warn(
+                            "Nexus refused to apply configuration, the supplied anonymous information is wrong: " + msg,
+                            e );
+                        throw new InvalidConfigurationException( msg, e );
+                    }
+                }
+                catch ( InvalidConfigurationException e )
+                {
+                    if ( statusChanged )
+                    {
+                        setAnonymousUserEnabled( username, false );
+                    }
+                    throw e;
+                }
+
+                // set the changed username/pw
+                getSecuritySystem().setAnonymousUsername( username );
+                getSecuritySystem().setAnonymousPassword( password );
+            }
+
+            getSecuritySystem().setAnonymousAccessEnabled( true );
+        }
+        else
+        {
+            // get existing username from XML realm, if we can (if security config about to be disabled still holds this
+            // info)
+            final String existingUsername = getSecuritySystem().getAnonymousUsername();
+
+            if ( !StringUtils.isBlank( existingUsername ) )
+            {
+                // try to disable the "anonymous" user defined in XML realm, but ignore any problem (users might delete
+                // or already disabled it, or completely removed XML realm)
+                setAnonymousUserEnabled( existingUsername, false );
+            }
+
+            getSecuritySystem().setAnonymousAccessEnabled( false );
+        }
+
+    }
+
+    protected boolean setAnonymousUserEnabled( final String anonymousUsername, final boolean enabled )
+        throws InvalidConfigurationException
+    {
+        try
+        {
+            final User anonymousUser = getSecuritySystem().getUser( anonymousUsername, SecurityXmlUserManager.SOURCE );
+            final UserStatus oldStatus = anonymousUser.getStatus();
+            if ( enabled )
+            {
+                anonymousUser.setStatus( UserStatus.active );
+            }
+            else
+            {
+                anonymousUser.setStatus( UserStatus.disabled );
+            }
+            getSecuritySystem().updateUser( anonymousUser );
+            return !oldStatus.equals( anonymousUser.getStatus() );
+        }
+        catch ( UserNotFoundException e )
+        {
+            // ignore, anon user maybe manually deleted from XML realm by Nexus admin, is okay (kinda expected)
+            getLogger().debug(
+                "Anonymous user not found while trying to disable it (as part of disabling anonymous access)!", e );
+            return false;
+        }
+        catch ( NoSuchUserManagerException e )
+        {
+            // ignore, XML realm removed from configuration by Nexus admin, is okay (kinda expected)
+            getLogger().debug(
+                "XML Realm not found while trying to disable Anonymous user (as part of disabling anonymous access)!",
+                e );
+            return false;
+        }
+        catch ( InvalidConfigurationException e )
+        {
+            // do not ignore, and report, as this jeopardizes whole security functionality
+            // we did not perform any _change_ against security sofar (we just did reading from it),
+            // so it is okay to bail out at this point
+            getLogger().warn(
+                "XML Realm reported invalid configuration while trying to disable Anonymous user (as part of disabling anonymous access)!",
+                e );
+            throw e;
+        }
+    }
+
+    @Deprecated
     public void setAnonymousAccessEnabled( boolean enabled )
     {
         getSecuritySystem().setAnonymousAccessEnabled( enabled );
@@ -518,6 +656,7 @@ public class DefaultNexusConfiguration
         return getSecuritySystem().getAnonymousUsername();
     }
 
+    @Deprecated
     public void setAnonymousUsername( String val )
         throws org.sonatype.configuration.validation.InvalidConfigurationException
     {
@@ -529,6 +668,7 @@ public class DefaultNexusConfiguration
         return getSecuritySystem().getAnonymousPassword();
     }
 
+    @Deprecated
     public void setAnonymousPassword( String val )
         throws org.sonatype.configuration.validation.InvalidConfigurationException
     {

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/MutableConfiguration.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/configuration/application/MutableConfiguration.java
@@ -38,16 +38,54 @@ public interface MutableConfiguration
 
     boolean isAnonymousAccessEnabled();
 
-    void setAnonymousAccessEnabled( boolean enabled )
-        throws IOException;
+    /**
+     * Configures anonymous access in atomic way.
+     * 
+     * @param enabled {@code true} to enable and {@code false} to disable it.
+     * @param username the username of the user to be used as "anonymous" user. If {@code enabled} parameter is
+     *            {@code true}, this value must be non-null.
+     * @param password the password of the user to be used as "anonymous" user. If {@code enabled} parameter is
+     *            {@code true}, this value must be non-null.
+     * @throws InvalidConfigurationException if {@code enabled} parameter is {@code true}, but passed in username or
+     *             password parameters are empty ({@code null} or empty string).
+     */
+    void setAnonymousAccess( boolean enabled, String username, String password )
+        throws InvalidConfigurationException;
 
     String getAnonymousUsername();
 
+    String getAnonymousPassword();
+
+    /**
+     * Set anonymous access.
+     * 
+     * @param val
+     * @throws IOException
+     * @deprecated Use {@link #setAnonymousAccess(boolean, String, String)} instead.
+     */
+    @Deprecated
+    void setAnonymousAccessEnabled( boolean enabled )
+        throws IOException;
+
+    /**
+     * Set anonymous username.
+     * 
+     * @param val
+     * @throws InvalidConfigurationException
+     * @deprecated Use {@link #setAnonymousAccess(boolean, String, String)} instead.
+     */
+    @Deprecated
     void setAnonymousUsername( String val )
         throws InvalidConfigurationException;
 
-    String getAnonymousPassword();
-
+    /**
+     * Set anonymous password.
+     * 
+     * @param val
+     * @throws InvalidConfigurationException
+     * @deprecated Use {@link #setAnonymousAccess(boolean, String, String)} instead.
+     */
+    @Deprecated
     void setAnonymousPassword( String val )
         throws InvalidConfigurationException;
 
@@ -67,7 +105,7 @@ public interface MutableConfiguration
     // ----------------------------------------------------------------------------------------------------------
     // Repositories
     // ----------------------------------------------------------------------------------------------------------
-    
+
     /**
      * Sets the default (applied to all that has no exceptions set with {
      * {@link #setRepositoryMaxInstanceCount(RepositoryTypeDescriptor, int)} method) maxInstanceCount. Any positive

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityUpgradeEventInspector.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityUpgradeEventInspector.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.nexus.ApplicationStatusSource;
@@ -24,7 +25,10 @@ import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 import org.sonatype.plexus.appevents.Event;
+import org.sonatype.security.configuration.model.SecurityConfiguration;
+import org.sonatype.security.configuration.source.SecurityConfigurationSource;
 import org.sonatype.security.events.SecurityConfigurationChangedEvent;
+import org.sonatype.security.model.CUser;
 import org.sonatype.security.model.Configuration;
 import org.sonatype.security.model.source.SecurityModelConfigurationSource;
 import org.sonatype.security.model.upgrade.SecurityDataUpgrader;
@@ -38,7 +42,10 @@ public class SecurityUpgradeEventInspector
     private ApplicationStatusSource applicationStatusSource;
 
     @Requirement( hint = "file" )
-    private SecurityModelConfigurationSource configSource;
+    private SecurityModelConfigurationSource realmConfigSource;
+
+    @Requirement( hint = "file" )
+    private SecurityConfigurationSource systemConfigSource;
 
     /**
      * Reuse the previous versions upgrader, this is normally run after the module upgrade of 2.0.1, so the module is
@@ -62,26 +69,49 @@ public class SecurityUpgradeEventInspector
         try
         {
             // re/load the config from file
-            this.configSource.loadConfiguration();
+            realmConfigSource.loadConfiguration();
 
             // if Nexus was upgraded and the security version is 2.0.2 we need to update the model
             // NOTE: once the security version changes we no longer need this class
-            Configuration securityConfig = this.configSource.getConfiguration();
-            if ( this.applicationStatusSource.getSystemStatus().isConfigurationUpgraded()
-                && securityConfig.getVersion().equals( "2.0.2" ) )
+            boolean changed = false;
+            Configuration securityRealmConfig = realmConfigSource.getConfiguration();
+            if ( applicationStatusSource.getSystemStatus().isConfigurationUpgraded()
+                && securityRealmConfig.getVersion().equals( "2.0.2" ) )
             {
-
                 // first get the config and upgrade it
+                upgrader.upgrade( realmConfigSource.getConfiguration() );
 
-                this.upgrader.upgrade( configSource.getConfiguration() );
+                changed = true;
+            }
 
+            // NEXUS-5049: but this time, we need to perform this _not_ against SecuritySystem API (is still not up)
+            // but by directly "tampering" with it's configuration(s).
+            final SecurityConfiguration securitySystemConfiguration = systemConfigSource.loadConfiguration();
+            if ( !securitySystemConfiguration.isAnonymousAccessEnabled()
+                && !StringUtils.isBlank( securitySystemConfiguration.getAnonymousUsername() ) )
+            {
+                // get the probably _changed_ one again
+                securityRealmConfig = realmConfigSource.getConfiguration();
+                
+                for ( CUser user : securityRealmConfig.getUsers() )
+                {
+                    if ( StringUtils.equals( securitySystemConfiguration.getAnonymousUsername(), user.getId() ) )
+                    {
+                        user.setStatus( CUser.STATUS_DISABLED );
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+
+            if ( changed )
+            {
                 // now save
-                configSource.storeConfiguration();
+                realmConfigSource.storeConfiguration();
 
                 // because we change the configuration directly we need to tell the SecuritySystem to clear the cache,
                 // although at this point nothing should be cached, but better safe the sorry
-                this.eventMulticaster.notifyEventListeners( new SecurityConfigurationChangedEvent( null ) );
-
+                eventMulticaster.notifyEventListeners( new SecurityConfigurationChangedEvent( null ) );
             }
         }
         catch ( ConfigurationIsCorruptedException e )

--- a/nexus/nexus-core-plugins/nexus-timeline-plugin/src/test/java/org/sonatype/nexus/events/DummyNexusConfiguration.java
+++ b/nexus/nexus-core-plugins/nexus-timeline-plugin/src/test/java/org/sonatype/nexus/events/DummyNexusConfiguration.java
@@ -340,4 +340,12 @@ public class DummyNexusConfiguration
         return null;
     }
 
+    @Override
+    public void setAnonymousAccess( boolean enabled, String username, String password )
+        throws InvalidConfigurationException
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
 }

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
@@ -145,9 +145,9 @@ public class NexusHttpAuthenticationFilter
             // NEXUS-5049: Check is this an attempt with "anonymous" user?
             // We do not allow logins with anonymous user if anon access is disabled
             final AuthenticationToken token = createToken( request, response );
-            final String anonymousUsername = getSecuritySystem().getAnonymousUsername();
+            final String anonymousUsername = getNexusConfiguration().getAnonymousUsername();
             final String loginUsername = token.getPrincipal().toString();
-            if ( !getSecuritySystem().isAnonymousAccessEnabled()
+            if ( !getNexusConfiguration().isAnonymousAccessEnabled()
                 && StringUtils.equals( anonymousUsername, loginUsername ) )
             {
                 getLogger().info(
@@ -235,12 +235,9 @@ public class NexusHttpAuthenticationFilter
 
         Subject subject = getSubject( request, response );
 
-        // disable the session creation for the anon user.
-        request.setAttribute( DefaultSubjectContext.SESSION_CREATION_ENABLED, Boolean.FALSE );
-
         UsernamePasswordToken usernamePasswordToken =
-            new UsernamePasswordToken( getSecuritySystem().getAnonymousUsername(),
-                getSecuritySystem().getAnonymousPassword() );
+            new UsernamePasswordToken( getNexusConfiguration().getAnonymousUsername(),
+                getNexusConfiguration().getAnonymousPassword() );
 
         try
         {

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
@@ -142,16 +142,32 @@ public class NexusHttpAuthenticationFilter
 
         if ( isLoginAttempt( request, response ) )
         {
-            try
+            // NEXUS-5049: Check is this an attempt with "anonymous" user?
+            // We do not allow logins with anonymous user if anon access is disabled
+            final AuthenticationToken token = createToken( request, response );
+            final String anonymousUsername = getSecuritySystem().getAnonymousUsername();
+            final String loginUsername = token.getPrincipal().toString();
+            if ( !getSecuritySystem().isAnonymousAccessEnabled()
+                && StringUtils.equals( anonymousUsername, loginUsername ) )
             {
-                loggedIn = executeLogin( request, response );
-            }
-            // if no username or password is supplied, an IllegalStateException (runtime)
-            // is thrown, so if anything fails in executeLogin just assume failed login
-            catch ( Exception e )
-            {
-                getLogger().error( "Unable to login", e );
+                getLogger().info(
+                    "Login attempt with username \"" + anonymousUsername
+                        + "\" (used for Anonymous Access) while Anonymous Access is disabled." );
                 loggedIn = false;
+            }
+            else
+            {
+                try
+                {
+                    loggedIn = executeLogin( request, response );
+                }
+                // if no username or password is supplied, an IllegalStateException (runtime)
+                // is thrown, so if anything fails in executeLogin just assume failed login
+                catch ( Exception e )
+                {
+                    getLogger().error( "Unable to login", e );
+                    loggedIn = false;
+                }
             }
         }
         else
@@ -219,9 +235,12 @@ public class NexusHttpAuthenticationFilter
 
         Subject subject = getSubject( request, response );
 
+        // disable the session creation for the anon user.
+        request.setAttribute( DefaultSubjectContext.SESSION_CREATION_ENABLED, Boolean.FALSE );
+
         UsernamePasswordToken usernamePasswordToken =
-            new UsernamePasswordToken( getNexusConfiguration().getAnonymousUsername(),
-                getNexusConfiguration().getAnonymousPassword() );
+            new UsernamePasswordToken( getSecuritySystem().getAnonymousUsername(),
+                getSecuritySystem().getAnonymousPassword() );
 
         try
         {

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4257/Nexus4257CookieVerificationIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4257/Nexus4257CookieVerificationIT.java
@@ -13,8 +13,6 @@
 package org.sonatype.nexus.integrationtests.nexus4257;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.commons.httpclient.Cookie;
 import org.apache.commons.httpclient.Header;
@@ -34,7 +32,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 
 public class Nexus4257CookieVerificationIT
@@ -70,7 +71,7 @@ public class Nexus4257CookieVerificationIT
 
         // do not set the cookie, expect failure
         GetMethod failedGetMethod = new GetMethod( url );
-        assertThat( executeAndRelease( httpClient, getMethod ), equalTo( 401 ) );
+        assertThat( executeAndRelease( httpClient, failedGetMethod ), equalTo( 401 ) );
 
         // set the cookie expect a 200, If a cookie is set, and cannot be found on the server, the response will fail with a 401
         httpClient.getState().addCookie( sessionCookie );


### PR DESCRIPTION
Includes two fixes - one for a compilation issue, and another fix to use the SecurityConfigurationManager (which provides locking and caching of the configuration model) over the raw SecurityConfigurationSource.

CI (pending) https://builds.sonatype.org/job/nexus-oss-its-feature/338/
