### PR TITLE
NEXUS-4692: Use HttpClient4x as default transport

### DIFF
--- a/nexus/nexus-configuration-model/pom.xml
+++ b/nexus/nexus-configuration-model/pom.xml
@@ -73,7 +73,7 @@
             </goals>
             <configuration>
               <useJava5>true</useJava5>
-              <version>2.0.0</version>
+              <version>2.0.1</version>
               <packagedVersions>
                 <packagedVersion>1.4.0</packagedVersion>
                 <packagedVersion>1.4.1</packagedVersion>
@@ -83,6 +83,7 @@
                 <packagedVersion>1.4.5</packagedVersion>
                 <packagedVersion>1.4.6</packagedVersion>
                 <packagedVersion>1.10.0</packagedVersion>
+                <packagedVersion>2.0.0</packagedVersion>
               </packagedVersions>
               <models>
                 <model>src/main/mdo/nexus.xml</model>
@@ -138,7 +139,7 @@
             </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <version>2.0.0</version>
+              <version>2.0.1</version>
               <packagedVersions>
                 <packagedVersion>1.4.0</packagedVersion>
                 <packagedVersion>1.4.1</packagedVersion>
@@ -148,6 +149,7 @@
                 <packagedVersion>1.4.5</packagedVersion>
                 <packagedVersion>1.4.6</packagedVersion>
                 <packagedVersion>1.10.0</packagedVersion>
+                <packagedVersion>2.0.0</packagedVersion>
               </packagedVersions>
               <models>
                 <model>src/main/mdo/nexus.xml</model>

--- a/nexus/nexus-configuration-model/pom.xml
+++ b/nexus/nexus-configuration-model/pom.xml
@@ -73,7 +73,7 @@
             </goals>
             <configuration>
               <useJava5>true</useJava5>
-              <version>2.0.1</version>
+              <version>2.2.0</version>
               <packagedVersions>
                 <packagedVersion>1.4.0</packagedVersion>
                 <packagedVersion>1.4.1</packagedVersion>
@@ -139,7 +139,7 @@
             </goals>
             <phase>generate-sources</phase>
             <configuration>
-              <version>2.0.1</version>
+              <version>2.2.0</version>
               <packagedVersions>
                 <packagedVersion>1.4.0</packagedVersion>
                 <packagedVersion>1.4.1</packagedVersion>

--- a/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
@@ -48,7 +48,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -76,7 +75,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -104,7 +102,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
@@ -14,7 +14,7 @@
 
 -->
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <nexusVersion>${project.version}</nexusVersion>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>

--- a/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/filtered-resources/META-INF/nexus/default-oss-nexus.xml
@@ -14,7 +14,7 @@
 
 -->
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <nexusVersion>${project.version}</nexusVersion>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>

--- a/nexus/nexus-configuration-model/src/main/mdo/nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/mdo/nexus.xml
@@ -253,9 +253,9 @@
 ]]></code>
         </codeSegment>
         <codeSegment>
-          <version>2.0.1</version>
+          <version>2.2.0</version>
           <code><![CDATA[
-    public static final String MODEL_VERSION = "2.0.1";
+    public static final String MODEL_VERSION = "2.2.0";
 ]]></code>
         </codeSegment>
       </codeSegments>

--- a/nexus/nexus-configuration-model/src/main/mdo/nexus.xml
+++ b/nexus/nexus-configuration-model/src/main/mdo/nexus.xml
@@ -252,6 +252,12 @@
     public static final String MODEL_VERSION = "2.0.0";
 ]]></code>
         </codeSegment>
+        <codeSegment>
+          <version>2.0.1</version>
+          <code><![CDATA[
+    public static final String MODEL_VERSION = "2.0.1";
+]]></code>
+        </codeSegment>
       </codeSegments>
     </class>
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade1100to200.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade1100to200.java
@@ -94,8 +94,8 @@ public class Upgrade1100to200
 
         org.sonatype.nexus.configuration.model.v2_0_0.Configuration newc = versionConverter.upgradeConfiguration( oldc );
 
