### PR TITLE
NEXUS-5109: fix

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -248,6 +248,18 @@ public abstract class AbstractRepository
     }
 
     // ==
+    
+    public void dispose()
+    {
+        super.dispose();
+        // remove "my" elements from NFC, as this is a shared one
+        // if following steps done with reusing same repo ID (add-fill NFC-remove-add new with same ID)
+        // then the new repo "inherits" the entries of old repo, all because of shared caches that
+        // was a mistake, btw
+        getNotFoundCache().purge();
+    }
+    
+    // ==
 
     public RepositoryTaskFilter getRepositoryTaskFilter()
     {


### PR DESCRIPTION
Simply, using Plexus Dispose lifecycle, to purge the EHCache (this
under the hud actually removes only this repositorie's entries since
shared caches implemented).
