### PR TITLE
NXCM-4024: Preparations and implementation

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/pom.xml
+++ b/nexus-maven-plugins/nexus-maven-plugin/pom.xml
@@ -38,8 +38,6 @@
 
   <properties>
     <forgeSiteUrl>dav:https://sites.sonatype.com/plugins/nexus-maven-plugin</forgeSiteUrl>
-    <mavenVersion>2.2.1</mavenVersion>
-    <log4jVersion>1.2.14</log4jVersion>
   </properties>
 
   <mailingLists>
@@ -81,19 +79,6 @@
     </mailingList>
   </mailingLists>
 
-  <developers>
-    <developer>
-      <id>jdcasey</id>
-      <name>John Casey</name>
-      <email>jdcasey@sonatype.com</email>
-      <organization>Sonatype</organization>
-      <roles>
-        <role>Developer</role>
-      </roles>
-      <timezone>-5</timezone>
-    </developer>
-  </developers>
-
   <dependencies>
     <!-- NOTE: These MUST BE at the top, or we get NoSuchFieldException in the Xerces bundled with the JDK during testing... -->
     <dependency>
@@ -119,7 +104,7 @@
     <dependency>
       <groupId>org.sonatype.maven</groupId>
       <artifactId>mojo-commons</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0</version>
     </dependency>
     
     <!-- Logging -->
@@ -146,17 +131,23 @@
     <dependency>
       <groupId>org.sonatype.spice.zapper</groupId>
       <artifactId>spice-zapper</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.1.3</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-charger</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.1</version>
     </dependency>
 
     <!-- Plexus container -->
