### PR TITLE
Bumped SISU Velocity version

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -175,7 +175,7 @@
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
     <sisu-jetty8.version>1.2</sisu-jetty8.version>
-    <sisu-velocity.version>1.0</sisu-velocity.version>
+    <sisu-velocity.version>1.1-SNAPSHOT</sisu-velocity.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.21</plexus.restlet.bridge.version>
     <plexus-security.version>2.7</plexus-security.version>


### PR DESCRIPTION
SISU Velocity made a real "drop in" replacement for Plexus Velocity.

Relevant change is here:
https://github.com/sonatype/sisu-velocity/commit/8f903a3ce66c1413876f39bc08f78776e759e0b6
