### PR TITLE
Security config changes.

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/DefaultNexus.java
@@ -459,6 +459,8 @@ public class DefaultNexus
 
             // essential service
             securitySystem.start();
+            // "ping" it to load configuration (as it is lazy)
+            securitySystem.getAnonymousUsername();
 
             // create internals
             nexusConfiguration.createInternals();

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityUpgradeEventInspector.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityUpgradeEventInspector.java
@@ -20,6 +20,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.nexus.ApplicationStatusSource;
+import org.sonatype.nexus.SystemStatus;
 import org.sonatype.nexus.proxy.events.AbstractEventInspector;
 import org.sonatype.nexus.proxy.events.EventInspector;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
@@ -63,69 +64,72 @@ public class SecurityUpgradeEventInspector
 
     public void inspect( Event<?> evt )
     {
-        NexusStartedEvent startedEvent = (NexusStartedEvent) evt;
+        final SystemStatus systemStatus = applicationStatusSource.getSystemStatus();
 
-        try
+        if ( systemStatus.isConfigurationUpgraded() || systemStatus.isInstanceUpgraded() )
         {
-            // re/load the config from file
-            realmConfigSource.loadConfiguration();
+            final NexusStartedEvent startedEvent = (NexusStartedEvent) evt;
 
-            // if Nexus was upgraded and the security version is 2.0.2 we need to update the model
-            // NOTE: once the security version changes we no longer need this class
-            boolean changed = false;
-            Configuration securityRealmConfig = realmConfigSource.getConfiguration();
-            if ( applicationStatusSource.getSystemStatus().isConfigurationUpgraded()
-                && securityRealmConfig.getVersion().equals( "2.0.2" ) )
+            try
             {
-                // first get the config and upgrade it
-                upgrader.upgrade( realmConfigSource.getConfiguration() );
+                // re/load the config from file
+                realmConfigSource.loadConfiguration();
 
-                changed = true;
-            }
-
-            // NEXUS-5049: but this time, we need to perform this _not_ against SecuritySystem API (is still not up)
-            // but by directly "tampering" with it's configuration(s).
-            if ( !systemConfigManager.isAnonymousAccessEnabled()
-                && !StringUtils.isBlank( systemConfigManager.getAnonymousUsername() ) )
-            {
-                // get the probably _changed_ one again
-                securityRealmConfig = realmConfigSource.getConfiguration();
-                
-                for ( CUser user : securityRealmConfig.getUsers() )
+                // if Nexus was upgraded and the security version is 2.0.2 we need to update the model
+                // NOTE: once the security version changes we no longer need this class
+                boolean changed = false;
+                Configuration securityRealmConfig = realmConfigSource.getConfiguration();
+                if ( securityRealmConfig.getVersion().equals( "2.0.2" ) )
                 {
-                    if ( StringUtils.equals( systemConfigManager.getAnonymousUsername(), user.getId() ) )
+                    // first get the config and upgrade it
+                    upgrader.upgrade( realmConfigSource.getConfiguration() );
+                    changed = true;
+                }
+
+                // NEXUS-5049: but this time, we need to perform this _not_ against SecuritySystem API (is still not up)
+                // but by directly "tampering" with it's configuration(s).
+                if ( !systemConfigManager.isAnonymousAccessEnabled()
+                    && !StringUtils.isBlank( systemConfigManager.getAnonymousUsername() ) )
+                {
+                    // get the probably _changed_ one again
+                    securityRealmConfig = realmConfigSource.getConfiguration();
+
+                    for ( CUser user : securityRealmConfig.getUsers() )
                     {
-                        user.setStatus( CUser.STATUS_DISABLED );
-                        changed = true;
-                        break;
+                        if ( StringUtils.equals( systemConfigManager.getAnonymousUsername(), user.getId() ) )
+                        {
+                            user.setStatus( CUser.STATUS_DISABLED );
+                            changed = true;
+                            break;
+                        }
                     }
                 }
-            }
 
-            if ( changed )
+                if ( changed )
+                {
+                    // now save
+                    realmConfigSource.storeConfiguration();
+                    // because we change the configuration directly we need to tell the SecuritySystem to clear the
+                    // cache,
+                    // although at this point nothing should be cached, but better safe the sorry
+                    eventMulticaster.notifyEventListeners( new SecurityConfigurationChangedEvent( null ) );
+                }
+            }
+            catch ( ConfigurationIsCorruptedException e )
             {
-                // now save
-                realmConfigSource.storeConfiguration();
-
-                // because we change the configuration directly we need to tell the SecuritySystem to clear the cache,
-                // although at this point nothing should be cached, but better safe the sorry
-                eventMulticaster.notifyEventListeners( new SecurityConfigurationChangedEvent( null ) );
+                this.getLogger().error( "Failed to upgrade security.xml: " + e );
+                startedEvent.putVeto( this, e );
             }
-        }
-        catch ( ConfigurationIsCorruptedException e )
-        {
-            this.getLogger().error( "Failed to upgrade security.xml: " + e );
-            startedEvent.putVeto( this, e );
-        }
-        catch ( ConfigurationException e )
-        {
-            this.getLogger().error( "Failed to upgrade security.xml: " + e );
-            startedEvent.putVeto( this, e );
-        }
-        catch ( IOException e )
-        {
-            this.getLogger().error( "Failed to upgrade security.xml: " + e );
-            startedEvent.putVeto( this, e );
+            catch ( ConfigurationException e )
+            {
+                this.getLogger().error( "Failed to upgrade security.xml: " + e );
+                startedEvent.putVeto( this, e );
+            }
+            catch ( IOException e )
+            {
+                this.getLogger().error( "Failed to upgrade security.xml: " + e );
+                startedEvent.putVeto( this, e );
+            }
         }
     }
 }


### PR DESCRIPTION
While Nexus boots, Security was not loading configuration
as it was "lazy". Instead, the "upgrade" event inspector
was loading it eagerly, the one meant to perform upgrade.

So, a bit clean up, now security is pinged during nexus
boot (to force it config load), and upgrader inspector
made to kick in only when needed, not resulting in
flush/reload _always_, as it is not needed unless
upgrade happened.
