### PR TITLE
Deprecate staging and deploy goals

### DIFF
--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/AbstractNexusMojo.java
@@ -114,17 +114,6 @@ public abstract class AbstractNexusMojo
 
     // ==
 
-    protected AbstractNexusMojo()
-    {
-        getLog().warn( "" );
-        getLog().warn( "DEPRECATION WARNING" );
-        getLog().warn( "===================" );
-        getLog().warn( "This whole plugin has been deprecated in favor of a new set of Maven Plugins." );
-        getLog().warn( "Please update your build, and stop using this plugin altogether,");
-        getLog().warn( "as this plugin is about to be dropped in near future." );
-        getLog().warn( "" );
-    }
-
     public final void execute()
         throws MojoExecutionException
     {

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/AbstractDeployMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/deploy/AbstractDeployMojo.java
@@ -215,6 +215,13 @@ public abstract class AbstractDeployMojo
      */
     private boolean keepOnFailure;
 
+    protected AbstractDeployMojo() {
+        getLog().warn( "DEPRECATION WARNING" );
+        getLog().warn( "===================" );
+        getLog().warn( "Deployment goals have been deprecated." );
+        getLog().warn( "Please use org.sonatype.plugins:nexus-staging-maven-plugin instead." );
+    }
+
     protected MavenSession getMavenSession()
     {
         return mavenSession;

--- a/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/AbstractStagingMojo.java
+++ b/nexus-maven-plugins/nexus-maven-plugin/src/main/java/org/sonatype/nexus/plugin/staging/AbstractStagingMojo.java
@@ -52,7 +52,10 @@ public abstract class AbstractStagingMojo
 
     public AbstractStagingMojo()
     {
-        super();
+        getLog().warn( "DEPRECATION WARNING" );
+        getLog().warn( "===================" );
+        getLog().warn( "Staging goals have been deprecated." );
+        getLog().warn( "Please use org.sonatype.plugins:nexus-staging-maven-plugin instead." );
     }
 
     protected final synchronized StageClient connect()


### PR DESCRIPTION
Add deprecation warning for staging and deployment goals, leaving settings download non-deprecated (will move/deprecate this in 2.2).
