### PR TITLE
NXCM-4381: Deprecate oldie nexus-maven-plugin

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
@@ -46,7 +46,7 @@ public abstract class AbstractNexusMojo
 
     /**
      * NOT REQUIRED IN ALL CASES. If this is available, the current project will be used in the Nexus discovery process.
-     *
+     * 
      * @parameter default-value="${project}"
      * @readonly
      */
@@ -56,7 +56,7 @@ public abstract class AbstractNexusMojo
      * If false, the Nexus discovery process will prompt the user to accept any Nexus connection information it finds
      * before using it. <br/>
      * <b>NOTE:</b> Batch-mode executions will override this parameter with an effective value of 'true'.
-     *
+     * 
      * @parameter expression="${nexus.automaticDiscovery}" default-value="false"
      */
     private boolean automatic;
@@ -64,7 +64,7 @@ public abstract class AbstractNexusMojo
     /**
      * The base URL for a Nexus Professional instance that includes the nexus-staging-plugin. If missing, the mojo will
      * prompt for this value.
-     *
+     * 
      * @parameter expression="${nexus.url}"
      */
     private String nexusUrl;
@@ -76,21 +76,21 @@ public abstract class AbstractNexusMojo
 
     /**
      * The username that should be used to log into Nexus.
-     *
+     * 
      * @parameter expression="${nexus.username}" default-value="${user.name}"
      */
     private String username;
 
     /**
      * If provided, lookup username/password from this server entry in the current Maven settings.
-     *
+     * 
      * @parameter expression="${nexus.serverAuthId}"
      */
     private String serverAuthId;
 
     /**
      * The password that should be used to log into Nexus. If missing, the mojo will prompt for this value.
-     *
+     * 
      * @parameter expression="${nexus.password}"
      */
     private String password;
@@ -113,6 +113,17 @@ public abstract class AbstractNexusMojo
     private NexusInstanceDiscoverer discoverer;
 
     // ==
+
+    protected AbstractNexusMojo()
+    {
+        getLog().warn( "" );
+        getLog().warn( "DEPRECATION WARNING" );
+        getLog().warn( "===================" );
+        getLog().warn( "This whole plugin has been deprecated, and is replaced with set of new Maven Plugins." );
+        getLog().warn( "Please update your build, and stop using this plugin altogether,");
+        getLog().warn( "as this plugin is about to be dropped in near future." );
+        getLog().warn( "" );
+    }
 
     public final void execute()
         throws MojoExecutionException
@@ -139,8 +150,7 @@ public abstract class AbstractNexusMojo
             ch.qos.logback.classic.Logger logger = null;
             if ( factory instanceof LoggerContext )
             {
-                logger =
-                    ( (LoggerContext) factory ).getLogger( ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME );
+                logger = ( (LoggerContext) factory ).getLogger( ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME );
             }
 
             if ( logger != null )
@@ -324,7 +334,7 @@ public abstract class AbstractNexusMojo
                     if ( info == null )
                     {
                         throw new MojoExecutionException( "Cannot determine login credentials for Nexus instance: "
-                                                              + getNexusUrl() );
+                            + getNexusUrl() );
                     }
 
                     setUsername( info.getUser() );