-        newc.setVersion( org.sonatype.nexus.configuration.model.Configuration.MODEL_VERSION );
-        message.setModelVersion( org.sonatype.nexus.configuration.model.Configuration.MODEL_VERSION );
+        newc.setVersion( org.sonatype.nexus.configuration.model.v2_0_0.Configuration.MODEL_VERSION );
+        message.setModelVersion( org.sonatype.nexus.configuration.model.v2_0_0.Configuration.MODEL_VERSION );
         message.setConfiguration( newc );
     }
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to201.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to201.java
@@ -23,10 +23,10 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
 import org.sonatype.configuration.upgrade.SingleVersionUpgrader;
 import org.sonatype.configuration.upgrade.UpgradeMessage;
-import org.sonatype.nexus.configuration.model.v2_0_1.upgrade.BasicVersionUpgrade;
+import org.sonatype.nexus.configuration.model.v2_2_0.upgrade.BasicVersionUpgrade;
 
 /**
- * Upgrades configuration model from version 2.0.0 to 2.0.1.
+ * Upgrades configuration model from version 2.0.0 to 2.2.0.
  * 
  * @author cstamas
  */

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to201.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to201.java
@@ -77,22 +77,22 @@ public class Upgrade200to201
         BasicVersionUpgrade versionConverter = new BasicVersionUpgrade()
         {
             @Override
-            public org.sonatype.nexus.configuration.model.CLocalStorage upgradeCLocalStorage( org.sonatype.nexus.configuration.model.v2_0_0.CLocalStorage cLocalStorage )
+            public org.sonatype.nexus.configuration.model.CRemoteStorage upgradeCRemoteStorage( org.sonatype.nexus.configuration.model.v2_0_0.CRemoteStorage cRemoteStorage )
             {
-                final org.sonatype.nexus.configuration.model.CLocalStorage localStorage =
-                    super.upgradeCLocalStorage( cLocalStorage );
-                if ( localStorage != null )
+                final org.sonatype.nexus.configuration.model.CRemoteStorage remoteStorage =
+                    super.upgradeCRemoteStorage( cRemoteStorage );
+                if ( remoteStorage != null )
                 {
-                    if ( StringUtils.equals( localStorage.getProvider(), "apacheHttpClient3x" ) )
+                    if ( StringUtils.equals( remoteStorage.getProvider(), "apacheHttpClient3x" ) )
                     {
                         // nullify the provider IF: it is set, and is set to the "old" HttpClient3x only
                         // as in nullified case, the
                         // org.sonatype.nexus.proxy.storage.remote.DefaultRemoteProviderHintFactory will kick in as we
                         // want
-                        localStorage.setProvider( null );
+                        remoteStorage.setProvider( null );
                     }
                 }
-                return localStorage;
+                return remoteStorage;
             }
         };
 

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to220.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade200to220.java
@@ -31,7 +31,7 @@ import org.sonatype.nexus.configuration.model.v2_2_0.upgrade.BasicVersionUpgrade
  * @author cstamas
  */
 @Component( role = SingleVersionUpgrader.class, hint = "2.0.0" )
