### PR TITLE
NXCM-4165: throw transient exception subtype when the error is temporary

### DIFF
--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/usermanagement/LdapUserManager.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/usermanagement/LdapUserManager.java
@@ -28,6 +28,8 @@ import org.sonatype.security.usermanagement.DefaultUser;
 import org.sonatype.security.usermanagement.RoleIdentifier;
 import org.sonatype.security.usermanagement.User;
 import org.sonatype.security.usermanagement.UserManager;
+import org.sonatype.security.usermanagement.UserNotFoundException;
+import org.sonatype.security.usermanagement.UserNotFoundTransientException;
 import org.sonatype.security.usermanagement.UserSearchCriteria;
 import org.sonatype.security.usermanagement.UserStatus;
 
@@ -46,6 +48,7 @@ public class LdapUserManager
     private Logger logger;
 
     public User getUser( String userId )
+        throws UserNotFoundException
     {
         if ( this.isEnabled() )
         {
@@ -60,9 +63,10 @@ public class LdapUserManager
             catch ( LdapDAOException e )
             {
                 this.logger.debug( "User: " + userId + " not found, cause: " + e.getMessage(), e );
+                throw new UserNotFoundTransientException( userId, e.getMessage(), e );
             }
         }
-        return null;
+        throw new UserNotFoundException( userId );
     }
 
 

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerNotConfiguredTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/usermanagement/LdapUserManagerNotConfiguredTest.java
@@ -20,6 +20,7 @@ import org.codehaus.plexus.util.IOUtil;
 import org.junit.Test;
 import org.sonatype.security.ldap.AbstractLdapTest;
 import org.sonatype.security.usermanagement.UserManager;
+import org.sonatype.security.usermanagement.UserNotFoundTransientException;
 
 public class LdapUserManagerNotConfiguredTest
     extends AbstractLdapTest
@@ -48,6 +49,15 @@ public class LdapUserManagerNotConfiguredTest
         throws Exception
     {
         UserManager userManager = this.lookup( UserManager.class, "LDAP" );
-        Assert.assertNull( userManager.getUser( "cstamas" ) );
+        try
+        {
+            userManager.getUser( "cstamas" );
+
+            Assert.fail( "Expected UserNotFoundTransientException" );
+        }
+        catch ( UserNotFoundTransientException e )
+        {
+            // expect transient error due to misconfiguration
+        }
     }
 }


### PR DESCRIPTION
This helps clients distinguish between a truly non-existent user and a temporary server issue.

CI votes +1: https://builds.sonatype.org/job/nexus-oss-its-feature/359/
