### PR TITLE
o [NXCM-4426] Set index.html to be rendered with IE8 engine

### DIFF
--- a/nexus/nexus-rest-api/src/main/resources/templates/index.vm
+++ b/nexus/nexus-rest-api/src/main/resources/templates/index.vm
@@ -31,6 +31,8 @@
   <title>$appName</title>
   
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=8"/>
+
   <link rel="shortcut icon" href="favicon.ico" type="image/gif" />
   <link rel="search" type="application/opensearchdescription+xml" href="$serviceBase/opensearch" title="Nexus" />
 


### PR DESCRIPTION
Ext JS 2.3 is not supported for IE9 anyway.
