### PR TITLE
NXCM-4504: Ability to use Verifier with Maven2 and Maven3

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractMavenNexusIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractMavenNexusIT.java
@@ -14,18 +14,14 @@ package org.sonatype.nexus.integrationtests;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
-import org.codehaus.plexus.util.FileUtils;
-import org.sonatype.nexus.test.utils.TestProperties;
-import org.testng.Assert;
 
 public class AbstractMavenNexusIT
     extends AbstractNexusIntegrationTest
 {
+    private static final MavenVerifierHelper mavenVerifierHelper = new MavenVerifierHelper();
 
     public AbstractMavenNexusIT()
     {
@@ -37,6 +33,17 @@ public class AbstractMavenNexusIT
         super( testRepositoryId );
     }
 
+    protected MavenVerifierHelper getMavenVerifierHelper()
+    {
+        return getStaticMavenVerifierHelper();
+    }
+
+    private static MavenVerifierHelper getStaticMavenVerifierHelper()
+    {
+        return mavenVerifierHelper;
+    }
+
+    @Deprecated
     public Verifier createVerifier( File mavenProject )
         throws VerificationException, IOException
     {
@@ -52,6 +59,7 @@ public class AbstractMavenNexusIT
      * @throws VerificationException
      * @throws IOException
      */
+    @Deprecated
     public Verifier createVerifier( File mavenProject, File settings )
         throws VerificationException, IOException
     {
@@ -62,29 +70,16 @@ public class AbstractMavenNexusIT
         return createMavenVerifier( mavenProject, settings, getTestId() );
     }
 
+    @Deprecated
     public static Verifier createMavenVerifier( File mavenProject, File settings, String testId )
         throws VerificationException, IOException
     {
-        System.setProperty( "maven.home", TestProperties.getString( "maven.instance" ) );
-
-        Verifier verifier = new Verifier( mavenProject.getAbsolutePath(), false );
-
         String logname = "logs/maven-execution/" + testId + "/" + mavenProject.getName() + ".log";
-        new File( verifier.getBasedir(), logname ).getParentFile().mkdirs();
-        verifier.setLogFileName( logname );
-
-        File mavenRepository = new File( TestProperties.getString( "maven.local.repo" ) );
-        verifier.setLocalRepo( mavenRepository.getAbsolutePath() );
-        cleanRepository( mavenRepository, testId );
-
-        verifier.resetStreams();
-
-        List<String> options = new ArrayList<String>();
-        options.add( "-X" );
-        options.add( "-Dmaven.repo.local=" + mavenRepository.getAbsolutePath() );
-        options.add( "-s " + settings.getAbsolutePath() );
-        verifier.setCliOptions( options );
-        return verifier;
+        final File logFile = new File( mavenProject, logname );
+        logFile.getParentFile().mkdirs();
+        final MavenDeployment mavenDeployment = MavenDeployment.defaultDeployment( logFile, settings, mavenProject );
+        cleanRepository( mavenDeployment.getLocalRepositoryFile(), testId );
+        return getStaticMavenVerifierHelper().createMavenVerifier( mavenDeployment );
     }
 
     /**
@@ -93,10 +88,10 @@ public class AbstractMavenNexusIT
      * @param verifier
      * @throws IOException
      */
+    @Deprecated
     public void cleanRepository( File mavenRepo )
         throws IOException
     {
-
         cleanRepository( mavenRepo, getTestId() );
     }
 
@@ -106,13 +101,11 @@ public class AbstractMavenNexusIT
      * @param verifier
      * @throws IOException
      */
+    @Deprecated
     public static void cleanRepository( File mavenRepo, String testId )
         throws IOException
     {
-
-        File testGroupIdFolder = new File( mavenRepo, testId );
-        FileUtils.deleteDirectory( testGroupIdFolder );
-
+        getStaticMavenVerifierHelper().cleanRepository( mavenRepo, testId );
     }
 
     /**
@@ -120,11 +113,10 @@ public class AbstractMavenNexusIT
      * 
      * @throws IOException
      */
+    @Deprecated
     protected void failTest( Verifier verifier )
         throws IOException
     {
-        File logFile = new File( verifier.getBasedir(), verifier.getLogFileName() );
-        String log = FileUtils.fileRead( logFile );
-        Assert.fail( log );
+        getStaticMavenVerifierHelper().failTest( verifier );
     }
 }

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/MavenDeployment.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/MavenDeployment.java
@@ -1,0 +1,115 @@
+package org.sonatype.nexus.integrationtests;
+
+import java.io.File;
+
+import org.sonatype.nexus.test.utils.TestProperties;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * A simple descriptor object describing the maven runtime and maven project you want to run Verifier against.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class MavenDeployment
+{
+    private final File mavenHomeFile;
+
+    private final File localRepositoryFile;
+
+    private final File logFile;
+
+    private final File settingsXmlFile;
+
+    private final File mavenProjectFile;
+
+    /**
+     * Creates a new instance of {@link MavenDeployment}.
+     * 
+     * @param testId the test ID, must not be {@code null}.
+     * @param mavenHomeFile the maven home, must not be {@code null}.
+     * @param localRepositoryFile the local repository, must not be {@code null}.
+     * @param logFile the log file of Verifier, must not be {@code null}.
+     * @param settingsXmlFile settings.xml file, must not be {@code null}.
+     * @param mavenProjectFile directory containing the project (pom.xml), must not be {@code null}.
+     */
+    public MavenDeployment( final File mavenHomeFile, final File localRepositoryFile, final File logFile,
+                            final File settingsXmlFile, final File mavenProjectFile )
+    {
+        this.mavenHomeFile = Preconditions.checkNotNull( mavenHomeFile );
+        this.localRepositoryFile = Preconditions.checkNotNull( localRepositoryFile );
+        this.logFile = Preconditions.checkNotNull( logFile );
+        this.settingsXmlFile = Preconditions.checkNotNull( settingsXmlFile );
+        this.mavenProjectFile = Preconditions.checkNotNull( mavenProjectFile );
+    }
+
+    /**
+     * Returns the Maven Home file (directory) where maven deployment is (unpacked binary distro of Maven).
+     * 
+     * @return
+     */
+    public File getMavenHomeFile()
+    {
+        return mavenHomeFile;
+    }
+
+    /**
+     * Returns the file (directory) where you want to Maven put it's local repository.
+     * 
+     * @return
+     */
+    public File getLocalRepositoryFile()
+    {
+        return localRepositoryFile;
+    }
+
+    /**
+     * Returns the logfile where you want to have Maven console output saved.
+     * 
+     * @return
+     */
+    public File getLogFile()
+    {
+        return logFile;
+    }
+
+    /**
+     * Returns the settings.xml file you want to use with Maven.
+     * 
+     * @return
+     */
+    public File getSettingsXmlFile()
+    {
+        return settingsXmlFile;
+    }
+
+    /**
+     * Retutns the baseDir of maven project you want to run Maven against.
+     * 
+     * @return
+     */
+    public File getMavenProjectFile()
+    {
+        return mavenProjectFile;
+    }
+
+    // ==
+
+    /**
+     * Returns the default deployment descriptor used throughout ITs. This is just a "handy" quick method that does
+     * things in same was as they happened before (pre 2.1).
+     * 
+     * @param testId
+     * @param logFile
+     * @param settingsXmlFile
+     * @param mavenProject
+     * @return
+     */
+    public static MavenDeployment defaultDeployment( final File logFile, final File settingsXmlFile,
+                                                     final File mavenProject )
+    {
+        return new MavenDeployment( new File( TestProperties.getString( "maven.instance" ) ), new File(
+            TestProperties.getString( "maven.local.repo" ) ), logFile, settingsXmlFile, mavenProject );
+    }
+}

--- a/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/MavenVerifierHelper.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/MavenVerifierHelper.java
@@ -1,0 +1,74 @@
+package org.sonatype.nexus.integrationtests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.codehaus.plexus.util.FileUtils;
+import org.testng.Assert;
+
+/**
+ * Helper class to create Maven Verifier.
+ * 
+ * @author cstamas
+ * @since 2.1
+ */
+public class MavenVerifierHelper
+{
+    /**
+     * Creates a Verifier against passed in {@link MavenDeployment}.
+     * 
+     * @param mavenDeployment
+     * @return
+     * @throws VerificationException
+     * @throws IOException
+     */
+    public Verifier createMavenVerifier( final MavenDeployment mavenDeployment )
+        throws VerificationException, IOException
+    {
+        System.setProperty( "maven.home", mavenDeployment.getMavenHomeFile().getAbsolutePath() );
+        Verifier verifier = new Verifier( mavenDeployment.getMavenProjectFile().getAbsolutePath(), false );
+        verifier.setLogFileName( mavenDeployment.getLogFile().getAbsolutePath() );
+        verifier.setLocalRepo( mavenDeployment.getLocalRepositoryFile().getAbsolutePath() );
+        verifier.resetStreams();
+        List<String> options = new ArrayList<String>();
+        options.add( "-X" );
+        options.add( "-Dmaven.repo.local=" + mavenDeployment.getLocalRepositoryFile().getAbsolutePath() );
+        options.add( "-s " + mavenDeployment.getSettingsXmlFile().getAbsolutePath() );
+        verifier.setCliOptions( options );
+        return verifier;
+    }
+
+    /**
+     * Removes artifacts from passed in local repository that has groupId of testId.
+     * 
+     * @param mavenRepo
+     * @param testId
+     * @throws IOException
+     */
+    protected void cleanRepository( final File mavenRepo, final String testId )
+        throws IOException
+    {
+        final File testGroupIdFolder = new File( mavenRepo, testId );
+        FileUtils.deleteDirectory( testGroupIdFolder );
+    }
+
+    /**
+     * Creates a "failure" message spitting out the Verifier execution log. This methods does not check any assertion,
+     * but should be rather call when you already checked and assertion, you know it is failed, and all you want to fail
+     * the test with some extra logging.
+     * 
+     * @param verifier
+     * @throws IOException
+     */
+    public void failTest( final Verifier verifier )
+        throws IOException
+    {
+        final File logFile = new File( verifier.getBasedir(), verifier.getLogFileName() );
+        final String log = FileUtils.fileRead( logFile );
+        Assert.fail( log );
+    }
+}


### PR DESCRIPTION
Verifier does not limit maven versions to be used, but how we integrated
Verifier with ITs did.

So, this is "liberation" of Maven Verifier, while keeping old behavior for old
ITs.

The module using different version of Maven (other than ITs default 2.2.1) would still need to get it and unpack it. This change is only about _the possibility_ to use other version, but does not force you to do so.

---

Note: while commits in this pull are marked as NXCM-4455, there was a confusion on my side. Read comment in [NXCM-4504](https://issues.sonatype.org/browse/NXCM-4504) why this happened.
