### PR TITLE
NXCM-3923: Extending DTO with new field.

### DIFF
--- a/nexus/nexus-rest-api-model/src/main/mdo/vos.xml
+++ b/nexus/nexus-rest-api-model/src/main/mdo/vos.xml
@@ -2296,6 +2296,13 @@
           <description>A name of the content item.</description>
         </field>
         <field>
+          <name>description</name>
+          <version>1.0.0+</version>
+          <type>String</type>
+          <required>true</required>
+          <description>A (possibly longer) description of the content item.</description>
+        </field>
+        <field>
           <name>leaf</name>
           <version>1.0.0+</version>
           <type>boolean</type>


### PR DESCRIPTION
This DTO is used to render the "index" page (when browsing slash-content), but seems misused in other parts too.

The new field make possible to "decorate" the item with extra (possibly lengthy) description, but leave to consumer of this DTO to render it in a way it wants.
