### PR TITLE
NEXUS-5068: Errors in recurrence help text of scheduled tasks

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.resources.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.resources.js
@@ -95,15 +95,15 @@
 
     // Scheduled Services Config help text
     schedules : {
-      enabled : 'This flag determines if the service is currently active.  To disable this service for a period of time, de-select this checkbox.',
+      enabled : 'This flag determines if the task is currently active.  To disable this task for a period of time, de-select this checkbox.',
       name : 'A name for the scheduled task.',
       serviceType : 'The type of service that will be scheduled to run.',
       alertEmail : 'The email address where an email will be sent in case that task execution will fail.',
-      serviceSchedule : 'The frequency this service will run.  None - this service can only be run manually. Once - run the service once at the specified date/time. Daily - run the service every day at the specified time. Weekly - run the service every week on the specified day at the specified time. Monthly - run the service every month on the specified day(s) and time. Advanced - run the service using the supplied cron string.',
-      startDate : 'The date this service should start running.',
-      startTime : 'The time this service should start running.',
-      recurringTime : 'The time this service should start on days it will run.',
-      cronCommand : 'A cron expression that will control the running of the service.'
+      serviceSchedule : 'The frequency this task will run.  Manual - this task can only be run manually. Once - run the task once at the specified date/time. Daily - run the task every day at the specified time. Weekly - run the task every week on the specified day at the specified time. Monthly - run the task every month on the specified day(s) and time. Advanced - run the task using the supplied cron string.',
+      startDate : 'The date this task should start running.',
+      startTime : 'The time this task should start running.',
+      recurringTime : 'The time this task should start on days it will run.',
+      cronCommand : 'A cron expression that will control the running of the task.'
     },
 
     // Users help


### PR DESCRIPTION
Also changed "service" to "task" in appropriate places for help texts of the Scheduled Tasks Config panel.

Signed-off-by: Anders Hammar anders@hammar.net
