### PR TITLE
NEXUS-1034: Velocity is shared across nexus

### DIFF
--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -47,16 +47,12 @@
       <artifactId>sisu-inject-plexus</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-velocity</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-velocity</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus.appevents</groupId>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/item/VelocityContentGenerator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/item/VelocityContentGenerator.java
@@ -19,12 +19,11 @@ import org.apache.velocity.VelocityContext;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.velocity.VelocityComponent;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
-import org.sonatype.nexus.proxy.StorageException;
 import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.sisu.velocity.Velocity;
 
 @Component( role = ContentGenerator.class, hint = VelocityContentGenerator.ID )
 public class VelocityContentGenerator
@@ -33,7 +32,7 @@ public class VelocityContentGenerator
     public static final String ID = "velocity";
 
     @Requirement
-    private VelocityComponent velocityComponent;
+    private Velocity velocityComponent;
 
     @Override
     public String getGeneratorId()
@@ -43,20 +42,16 @@ public class VelocityContentGenerator
 
     @Override
     public ContentLocator generateContent( Repository repository, String path, StorageFileItem item )
-        throws IllegalOperationException, ItemNotFoundException, StorageException
+        throws IllegalOperationException, ItemNotFoundException, LocalStorageException
     {
         InputStreamReader isr = null;
 
         try
         {
             StringWriter sw = new StringWriter();
-
             VelocityContext vctx = new VelocityContext( item.getItemContext() );
-
             isr = new InputStreamReader( item.getInputStream(), "UTF-8" );
-
             velocityComponent.getEngine().evaluate( vctx, sw, item.getRepositoryItemUid().toString(), isr );
-
             return new StringContentLocator( sw.toString() );
         }
         catch ( Exception e )

--- a/nexus/nexus-rest-api/pom.xml
+++ b/nexus/nexus-rest-api/pom.xml
@@ -81,10 +81,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusApplication.java
@@ -156,7 +156,7 @@ public class NexusApplication
         {
             return;
         }
-        
+
         // set our StatusService
         setStatusService( statusService );
 
@@ -216,8 +216,8 @@ public class NexusApplication
 
         // protecting the content service manually
         this.protectedPathManager.addProtectedResource( "/content"
-            + contentResource.getResourceProtection().getPathPattern(),
-            "noSessionCreation," + contentResource.getResourceProtection().getFilterExpression() );
+            + contentResource.getResourceProtection().getPathPattern(), "noSessionCreation,"
+            + contentResource.getResourceProtection().getFilterExpression() );
 
         // protecting service resources with "wall" permission
         this.protectedPathManager.addProtectedResource( "/service/**",
@@ -240,7 +240,7 @@ public class NexusApplication
             // don't create session unless the user logs in from the UI
             filterExpression = "noSessionCreation," + filterExpression;
         }
-        
+
         this.protectedPathManager.addProtectedResource( "/service/*" + descriptor.getPathPattern(), filterExpression );
     }
 

--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusStatusService.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/NexusStatusService.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.restlet.Context;
 import org.restlet.data.MediaType;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
@@ -43,7 +44,7 @@ public class NexusStatusService
 
     @Requirement
     private Nexus nexus;
-
+    
     public Representation getRepresentation( final Status status, final Request request, final Response response )
     {
         final HashMap<String, Object> dataModel = new HashMap<String, Object>();
@@ -61,10 +62,10 @@ public class NexusStatusService
             dataModel.put( "errorStackTrace",
                 StringEscapeUtils.escapeHtml( ExceptionUtils.getStackTrace( status.getThrowable() ) ) );
         }
-
+        
         // Load up the template, and pass in the data
         VelocityRepresentation representation =
-            new VelocityRepresentation( null, "/templates/errorPageContentHtml.vm", dataModel, MediaType.TEXT_HTML );
+            new VelocityRepresentation( Context.getCurrent(), "/templates/errorPageContentHtml.vm", dataModel, MediaType.TEXT_HTML );
 
         return representation;
     }

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -164,7 +164,7 @@
     <jetty.version>8.1.3.v20120416</jetty.version>
     <jsw.binaries.version>3.2.3.5</jsw.binaries.version>
     <maven.version>3.0.4</maven.version>
-    <micromailer.version>1.1.1</micromailer.version>
+    <micromailer.version>1.5-SNAPSHOT</micromailer.version>
     <nexus.repository.metadata.version>1.2</nexus.repository.metadata.version>
     <plexus.appbooter.version>2.1.1</plexus.appbooter.version>
     <plexus-app-events.version>1.2-SNAPSHOT</plexus-app-events.version>
@@ -175,12 +175,12 @@
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
     <sisu-jetty8.version>1.2-SNAPSHOT</sisu-jetty8.version>
+    <sisu-velocity.version>1.0-SNAPSHOT</sisu-velocity.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
-    <plexus.restlet.bridge.version>1.20</plexus.restlet.bridge.version>
+    <plexus.restlet.bridge.version>1.3-SNAPSHOT</plexus.restlet.bridge.version>
     <plexus-security.version>2.7</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.6.0</plexus-task-scheduler.version>
-    <plexus-velocity.version>1.1.7</plexus-velocity.version>
     <restlet.version>1.1.6-SONATYPE-5348-V4</restlet.version>
     <shiro.version>1.2.0</shiro.version>
     <spice-timeline.version>2.1</spice-timeline.version>
@@ -490,45 +490,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.sisu</groupId>
-        <artifactId>sisu-mailer</artifactId>
-        <version>${micromailer.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-velocity</artifactId>
-        <version>${plexus-velocity.version}</version>
-        <type>jar</type>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>velocity</groupId>
-            <artifactId>velocity</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.sonatype.spice</groupId>
         <artifactId>spice-timeline</artifactId>
         <version>${spice-timeline.version}</version>
@@ -556,6 +517,33 @@
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-charger</artifactId>
         <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-mailer</artifactId>
+        <version>${micromailer.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-velocity</artifactId>
+        <version>${sisu-velocity.version}</version>
+        <type>jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.velocity</groupId>
+        <artifactId>velocity</artifactId>
+        <version>1.5</version>
+        <type>jar</type>
       </dependency>
 
       <!-- locks -->
@@ -802,12 +790,6 @@
         <artifactId>servlet-api</artifactId>
         <version>2.5</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
-        <version>1.5</version>
-        <type>jar</type>
       </dependency>
       <dependency>
         <groupId>rome</groupId>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -177,7 +177,7 @@
     <sisu-jetty8.version>1.2-SNAPSHOT</sisu-jetty8.version>
     <sisu-velocity.version>1.0-SNAPSHOT</sisu-velocity.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
-    <plexus.restlet.bridge.version>1.3-SNAPSHOT</plexus.restlet.bridge.version>
+    <plexus.restlet.bridge.version>1.21-SNAPSHOT</plexus.restlet.bridge.version>
     <plexus-security.version>2.7</plexus-security.version>
     <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.6.0</plexus-task-scheduler.version>


### PR DESCRIPTION
This change bumps multiple Spice/Sisu components
(mailer, restlet-bridge), dumps some ancient ones (plexus-velocity)
and introduces the shiny new sisu-velocity.

While the bumped deps are all about "update" in majority (to use
new sisu-velocity), plexus-restlet-bridge holds the needed fix too,
that makes use share _one single_ instance of Velocity, instead
recreating it by each request.
