### PR TITLE
NXCM-3970: Bugfix.

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/AbstractDeployMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/AbstractDeployMojo.java
@@ -612,4 +612,14 @@ public abstract class AbstractDeployMojo
     {
         return MojoExecution.isCurrentTheLastProjectWithMojoInExecution( mavenSession, pluginGroupId, pluginArtifactId );
     }
+
+    /**
+     * Returns true if the current project is the last one being executed in this build.
+     * 
+     * @return true if last project is being built.
+     */
+    protected boolean isThisLastProject()
+    {
+        return MojoExecution.isCurrentTheLastProjectInExecution( mavenSession );
+    }
 }

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployStagedMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployStagedMojo.java
@@ -30,7 +30,7 @@ public class DeployStagedMojo
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-        if ( isThisLastProjectWithThisMojoInExecution() )
+        if ( isThisLastProject() )
         {
             failIfOffline();
 


### PR DESCRIPTION
The goal was not working when the Mojo was not configured in the
POM (the "do not modify POM" case).

In case when POM was modified, and hence, the Mojo was not registered to run, this Mojo actually never kicked in (reported by JD).