@@ -176,7 +167,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.5.15</version> <!-- FIXME: latest version is 3.0.1 -->
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -240,18 +230,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${mavenVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${maven.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -262,7 +241,8 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
@@ -288,8 +268,9 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>${mavenVersion}</version>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -298,41 +279,29 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>${mavenVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-settings</artifactId>
-      <version>${mavenVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-api</artifactId>
+      <version>1.13.1</version>
+      <scope>runtime</scope>
     </dependency>
     
     <!-- Restlight client -->
     <dependency>
       <groupId>org.sonatype.nexus.restlight</groupId>
       <artifactId>nexus-restlight-stage-client</artifactId>
+      <version>${nexus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.nexus.restlight</groupId>
       <artifactId>nexus-restlight-m2-settings-client</artifactId>
+      <version>${nexus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.nexus.restlight</groupId>
       <artifactId>nexus-restlight-client-common</artifactId>
+      <version>${nexus.version}</version>
     </dependency>
+    
     <!-- We don't want to use a "nexus only" patched HttpClient 3.1 that is not in Central -->
     <dependency>
       <groupId>commons-httpclient</groupId>
@@ -350,22 +319,37 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
+      <version>2.3</version>
+      <type>jar</type>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-core</artifactId>
+      <version>1.7.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils-bean-collections</artifactId>
+      <version>1.7.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
     </dependency>
 
+    <!-- Siesta/Jersey Usertoken -->
     <dependency>
       <groupId>org.sonatype.sisu.siesta</groupId>
       <artifactId>siesta-client</artifactId>
       <version>1.2-SNAPSHOT</version>
     </dependency>
-
     <dependency>
       <groupId>org.sonatype.sisu.siesta</groupId>
       <artifactId>siesta-xstream</artifactId>
@@ -374,12 +358,30 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>org.sonatype.sisu.litmus</groupId>
-      <artifactId>litmus-testsupport</artifactId>
-      <version>1.2</version>
+      <groupId>junit</groupId>
+      <artifactId>junit-dep</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.sisu.litmus</groupId>
+      <artifactId>litmus-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-jetty-testsuite</artifactId>

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipant.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipant.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.plugin.deploy;
 
 import java.util.List;

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipantTest.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipantTest.java
@@ -1,0 +1,326 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugin.deploy;
+
+import java.util.ArrayList;
+
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DeployLifecycleParticipantTest
+{
+    private StringBufferLogger fakeLogger;
+
+    private DeployLifecycleParticipant defaultLifecycleParticipant;
+
+    @Before
+    public void before()
+    {
+        fakeLogger = new StringBufferLogger( "fake" );
+        this.defaultLifecycleParticipant = new DeployLifecycleParticipant();
+        this.defaultLifecycleParticipant.enableLogging( fakeLogger );
+    }
+
+    // ===
+
+    protected Plugin createPlugin( String groupId, String artifactId )
+    {
+        final Plugin plugin = new Plugin();
+        plugin.setGroupId( groupId );
+        plugin.setArtifactId( artifactId );
+        Xpp3Dom configuration = new Xpp3Dom( "configuration" );
+        plugin.setConfiguration( configuration );
+        return plugin;
+    }
+
+    protected Plugin createPlugin( String groupId, String artifactId, String goal )
+    {
+        final Plugin plugin = createPlugin( groupId, artifactId );
+        if ( goal != null && goal.trim().length() > 0 )
+        {
+            final PluginExecution execution = new PluginExecution();
+            execution.setId( "default-" + goal );
+            execution.setPhase( "deploy" );
+            execution.getGoals().add( goal );
+            plugin.getExecutions().add( execution );
+        }
+        return plugin;
+    }
+
+    protected Plugin createPluginAndSetConfig( String groupId, String artifactId, String goal, String configValue )
+    {
+        final Plugin plugin = createPlugin( groupId, artifactId, goal );
+        plugin.setGroupId( groupId );
+        plugin.setArtifactId( artifactId );
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        Xpp3Dom foo = new Xpp3Dom( "aSwitch" );
+        foo.setValue( configValue );
+        configuration.addChild( foo );
+        return plugin;
+    }
+
+    protected MavenSession createSessionWithProjectsForModels( Model... models )
+    {
+        final MavenSession mockSession = Mockito.mock( MavenSession.class );
+        final ArrayList<MavenProject> projects = new ArrayList<MavenProject>();
+        for ( Model model : models )
+        {
+            final MavenProject mockProject = Mockito.mock( MavenProject.class );
+            Mockito.when( mockProject.getModel() ).thenReturn( model );
+            projects.add( mockProject );
+        }
+        Mockito.when( mockSession.getProjects() ).thenReturn( projects );
+        return mockSession;
+    }
+
+    protected Model createModel( String groupId, String artifactId )
+    {
+        final Model model = new Model();
+        model.setGroupId( groupId );
+        model.setArtifactId( artifactId );
+        model.setVersion( "1.0" );
+        model.setBuild( new Build() );
+        return model;
+    }
+
+    // ==
+
+    @Test
+    public void testSimpleOneModule()
+        throws MavenExecutionException
+    {
+        final Model model = createModel( "org.foo", "simple" );
+        // deploy defined as "usual"
+        model.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // out plugin just declared as extension, nothing more. no goals
+        model.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.THIS_GROUP_ID, DeployLifecycleParticipant.THIS_ARTIFACT_ID ) );
+
+        final MavenSession mockSession = createSessionWithProjectsForModels( model );
+
+        defaultLifecycleParticipant.afterProjectsRead( mockSession );
+
+        // aftermath: deploy plugin should executions removed, nexus-maven-plugin should have executions added
+        for ( Plugin plugin : mockSession.getProjects().get( 0 ).getModel().getBuild().getPlugins() )
+        {
+            if ( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertTrue( "No executions for plugin "
+                    + DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, plugin.getExecutions().isEmpty() );
+            }
+            else if ( DeployLifecycleParticipant.THIS_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertEquals( "One execution for plugin " + DeployLifecycleParticipant.THIS_ARTIFACT_ID, 1,
+                    plugin.getExecutions().size() );
+            }
+            else
+            {
+                // wtf? we did not add any other plugin
+                Assert.fail( "Unknown plugin (): " + plugin.getGroupId() + ":" + plugin.getArtifactId() );
+            }
+        }
+        // logging should happen
+        Assert.assertTrue( "Missing log?", fakeLogger.getLoggedStuff().contains( "Installing Nexus Staging" ) );
+        Assert.assertTrue( "Wrong count reported?", fakeLogger.getLoggedStuff().contains( "... total of 1" ) );
+    }
+
+    @Test
+    public void testSimpleOneModuleWithManuallySetPlugin()
+        throws MavenExecutionException
+    {
+        final Model model = createModel( "org.foo", "simple-but-manually-set" );
+        // deploy defined as "usual"
+        model.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // out plugin declared as extension with manually set execution
+        model.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.THIS_GROUP_ID, DeployLifecycleParticipant.THIS_ARTIFACT_ID,
+                "deploy" ) );
+
+        final MavenSession mockSession = createSessionWithProjectsForModels( model );
+
+        defaultLifecycleParticipant.afterProjectsRead( mockSession );
+
+        // aftermath: lifecycle participant should stay put, do not intervene at all!
+        for ( Plugin plugin : mockSession.getProjects().get( 0 ).getModel().getBuild().getPlugins() )
+        {
+            if ( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertEquals( "One execution for plugin "
+                    + DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, 1, plugin.getExecutions().size() );
+            }
+            else if ( DeployLifecycleParticipant.THIS_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertEquals( "One execution for plugin " + DeployLifecycleParticipant.THIS_ARTIFACT_ID, 1,
+                    plugin.getExecutions().size() );
+            }
+            else
+            {
+                // wtf? we did not add any other plugin
+                Assert.fail( "Unknown plugin (): " + plugin.getGroupId() + ":" + plugin.getArtifactId() );
+            }
+        }
+        // logging should happen
+        Assert.assertTrue( "Missing log?", fakeLogger.getLoggedStuff().contains( "Not installing Nexus Staging" ) );
+    }
+
+    @Test
+    public void testComplexReactorWithAggregators()
+        throws MavenExecutionException
+    {
+        // layout
+        // aggregator-pom:
+        // parent-A : has one config for nexus-maven-plugin (declared as extension + config)
+        // module-A1
+        // parent-B : had other config for nexus-maven-plugin (declared as extension + config)
+        // module-B1
+
+        // remember: we "simulate" running in maven, where models are already interpolated and executions added!
+        // hence, we do not fiddle with "modules" but just creating a list, as "maven would" load and sort em
+
+        // aggregator-pom, essentially empty
+        final Model aggregatorPom = createModel( "org.foo", "aggregator" );
+
+        // parent-A:
+        final Model parentA = createModel( "org.foo", "parent-a" );
+        // deploy defined as "usual"
+        parentA.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // our plugin declared as extension, no execution and A specific param
+        parentA.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-a" ) );
+
+        // module-A:
+        final Model moduleA = createModel( "org.foo", "module-a" );
+        // deploy defined as "usual"
+        moduleA.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // our plugin declared as extension, no execution and A specific param
+        moduleA.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-a" ) );
+
+        // parent-B:
+        final Model parentB = createModel( "org.foo", "parent-b" );
+        // deploy defined as "usual"
+        parentB.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // our plugin declared as extension, no execution and A specific param
+        parentB.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-b" ) );
+
+        // module-B:
+        final Model moduleB = createModel( "org.foo", "module-b" );
+        // deploy defined as "usual"
+        moduleB.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // our plugin declared as extension, no execution and A specific param
+        moduleB.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-b" ) );
+
+        final MavenSession mockSession =
+            createSessionWithProjectsForModels( aggregatorPom, parentA, moduleA, parentB, moduleB );
+
+        defaultLifecycleParticipant.afterProjectsRead( mockSession );
+
+        // aftermath: everyting should happen as "usual", but check the proper configurations!
+        for ( Plugin plugin : mockSession.getProjects().get( 0 ).getModel().getBuild().getPlugins() )
+        {
+            if ( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertTrue( "No executions for plugin "
+                    + DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, plugin.getExecutions().isEmpty() );
+            }
+            else if ( DeployLifecycleParticipant.THIS_ARTIFACT_ID.equals( plugin.getArtifactId() ) )
+            {
+                Assert.assertEquals( "One execution for plugin " + DeployLifecycleParticipant.THIS_ARTIFACT_ID, 1,
+                    plugin.getExecutions().size() );
+                if ( plugin.getArtifactId().endsWith( "-a" ) )
+                {
+                    Assert.assertTrue( "Config mismatch!",
+                        ( (Xpp3Dom) plugin.getConfiguration() ).getChild( "aSwitch" ).getValue().endsWith( "-a" ) );
+                }
+                else if ( plugin.getArtifactId().endsWith( "-b" ) )
+                {
+                    Assert.assertTrue( "Config mismatch!",
+                        ( (Xpp3Dom) plugin.getConfiguration() ).getChild( "aSwitch" ).getValue().endsWith( "-b" ) );
+                }
+                else
+                {
+                    // wtf? we did not add any other plugin
+                    Assert.fail( "Unknown plugin config: " + plugin.getGroupId() + ":" + plugin.getArtifactId() );
+                }
+            }
+            else
+            {
+                // wtf? we did not add any other plugin
+                Assert.fail( "Unknown plugin: " + plugin.getGroupId() + ":" + plugin.getArtifactId() );
+            }
+        }
+        // logging should happen
+        Assert.assertTrue( "Missing log?", fakeLogger.getLoggedStuff().contains( "Installing Nexus Staging" ) );
+        Assert.assertTrue( "Wrong count reported?", fakeLogger.getLoggedStuff().contains( "... total of 4" ) );
+    }
+
+    @Test
+    public void testABadProject()
+        throws MavenExecutionException
+    {
+        final Model model = createModel( "org.foo", "bad" );
+        model.getBuild().getPlugins().add(
+            createPlugin( DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_GROUP_ID,
+                DeployLifecycleParticipant.MAVEN_DEPLOY_PLUGIN_ARTIFACT_ID, "deploy" ) );
+        // our plugin declared MULTIPLE TIMES
+        model.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-a" ) );
+        model.getBuild().getPlugins().add(
+            createPluginAndSetConfig( DeployLifecycleParticipant.THIS_GROUP_ID,
+                DeployLifecycleParticipant.THIS_ARTIFACT_ID, null, "profile-a" ) );
+
+        final MavenSession mockSession = createSessionWithProjectsForModels( model );
+
+        try
+        {
+            defaultLifecycleParticipant.afterProjectsRead( mockSession );
+            Assert.fail( "Should choke on this!" );
+        }
+        catch ( MavenExecutionException e )
+        {
+            // good
+            Assert.assertEquals( "The build contains multiple versions of plugin "
+                + DeployLifecycleParticipant.THIS_GROUP_ID + ":" + DeployLifecycleParticipant.THIS_ARTIFACT_ID,
+                e.getMessage() );
+        }
+    }
+}

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/deploy/StringBufferLogger.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/deploy/StringBufferLogger.java
@@ -1,0 +1,68 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugin.deploy;
+
+import org.codehaus.plexus.logging.AbstractLogger;
+import org.codehaus.plexus.logging.Logger;
+
+public class StringBufferLogger
+    extends AbstractLogger
+{
+    private final StringBuilder stringBuilder = new StringBuilder();
+
+    public String getLoggedStuff()
+    {
+        return stringBuilder.toString();
+    }
+
+    public StringBufferLogger( final String name )
+    {
+        super( LEVEL_INFO, name );
+    }
+
+    @Override
+    public void warn( String message, Throwable throwable )
+    {
+        stringBuilder.append( message ).append( "\n" );
+    }
+
+    @Override
+    public void info( String message, Throwable throwable )
+    {
+        stringBuilder.append( message ).append( "\n" );
+    }
+
+    @Override
+    public void fatalError( String message, Throwable throwable )
+    {
+        stringBuilder.append( message ).append( "\n" );
+    }
+
+    @Override
+    public void error( String message, Throwable throwable )
+    {
+        stringBuilder.append( message ).append( "\n" );
+    }
+
+    @Override
+    public void debug( String message, Throwable throwable )
+    {
+        stringBuilder.append( message ).append( "\n" );
+    }
+
+    @Override
+    public Logger getChildLogger( String name )
+    {
+        return this;
+    }
+}

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/discovery/AbstractNexusDiscoveryTest.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/discovery/AbstractNexusDiscoveryTest.java
@@ -18,7 +18,12 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.Random;
 
-import org.apache.maven.project.artifact.ProjectArtifactFactory;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
@@ -41,7 +46,6 @@ import org.sonatype.plexus.components.sec.dispatcher.model.io.xpp3.SecurityConfi
 
 public class AbstractNexusDiscoveryTest
 {
-
     protected DefaultNexusDiscovery discovery;
 
     protected ClientManagerFixture testClientManager;
@@ -50,7 +54,7 @@ public class AbstractNexusDiscoveryTest
 
     protected SecDispatcher secDispatcher;
 
-    protected ProjectArtifactFactory factory;
+    private ArtifactHandlerManager artifactHandlerManager;
 
     protected ExpectPrompter prompter;
 
@@ -126,7 +130,7 @@ public class AbstractNexusDiscoveryTest
         testClientManager = new ClientManagerFixture();
 
         secDispatcher = (SecDispatcher) container.lookup( SecDispatcher.class.getName(), "maven" );
-        factory = (ProjectArtifactFactory) container.lookup( ProjectArtifactFactory.class.getName() );
+        artifactHandlerManager = container.lookup( ArtifactHandlerManager.class );
 
         prompter = new ExpectPrompter();
 
@@ -138,8 +142,15 @@ public class AbstractNexusDiscoveryTest
         throws ComponentLifecycleException
     {
         container.release( secDispatcher );
-        container.release( factory );
+        container.release( artifactHandlerManager );
         container.dispose();
     }
 
+    public Artifact createArtifactFromProject( MavenProject project )
+    {
+        ArtifactHandler handler = artifactHandlerManager.getArtifactHandler( project.getPackaging() );
+
+        return new DefaultArtifact( project.getGroupId(), project.getArtifactId(),
+            VersionRange.createFromVersion( project.getVersion() ), null, project.getPackaging(), null, handler, false );
+    }
 }

--- a/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/discovery/DefaultNexusDiscovery_DiscoverTest.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/test/java/org/sonatype/nexus/plugin/discovery/DefaultNexusDiscovery_DiscoverTest.java
@@ -349,7 +349,7 @@ public class DefaultNexusDiscovery_DiscoverTest
 
         MavenProject project = new MavenProject( model );
 
-        project.setArtifact( factory.create( project ) );
+        project.setArtifact( createArtifactFromProject( project ) );
 
         discovery.discover( settings, project, "blah", true );
     }
@@ -394,7 +394,7 @@ public class DefaultNexusDiscovery_DiscoverTest
 
         MavenProject project = new MavenProject( model );
 
-        project.setArtifact( factory.create( project ) );
+        project.setArtifact( createArtifactFromProject( project ) );
 
         discovery.discover( settings, project, "blah", true );
     }

