### PR TITLE
NXCM-4391: not a fix, a "best effort" instead

### DIFF
--- a/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/conf/jetty.xml
@@ -23,6 +23,9 @@
 <!--                                                              -->
 <!-- ============================================================ -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Set name="threadPool">
+        <New class="org.sonatype.sisu.jetty.thread.InstrumentedQueuedThreadPool"/>
+    </Set>
     <Call name="addConnector">
         <Arg>
             <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -174,7 +174,7 @@
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
-    <sisu-jetty8.version>1.3-SNAPSHOT</sisu-jetty8.version>
+    <sisu-jetty8.version>1.3</sisu-jetty8.version>
     <sisu-velocity.version>1.1-SNAPSHOT</sisu-velocity.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.21</plexus.restlet.bridge.version>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -174,7 +174,7 @@
     <plexus-interpolation.version>1.14</plexus-interpolation.version>
     <plexus-jetty6.version>1.7</plexus-jetty6.version>
     <plexus-jetty7.version>1.2.1</plexus-jetty7.version>
-    <sisu-jetty8.version>1.2</sisu-jetty8.version>
+    <sisu-jetty8.version>1.3-SNAPSHOT</sisu-jetty8.version>
     <sisu-velocity.version>1.1-SNAPSHOT</sisu-velocity.version>
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.21</plexus.restlet.bridge.version>


### PR DESCRIPTION
This change is NOT fixing the cause of OOM at all, but improves
Jetty's capability to at least warn in logs about it.

The original reason for issue NXCM-4391 was another bug (OOM in P2),
but Jetty's handling of Errors (OOM is Error) made us realize that there was
NO any notification about death and removal of the thread. The
OOM went totally unnoticed (original investigation started due to
unreleased locks, there were held by "no one", as the thread holding was
dead actually).

Again, this change only enables "some" notification about extreme
conditions (like thread dying coz of some Error, as Exceptions
ARE logged by Jetty). Only "some", as in OOM state strange things
happens, but still, this is "best effort" to say "hey dude, you'd
better reboot your JVM" at least.

P2 issues (the actual cause of OOM that lead us to this recognition)
are handled in P2 plugin (finally blocks cleanup and memory optimization).
