### PR TITLE
NXCM-4165: provide task to purge orphaned API keys

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/AbstractNexusTask.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/scheduling/AbstractNexusTask.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.scheduling.events.NexusTaskEventStoppedCanceled;
 import org.sonatype.nexus.scheduling.events.NexusTaskEventStoppedDone;
 import org.sonatype.nexus.scheduling.events.NexusTaskEventStoppedFailed;
 import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
+import org.sonatype.plexus.appevents.Event;
 import org.sonatype.scheduling.AbstractSchedulerTask;
 import org.sonatype.scheduling.ScheduledTask;
 import org.sonatype.scheduling.TaskInterruptedException;
@@ -57,6 +58,11 @@ public abstract class AbstractNexusTask<T>
         }
     }
 
+    protected void notifyEventListeners( final Event<?> event )
+    {
+        applicationEventMulticaster.notifyEventListeners( event );
+    }
+    
     // TODO: finish this thread!
     public RepositoryTaskActivityDescriptor getTaskActivityDescriptor()
     {

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/tasks/PurgeApiKeysTask.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/tasks/PurgeApiKeysTask.java
@@ -1,0 +1,49 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.tasks;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.sonatype.nexus.scheduling.AbstractNexusTask;
+import org.sonatype.nexus.tasks.descriptors.PurgeApiKeysTaskDescriptor;
+import org.sonatype.scheduling.SchedulerTask;
+import org.sonatype.security.events.UserPrincipalsExpiredEvent;
+
+@Component( role = SchedulerTask.class, hint = PurgeApiKeysTaskDescriptor.ID, instantiationStrategy = "per-lookup" )
+public class PurgeApiKeysTask
+    extends AbstractNexusTask<Void>
+{
+    /**
+     * System event action: purge API keys
+     */
+    public static final String ACTION = "PURGE_API_KEYS";
+
+    @Override
+    protected Void doRun()
+    {
+        // triggers the expiry of any orphaned cached user principals
+        notifyEventListeners( new UserPrincipalsExpiredEvent( null ) );
+        return null;
+    }
+
+    @Override
+    protected String getAction()
+    {
+        return ACTION;
+    }
+
+    @Override
+    protected String getMessage()
+    {
+        return "Purging Orphaned API Keys.";
+    }
+}

--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/tasks/descriptors/PurgeApiKeysTaskDescriptor.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/tasks/descriptors/PurgeApiKeysTaskDescriptor.java
@@ -1,0 +1,32 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.tasks.descriptors;
+
+import org.codehaus.plexus.component.annotations.Component;
+
+@Component( role = ScheduledTaskDescriptor.class, hint = "PurgeApiKeys", description = "Purge Orphaned API Keys" )
+public class PurgeApiKeysTaskDescriptor
+    extends AbstractScheduledTaskDescriptor
+{
+    public static final String ID = "PurgeApiKeysTask";
+
+    public String getId()
+    {
+        return ID;
+    }
+
+    public String getName()
+    {
+        return "Purge Orphaned API Keys";
+    }
+}


### PR DESCRIPTION
This task purges orphaned API Keys linked to external authentication systems where users could be deleted at any time without notifying Nexus. It triggers the new UserPrincipalsExpiredEvent (see security system) which will be listened for by components that cache user principals. These components will then check the cached principals against their original source and remove any whose user has been deleted.

Note that the UserPrincipalsExpiredEvent is also triggered by the security system when removing internal users (in that scenario the event has a specific userId and source).
