### PR TITLE
o [NXCM-4203] Add refresh tool to sec/users detail tabs

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/extensions/Sonatype.panels.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/extensions/Sonatype.panels.js
@@ -26,7 +26,19 @@ Sonatype.panels.AutoTabPanel = function(config) {
     frame : false,
     border : false,
     activeTab : 0,
-    hideMode : 'offsets'
+    hideMode : 'offsets',
+    tools : [{
+      id : 'refresh',
+      qtip : 'Refresh data',
+      handler : function(evt, toolEl, panel) {
+        if ( panel.tabPanel ) {
+          var active = panel.tabPanel.getActiveTab();
+        } else {
+          var active = panel.getComponent(0);
+        }
+        active && active.refreshContent && active.refreshContent();
+      }
+    }]
   };
   Ext.apply(this, config, defaultConfig);
   Sonatype.panels.AutoTabPanel.superclass.constructor.call(this, {
@@ -87,7 +99,17 @@ Ext.extend(Sonatype.panels.AutoTabPanel, Ext.Panel, {
               border : false,
               layoutOnTabChange : true,
               items : [first],
-              hideMode : 'offsets'
+              hideMode : 'offsets',
+              listeners : {
+                tabchange : function(panel, tab) {
+                  if ( tab.refreshContent ) {
+                    this.tools['refresh'].show();
+                  } else {
+                    this.tools['refresh'].hide();
+                  }
+                },
+                scope : this
+              }
             });
 
         Sonatype.panels.AutoTabPanel.superclass.add.call(this, this.tabPanel);

--- a/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.UserEditPanel.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/repoServer/repoServer.UserEditPanel.js
@@ -1115,7 +1115,7 @@ Sonatype.Events.addListener('userViewInit', function(cardPanel, rec) {
       var config = {
         payload : rec,
         tabTitle : 'Config'
-      };
+      }
       cardPanel.add(rec.data.source == 'default' ? new Sonatype.repoServer.DefaultUserEditor(config) : new Sonatype.repoServer.UserMappingEditor(config));
     });
 


### PR DESCRIPTION
The tool is only visible if the active tab has a `refreshContent`
method, the same as for the user profile refresh bits.
