### PR TITLE
o [NEXUS-5193] Fix LDAP URL check

### DIFF
--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/realms/DefaultLdapContextFactory.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/main/java/org/sonatype/security/ldap/realms/DefaultLdapContextFactory.java
@@ -221,7 +221,6 @@ public class DefaultLdapContextFactory implements LdapContextFactory {
                                                    final boolean systemContext )
     {
         Preconditions.checkNotNull( url, "No ldap URL specified (ldap://<hostname>:<port>)" );
-        Preconditions.checkArgument( url.startsWith( "ldap://" ), "LDAP URL is not valid (must be 'ldap://<hostname>:<port>')" );
 
         if ( username != null && principalSuffix != null )
         {

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/realms/DefaultLdapContextFactoryTest.java
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/ldap-common/src/test/java/org/sonatype/security/ldap/realms/DefaultLdapContextFactoryTest.java
@@ -44,11 +44,12 @@ public class DefaultLdapContextFactoryTest
                     is( "ldap://localhost:439" ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
-    public void testInvalidLdapUrl()
+    @Test
+    public void testValidLdapsUrl()
     {
-        underTest.setUrl( "localhost:439" );
-        underTest.getSetupEnvironment( null, null, false );
+        underTest.setUrl( "ldaps://localhost:439" );
+        assertThat( underTest.getSetupEnvironment( null, null, false ).get( Context.PROVIDER_URL ),
+                    is( "ldaps://localhost:439" ) );
     }
 
     @Test( expected = NullPointerException.class )


### PR DESCRIPTION
Precondition was introduced when creating tests to the ldap context factory, but did not allow for ldaps:// URLs.
