### PR TITLE
NXCM-4479 and related: Nexus Client error handling.

### DIFF
--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusClientException.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusClientException.java
@@ -10,30 +10,29 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.client.rest;
+package org.sonatype.nexus.client.core;
 
 /**
- * Runtime exception to be thrown by Subsystems, when some error is reported by Nexus. This exception here is solely for
- * purpose of not proliferating possible runtime exceptions of underlying implementation.
+ * Generic runtime exception to be thrown by Subsystems, when some error is reported by Nexus. This exception here is
+ * solely for purpose of not proliferating possible runtime exceptions of underlying implementation.
  * 
  * @author cstamas
  */
-public class NexusServerException
+@SuppressWarnings( "serial" )
+public abstract class NexusClientException
     extends RuntimeException
 {
-    private static final long serialVersionUID = -7495018997359291568L;
-
-    public NexusServerException( String message )
+    public NexusClientException( String message )
     {
         super( message );
     }
 
-    public NexusServerException( String message, Throwable cause )
+    public NexusClientException( String message, Throwable cause )
     {
         super( message, cause );
     }
 
-    public NexusServerException( Throwable cause )
+    public NexusClientException( Throwable cause )
     {
         super( cause );
     }

--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusErrorMessageException.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusErrorMessageException.java
@@ -18,46 +18,30 @@ import java.util.Map;
 
 /**
  * Thrown when Nexus responds with an Client Error status code and (optionally) with an error message.
- *
+ * 
  * @author cstamas
  */
 @SuppressWarnings( "serial" )
-public class NexusErrorException
-    extends RuntimeException
+public class NexusErrorMessageException
+    extends NexusUnexpectedResponseException
 {
-
-    private final int statusCode;
-
-    private final String statusMessage;
-
     private final Map<String, String> errors;
 
-    public NexusErrorException( final int statusCode, final String statusMessage, final Map<String, String> errors )
+    public NexusErrorMessageException( final int statusCode, final String statusMessage,
+                                       final Map<String, String> errors )
     {
-        super( statusMessage );
-        this.statusCode = statusCode;
-        this.statusMessage = statusMessage;
+        super( statusCode, statusMessage );
         this.errors = initErrors( errors );
     }
 
     protected Map<String, String> initErrors( final Map<String, String> errors )
     {
         final Map<String, String> result = new LinkedHashMap<String, String>();
-        if ( errors != null )
+        if ( errors != null && !errors.isEmpty() )
         {
             result.putAll( errors );
         }
         return result;
-    }
-
-    public int getStatusCode()
-    {
-        return statusCode;
-    }
-
-    public String getStatusMessage()
-    {
-        return statusMessage;
     }
 
     public Map<String, String> getErrors()

--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusUnexpectedResponseException.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/NexusUnexpectedResponseException.java
@@ -1,0 +1,49 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.client.core;
+
+import org.sonatype.nexus.client.internal.util.Check;
+
+/**
+ * Generic runtime exception to be thrown by Subsystems, when some unexpected error is reported by Nexus. This exception
+ * here is solely for purpose of not proliferating possible runtime exceptions of underlying implementation. Best to use
+ * some subclass of this exception, but this is the last resort (ie. resource does not send proper response, just HTTP
+ * code and reason phrase).
+ * 
+ * @author cstamas
+ */
+@SuppressWarnings( "serial" )
+public class NexusUnexpectedResponseException
+    extends NexusClientException
+{
+    private final int statusCode;
+
+    private final String statusMessage;
+
+    public NexusUnexpectedResponseException( final int statusCode, final String statusMessage )
+    {
+        super( statusMessage );
+        this.statusCode = Check.argument( statusCode > 0, statusCode, "statusCode not positive" );
+        this.statusMessage = Check.notBlank( statusMessage, "statusMessage" );
+    }
+
+    public int getStatusCode()
+    {
+        return statusCode;
+    }
+
+    public String getStatusMessage()
+    {
+        return statusMessage;
+    }
+}

--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/spi/SubsystemSupport.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/spi/SubsystemSupport.java
@@ -25,7 +25,7 @@ public abstract class SubsystemSupport<NC extends NexusClient>
         this.nexusClient = Check.notNull( nexusClient, NexusClient.class );
     }
 
-    protected NC getNexusClient()
+    public NC getNexusClient()
     {
         return nexusClient;
     }

--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/rest/jersey/JerseyNexusClient.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/rest/jersey/JerseyNexusClient.java
@@ -14,13 +14,17 @@ package org.sonatype.nexus.client.rest.jersey;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.sonatype.nexus.client.core.Condition;
+import org.sonatype.nexus.client.core.NexusErrorMessageException;
 import org.sonatype.nexus.client.core.NexusStatus;
 import org.sonatype.nexus.client.core.spi.SubsystemFactory;
+import org.sonatype.nexus.client.internal.msg.ErrorMessage;
+import org.sonatype.nexus.client.internal.msg.ErrorResponse;
 import org.sonatype.nexus.client.internal.rest.AbstractXStreamNexusClient;
 import org.sonatype.nexus.client.internal.util.Check;
 import org.sonatype.nexus.client.rest.ConnectionInfo;
@@ -176,4 +180,24 @@ public class JerseyNexusClient
         }
     }
 
+    // ==
+
+    /**
+     * Internal method to be used by subsystem implementations to convert Jersey specific exception to
+     * {@link NexusErrorMessageException}.
+     * 
+     * @param e
+     * @return
+     */
+    public NexusErrorMessageException convertErrorResponse( final int statusCode, final String reasonPhrase,
+                                                            final ErrorResponse errorResponse )
+    {
+        final Map<String, String> errors = new LinkedHashMap<String, String>();
+        for ( ErrorMessage errorMessage : errorResponse.getErrors() )
+        {
+            errors.put( errorMessage.getId(), errorMessage.getMsg() );
+        }
+
+        return new NexusErrorMessageException( statusCode, reasonPhrase, errors );
+    }
 }


### PR DESCRIPTION
This is client mostly. Added a bit of exception hierarchy to cover all the weird error cases that Nexus emits. Indexer client adjusted.

In general, no Jersey exception should "leak" from clients, only exceptions coning out from client should be subclasses of NexusClientException. But, if it does (ClientHandlerException for example), it means the you better give up