--- a/nexus-maven-plugins/pom.xml
+++ b/nexus-maven-plugins/pom.xml
@@ -13,26 +13,179 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.sonatype.nexus</groupId>
-    <artifactId>nexus</artifactId>
-    <version>2.1-SNAPSHOT</version>
-    <relativePath>../nexus</relativePath>
+    <groupId>org.sonatype.forge</groupId>
+    <artifactId>forge-parent</artifactId>
+    <version>11</version>
+    <relativePath />
   </parent>
 
+  <groupId>org.sonatype.nexus</groupId>
   <artifactId>nexus-maven-plugins-parent</artifactId>
+  <version>2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <name>Nexus : Maven Plugins : Parent</name>
   <description>Sonatype Nexus Maven Plugins Parent</description>
 
   <properties>
-    <!-- override maven version managed by nexus - we want to build against 2.2.1 -->
-    <maven.version>2.2.1</maven.version>
+    <sisu-inject.version>2.3.0</sisu-inject.version>
+    <slf4j.version>1.6.4</slf4j.version>
+    <logback.version>1.0.5</logback.version>
+    <maven.version>3.0.4</maven.version>
+    <nexus.version>${project.version}</nexus.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <!-- Inject Bean container -->
+      <!-- Spice hosts SISU/Plexus-legacy libraries, and they expect they are embedded into apps having these provided -->
+      <!-- That makes: shouldn't SISU be actually "provided" instead? -->
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-inject-bean</artifactId>
+        <version>${sisu-inject.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-guice</artifactId>
+        <version>3.1.1</version>
+        <classifier>no_aop</classifier>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>10.0.1</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+        <scope>compile</scope>
+      </dependency>
+
+      <!-- Plexus support (the version should be tied to SISU used ones!) -->
+      <!-- Plexus needs to be compiled against, is specific (unlike JSR330-enabled SISU is) -->
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-inject-plexus</artifactId>
+        <version>${sisu-inject.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>1.5.5</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-classworlds</artifactId>
+        <version>2.4</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.0</version>
+        <scope>compile</scope>
+      </dependency>
+
+      <!-- SLF4J Logging -->
+      <!-- Only those needed during compile and runtime phases -->
+      <!-- Spice is a library collection, so only the "simple" backend for testing and nothing more -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <type>jar</type>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <type>jar</type>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+        <type>jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+        <type>jar</type>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+        <type>jar</type>
+        <scope>runtime</scope>
+      </dependency>
+
+      <!-- Standard test -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit-dep</artifactId>
+        <version>4.8.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3.RC2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3.RC2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu.litmus</groupId>
+        <artifactId>litmus-testsupport</artifactId>
+        <version>1.2</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>mockito-all</artifactId>
+            <groupId>org.mockito</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.9.0</version>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
 
   <!-- pluginManagement and reporting taken from org.sonatype.plugins:plugins-parent:6 -->
   <build>
@@ -52,6 +205,25 @@
       <plugins>
         <plugin>
           <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-metadata</artifactId>
+          <version>1.5.5</version>
+          <executions>
+            <execution>
+              <id>process-classes</id>
+              <goals>
+                <goal>generate-metadata</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>process-test-classes</id>
+              <goals>
+                <goal>generate-test-metadata</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-maven-plugin</artifactId>
           <version>1.3.8</version>
           <executions>
@@ -61,6 +233,14 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -139,6 +319,112 @@
 
   <profiles>
     <profile>
+      <id>m2e</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- "new" M2E like 1.0 "IndIgor" -->
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-component-metadata</artifactId>
+                        <versionRange>[1.5.5,)</versionRange>
+                        <goals>
+                          <goal>merge-metadata</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>modello-plugin-upgrade</artifactId>
+                        <versionRange>[1.0,)</versionRange>
+                        <goals>
+                          <goal>upgrade</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <versionRange>[2.0,)</versionRange>
+                        <goals>
+                          <goal>unpack</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.sonatype.nexus.plugins</groupId>
+                        <artifactId>nexus-test-environment-maven-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
+                        <!-- says "all", disregard version -->
+                        <goals>
+                          <goal>setup-environment</goal>
+                          <goal>package</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <versionRange>[1.0,)</versionRange>
+                        <goals>
+                          <goal>enforce</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <versionRange>[1.6,)</versionRange>
+                        <goals>
+                          <goal>install</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
       <id>modules</id>
       <activation>
         <property>
@@ -151,7 +437,6 @@
     </profile>
     <profile>
       <id>site</id>
-
       <build>
         <plugins>
           <plugin>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -516,7 +516,7 @@
       <dependency>
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-charger</artifactId>
-        <version>1.0</version>
+        <version>1.1</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.sisu</groupId>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -2015,49 +2015,6 @@
     </profile>
 
     <profile>
-      <id>staging-test</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-maven-plugin</artifactId>
-            <version>2.1-SNAPSHOT</version>
-            <executions>
-              <execution>
-                <id>default-deploy</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <serverId>local-nexus</serverId>
-              <nexusUrl>http://localhost:8081/nexus/</nexusUrl>
-              <!-- Deploy URL overrides all, so not Staging happens at all -->
-              <!--deployUrl>http://localhost:8081/nexus/content/repositories/snapshots/</deployUrl-->
-              <!-- Profile Id override profile matching -->
-              <!--stagingProfileId></stagingProfileId-->
-              <!-- By having none of those above, we actually use Staging V2 in "auto" mode, profile will be matched server side -->
-              <!-- Tags -->
-              <tags>
-                <localUsername>${env.USER}</localUsername>
-                <javaVersion>${java.version}</javaVersion>
-              </tags>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>skipTests</id>
       <activation>
         <property>


### PR DESCRIPTION
These commits are:
- detaching nexus-maven-plugins parent from Nexus parent (it made no sense)
- cleaning up POM of nexus-maven-plugin
- bumping the already present maven-core dependency from 2.2.1 to 3.0.4, it went with slight changes in UT, no code changes in plugin. This step was needed to make possible to implement Lifecycle Participant.
- Verified plugin still works with mvn2.2.1 and mvn3.0.4
- Implemented lifecycle participant, now all you need is to add it to POM and have extensions=true