-public class Upgrade200to201
+public class Upgrade200to220
     extends AbstractLogEnabled
     implements SingleVersionUpgrader
 {

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -32,7 +32,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -60,7 +59,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository</url>
       </remoteStorage>
       <externalConfiguration>
@@ -88,7 +86,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -32,7 +32,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -60,7 +59,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository</url>
       </remoteStorage>
       <externalConfiguration>
@@ -88,7 +86,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-1.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-1.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -36,7 +36,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.1.1:8080/nexus/groups/public</url>
       </remoteStorage>
       <externalConfiguration>
@@ -64,7 +63,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.1.1:8080/nexus/groups/snapshot</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-1.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-1.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-2.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-2.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -40,7 +40,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -68,7 +67,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://hehe.sonatype.com/repos/customer</url>
       </remoteStorage>
       <externalConfiguration>
@@ -96,7 +94,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://java.freehep.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -124,7 +121,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-incubating-repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -152,7 +148,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>https://maven.atlassian.com/public/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -180,7 +175,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://www.openfast.org/maven/release/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -208,7 +202,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -236,7 +229,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -264,7 +256,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://java.freehep.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -292,7 +283,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>https://maven.atlassian.com/public-snapshot/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -320,7 +310,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://www.openfast.org/maven/snapshot/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-2.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-2.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-3.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-3.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-3.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-001-3.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -36,7 +36,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.1.1:8443/nexus/groups/public</url>
       </remoteStorage>
       <externalConfiguration>
@@ -64,7 +63,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.1.1:8443/nexus/groups/snapshot</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-100.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-100.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-100.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-100.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -36,7 +36,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.228.40:8443/nexus/groups/public</url>
       </remoteStorage>
       <externalConfiguration>
@@ -64,7 +63,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://192.168.228.40:8443/nexus/groups/snapshot</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -32,7 +32,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/releases</url>
       </remoteStorage>
       <externalConfiguration>
@@ -60,7 +59,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -88,7 +86,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/customer</url>
       </remoteStorage>
       <externalConfiguration>
@@ -116,7 +113,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -144,7 +140,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -172,7 +167,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -200,7 +194,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -228,7 +221,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://gwt-maven.googlecode.com/svn/trunk/mavenrepo/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -256,7 +248,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository</url>
       </remoteStorage>
       <externalConfiguration>
@@ -284,7 +275,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -312,7 +302,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-104.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-104.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -32,7 +32,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/releases</url>
       </remoteStorage>
       <externalConfiguration>
@@ -60,7 +59,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -88,7 +86,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/customer</url>
       </remoteStorage>
       <externalConfiguration>
@@ -116,7 +113,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -144,7 +140,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -172,7 +167,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -200,7 +194,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -228,7 +221,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://gwt-maven.googlecode.com/svn/trunk/mavenrepo/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -256,7 +248,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository</url>
       </remoteStorage>
       <externalConfiguration>
@@ -284,7 +275,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -312,7 +302,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-104.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-104.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-105.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-105.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -32,7 +32,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/releases</url>
       </remoteStorage>
       <externalConfiguration>
@@ -60,7 +59,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -88,7 +86,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://svn.sonatype.com/mvnrepos/customer</url>
       </remoteStorage>
       <externalConfiguration>
@@ -116,7 +113,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -144,7 +140,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -172,7 +167,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -200,7 +194,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -228,7 +221,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://gwt-maven.googlecode.com/svn/trunk/mavenrepo/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -256,7 +248,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://people.apache.org/repo/m2-snapshot-repository</url>
       </remoteStorage>
       <externalConfiguration>
@@ -284,7 +275,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -312,7 +302,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-105.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-105.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108-with-mirrors.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108-with-mirrors.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -33,7 +33,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
         <mirrors>
           <mirror>
@@ -95,7 +94,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -123,7 +121,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108-with-mirrors.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108-with-mirrors.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -33,7 +33,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -61,7 +60,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -89,7 +87,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-108.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -38,7 +38,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -69,7 +68,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -100,7 +98,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -129,7 +126,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -158,7 +154,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -189,7 +184,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -38,7 +38,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -70,7 +69,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -102,7 +100,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -131,7 +128,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -160,7 +156,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -191,7 +186,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>
@@ -34,7 +34,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>https://repository.apache.org/content/groups/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -62,7 +61,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -113,7 +111,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://maven.restlet.org</url>
       </remoteStorage>
       <externalConfiguration>
@@ -281,7 +278,6 @@
       <browseable>true</browseable>
       <writePolicy>READ_ONLY</writePolicy>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2</url>
       </remoteStorage>
       <externalConfiguration>
@@ -355,7 +351,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://oss.sonatype.org/content/repositories/plexus-releases/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -429,7 +424,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://oss.sonatype.org/content/repositories/plexus-snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -457,7 +451,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>https://maven.atlassian.com/public</url>
       </remoteStorage>
       <externalConfiguration>
@@ -485,7 +478,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -513,7 +505,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -541,7 +532,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.jboss.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -569,7 +559,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo.open.iona.com/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -597,7 +586,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.terracotta.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -671,7 +659,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://archiva.openqa.org/repository/releases</url>
       </remoteStorage>
       <externalConfiguration>
@@ -722,7 +709,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.jboss.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -750,7 +736,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo.ddsteps.org/maven/release/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -824,7 +809,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://mc-repo.googlecode.com/svn/maven2/releases</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/nexus.xml.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <globalConnectionSettings>
     <connectionTimeout>10000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>

--- a/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
+++ b/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
@@ -48,7 +48,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -76,7 +75,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -104,7 +102,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
+++ b/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
@@ -14,7 +14,7 @@
 
 -->
 <nexusConfiguration>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <nexusVersion>${project.version}</nexusVersion>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>

--- a/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
+++ b/nexus/nexus-oss-edition/src/main/filtered-resources/META-INF/nexus/nexus.xml
@@ -14,7 +14,7 @@
 
 -->
 <nexusConfiguration>
-  <version>2.0.1</version>
+  <version>2.2.0</version>
   <nexusVersion>${project.version}</nexusVersion>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -294,6 +294,32 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>apacheHttpClient3x-provider</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>apacheHttpClient3x-provider-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <reportsDirectory>${project.build.directory}/surefire-reports-apacheHttpClient3x-provider</reportsDirectory>
+                  <systemPropertyVariables>
+                    <nexus.default.http.provider>apacheHttpClient3x</nexus.default.http.provider>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/DefaultRemoteProviderHintFactory.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/DefaultRemoteProviderHintFactory.java
@@ -16,7 +16,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
-import org.sonatype.nexus.proxy.storage.remote.commonshttpclient.CommonsHttpClientRemoteStorage;
+import org.sonatype.nexus.proxy.storage.remote.httpclient.HttpClientRemoteStorage;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 
 /**
@@ -92,16 +92,14 @@ public class DefaultRemoteProviderHintFactory
             throw new IllegalArgumentException( "RemoteRepositoryStorage hint cannot be null!" );
         }
 
-        logger.info( "Returning supplied \"{}\" hint for remote URL {}.",
-            new Object[] { remoteUrl, hint } );
+        logger.info( "Returning supplied \"{}\" hint for remote URL {}.", new Object[] { remoteUrl, hint } );
 
         return hint;
     }
 
     public String getDefaultHttpRoleHint()
     {
-        return SystemPropertiesHelper.getString( DEFAULT_HTTP_PROVIDER_KEY,
-            CommonsHttpClientRemoteStorage.PROVIDER_STRING );
+        return SystemPropertiesHelper.getString( DEFAULT_HTTP_PROVIDER_KEY, HttpClientRemoteStorage.PROVIDER_STRING );
     }
 
     public String getHttpRoleHint( final String hint )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
@@ -65,7 +65,7 @@ import org.sonatype.nexus.proxy.utils.UserAgentBuilder;
  */
 @Named( HttpClientRemoteStorage.PROVIDER_STRING )
 @Singleton
-class HttpClientRemoteStorage
+public class HttpClientRemoteStorage
     extends AbstractHTTPRemoteRepositoryStorage
     implements RemoteRepositoryStorage
 {

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/RemoteProviderHintFactoryTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/RemoteProviderHintFactoryTest.java
@@ -14,8 +14,7 @@ package org.sonatype.nexus.proxy.storage.remote;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import org.sonatype.nexus.proxy.storage.remote.commonshttpclient.CommonsHttpClientRemoteStorage;
+import org.sonatype.nexus.proxy.storage.remote.httpclient.HttpClientRemoteStorage;
 import org.sonatype.nexus.test.PlexusTestCaseSupport;
 
 public class RemoteProviderHintFactoryTest
@@ -42,7 +41,7 @@ public class RemoteProviderHintFactoryTest
         System.clearProperty( DefaultRemoteProviderHintFactory.DEFAULT_HTTP_PROVIDER_KEY );
 
         // nothing set
-        Assert.assertEquals( CommonsHttpClientRemoteStorage.PROVIDER_STRING, hintFactory.getDefaultHttpRoleHint() );
+        Assert.assertEquals( HttpClientRemoteStorage.PROVIDER_STRING, hintFactory.getDefaultHttpRoleHint() );
 
         System.setProperty( DefaultRemoteProviderHintFactory.DEFAULT_HTTP_PROVIDER_KEY, FAKE_VALUE );
         Assert.assertEquals( FAKE_VALUE, hintFactory.getDefaultHttpRoleHint() );

--- a/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
@@ -386,6 +386,30 @@
     </profile>
 
     <profile>
+      <id>apacheHttpClient3x-provider</id>
+      <activation>
+        <property>
+          <name>rrs</name>
+          <value>apacheHttpClient3x</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <nexus.default.http.provider>apacheHttpClient3x</nexus.default.http.provider>
+                <nexus.default.http.providerForced>true</nexus.default.http.providerForced>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>cargo</id>
       <build>
         <plugins>


### PR DESCRIPTION
Changes in:
- Alin's original plus the missing "boxed config" changes
- Config version bumped to force upgrade, new upgrader
- UT resource updates

These changes covers the OSS part, non-OSS editions still has pending changes.