@@ -334,7 +344,7 @@ public abstract class AbstractNexusMojo
                 catch ( NexusDiscoveryException e )
                 {
                     throw new MojoExecutionException( "Failed to determine authentication information for Nexus at: "
-                                                          + getNexusUrl(), e );
+                        + getNexusUrl(), e );
                 }
                 catch ( SecDispatcherException e )
                 {
@@ -389,7 +399,7 @@ public abstract class AbstractNexusMojo
 
     /**
      * Configures the proxy information based on the configured settings and Nexus URL.
-     *
+     * 
      * @since 1.9.2
      */
     protected void setAndValidateProxy()

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
@@ -119,7 +119,7 @@ public abstract class AbstractNexusMojo
         getLog().warn( "" );
         getLog().warn( "DEPRECATION WARNING" );
         getLog().warn( "===================" );
-        getLog().warn( "This whole plugin has been deprecated, and is replaced with set of new Maven Plugins." );
+        getLog().warn( "This whole plugin has been deprecated in favor of a new set of Maven Plugins." );
         getLog().warn( "Please update your build, and stop using this plugin altogether,");
         getLog().warn( "as this plugin is about to be dropped in near future." );
         getLog().warn( "" );

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipant.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployLifecycleParticipant.java
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * 
  * @author cstamas
  */
-@Component( role = AbstractMavenLifecycleParticipant.class, hint = "org.sonatype.nexus.plugin.deploy.DeployLifecycleParticipant" )
+// @Component( role = AbstractMavenLifecycleParticipant.class, hint = "org.sonatype.nexus.plugin.deploy.DeployLifecycleParticipant" )
 public class DeployLifecycleParticipant
     extends AbstractMavenLifecycleParticipant
     implements LogEnabled

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployMojo.java
@@ -30,8 +30,8 @@ import org.apache.maven.project.artifact.ProjectArtifactMetadata;
  * 
  * @author cstamas
  * @since 2.1
- * @goal deploy
- * @phase deploy
+ * goal deploy
+ * phase deploy
  */
 public class DeployMojo
     extends AbstractDeployMojo

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployStagedMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/DeployStagedMojo.java
@@ -21,7 +21,7 @@ import org.apache.maven.plugin.MojoFailureException;
  * 
  * @author cstamas
  * @since 2.1
- * @goal deploy-staged
+ * goal deploy-staged
  */
 public class DeployStagedMojo
     extends AbstractDeployMojo

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/ZapperImpl.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/ZapperImpl.java
@@ -33,7 +33,7 @@ import org.sonatype.spice.zapper.fs.DirectoryIOSource;
  * @author cstamas
  * @since 2.1
  */
-@Component( role = Zapper.class )
+//@Component( role = Zapper.class )
 public class ZapperImpl
     implements Zapper
 {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/BuildPromotionMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/BuildPromotionMojo.java
@@ -1,0 +1,42 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugin.staging;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.beanutils.BeanComparator;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.components.interactivity.PrompterException;
+import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.plugin.util.PromptUtil;
+import org.sonatype.nexus.restlight.common.RESTLightClientException;
+import org.sonatype.nexus.restlight.stage.StageClient;
+import org.sonatype.nexus.restlight.stage.StageProfile;
+import org.sonatype.nexus.restlight.stage.StageRepository;
+
+/**
+ * Promotes a set of closed Nexus staging repositories into a Nexus Build Promotion Profile.
+ *
+ * @goal staging-build-promotion
+ * @requiresProject false
+ * @aggregator
+ */
+// TODO: Remove aggregator annotation once we have a better solution, but we should only run this once per build.
+public class BuildPromotionMojo
+    extends PromoteToStageProfileMojo
+{
+}

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/ListStageRepositoriesMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/ListStageRepositoriesMojo.java
@@ -23,7 +23,7 @@ import org.sonatype.nexus.restlight.stage.StageRepository;
  * Lists all Nexus staging repositories available for a user. This goal lists both, "opened" and "closed" staging
  * repositories.
  * 
- * @goal staging-repositories-list
+ * @goal staging-list
  * @requiresProject false
  * @aggregator
  */


### PR DESCRIPTION
The old nexus-maven-plugin (part of Nexus Core build) is about to be dropped in near future, hence, today's release have to show a big fat deprecation warning.

Things done:
- as Staging V2 work has been done here, related classes had just removed Mojo/Plexus annos (leaving classes intact) to not have newly introduced Mojos and components in the plugin
- undone the Staging related goal naming cleanup (when V2 work started, goal names were cleaned up, as there was a duplication but also some poorly named goals)
- added big fat deprecation message.

Things left to be done:
- move out settings related stuff into `nexus-settings-maven-plugin` or similar in https://github.com/sonatype/nexus-maven-plugins
