### PR TITLE
NEXUS-5033: Exposing Aether as shared from MI Indexer plugin.

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/pom.xml
@@ -58,6 +58,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Aether is needed and will be published too (see applifecycle config) -->
+    <!-- since sadly Maven Indexer exposes it's classes over it's public API -->
+    <!-- All this because of the presence of Version in ArtifactInfo -->
+    <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-util</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- ZipFacade -->
     <dependency>
@@ -72,6 +85,11 @@
     </dependency>
 
     <!-- Is in core -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
@@ -146,10 +164,13 @@
             <configuration>
               <sharedDependencies>
                 <sharedDependencies>org.sonatype.nexus.plugins:nexus-indexer-lucene-plugin-model</sharedDependencies>
+                <sharedDependencies>org.apache.maven.indexer:indexer-artifact</sharedDependencies>
                 <sharedDependencies>org.apache.maven.indexer:indexer-core</sharedDependencies>
                 <sharedDependencies>org.apache.lucene:lucene-core</sharedDependencies>
                 <sharedDependencies>org.apache.lucene:lucene-highlighter</sharedDependencies>
                 <sharedDependencies>org.apache.lucene:lucene-memory</sharedDependencies>
+                <sharedDependencies>org.sonatype.aether:aether-api</sharedDependencies>
+                <sharedDependencies>org.sonatype.aether:aether-util</sharedDependencies>
               </sharedDependencies>
             </configuration>
           </execution>


### PR DESCRIPTION
As Maven Indexer public API contains Aether classes, they have to
be shared too, to make it able to completely cover development
against it's APIs and avoid problems like Linking Errors or
other ugly circumventions.

Changes happened:
- exposed aether-api and aether-util as "shared" from MI Plugin
- exposed maven-indexer-artifact to publish complete MI API
- plexus-utils made "provided", as it was included in plugin but
  artifact is present in core. Did not hurt (core wins), but was bloating
  the plugin size.
