### PR TITLE
NEXUS-5043: decode the path

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
@@ -116,7 +116,7 @@ public abstract class AbstractResourceStoreContentPlexusResource
 
     protected String getResourceStorePath( Request request )
     {
-        return parsePathFromUri( request.getResourceRef().getRemainingPart() );
+        return parsePathFromUri( request.getResourceRef().getRemainingPart( true, true ) );
     }
 
     protected boolean isDescribe( Request request )

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ContentPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/ContentPlexusResource.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.nexus.rest;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.codehaus.plexus.component.annotations.Component;

--- a/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/ContentPlexusResourceTest.java
+++ b/nexus/nexus-rest-api/src/test/java/org/sonatype/nexus/rest/ContentPlexusResourceTest.java
@@ -12,23 +12,28 @@
  */
 package org.sonatype.nexus.rest;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Collections;
+
 import org.junit.Test;
 import org.restlet.Context;
 import org.restlet.data.MediaType;
 import org.restlet.data.Method;
 import org.restlet.data.Preference;
+import org.restlet.data.Reference;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
 import org.restlet.resource.Variant;
 
-import javax.print.attribute.standard.Media;
-import java.util.Collections;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Tests for {@link ContentPlexusResource}.
+ * 
  * @since 2.0
  */
 public class ContentPlexusResourceTest
@@ -51,16 +56,35 @@ public class ContentPlexusResourceTest
     private void verifyPreferredVariant( MediaType mediaTypeInRequest, MediaType expectedMediaType )
     {
         Request request = new Request();
-        if( mediaTypeInRequest != null )
+        if ( mediaTypeInRequest != null )
         {
-            request.getClientInfo().setAcceptedMediaTypes(  Collections.singletonList( new Preference<MediaType>( mediaTypeInRequest ) ) );
+            request.getClientInfo().setAcceptedMediaTypes(
+                Collections.singletonList( new Preference<MediaType>( mediaTypeInRequest ) ) );
         }
         Response response = new Response( request );
 
-        NexusRestletResource resource = new NexusRestletResource( new Context(), request, response, new ContentPlexusResource() );
+        NexusRestletResource resource =
+            new NexusRestletResource( new Context(), request, response, new ContentPlexusResource() );
 
         Variant preferredVariant = resource.getPreferredVariant();
-        assertThat( "Preferred Variant is null for media type: " + mediaTypeInRequest + " expected: " + expectedMediaType, preferredVariant, notNullValue() );
+        assertThat( "Preferred Variant is null for media type: " + mediaTypeInRequest + " expected: "
+            + expectedMediaType, preferredVariant, notNullValue() );
         assertThat( preferredVariant.getMediaType(), equalTo( expectedMediaType ) );
+    }
+
+    @Test
+    public void testNexus5043UrlEncodedCharsInPath()
+        throws UnsupportedEncodingException
+    {
+        final String tilde = "~";
+        // as made with lightweight wagon
+        final Request nonEncodedRequest = new Request( Method.GET, new Reference( tilde ) );
+        // as made with http wagon
+        final Request encodedRequest = new Request( Method.GET, new Reference( URLEncoder.encode( tilde, "UTF-8" ) ) );
+
+        final ContentPlexusResource contentPlexusResource = new ContentPlexusResource();
+
+        assertThat( contentPlexusResource.getResourceStorePath( nonEncodedRequest ), equalTo( tilde ) );
+        assertThat( contentPlexusResource.getResourceStorePath( encodedRequest ), equalTo( tilde ) );
     }
 }


### PR DESCRIPTION
This problem was never hit as "non standard" characters are rarely used
in GAV coordinates, and before, even if they were used, Maven2 by default
used lightweight wagon that does not encoded paths.

Today, Maven3 defaults to wagon-http that uses Apache HttpClient that does
encode paths if a "prohibited" character is used.
