### PR TITLE
AbstractMavenRepositoryTemplate should use AbstractRepositoryTemplateProvider

### DIFF
--- a/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/AbstractMavenRepositoryTemplate.java
+++ b/nexus/nexus-app/src/main/java/org/sonatype/nexus/templates/repository/maven/AbstractMavenRepositoryTemplate.java
@@ -19,6 +19,7 @@ import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
 import org.sonatype.nexus.proxy.registry.ContentClass;
 import org.sonatype.nexus.templates.repository.AbstractRepositoryTemplate;
+import org.sonatype.nexus.templates.repository.AbstractRepositoryTemplateProvider;
 import org.sonatype.nexus.templates.repository.DefaultRepositoryTemplateProvider;
 
 public abstract class AbstractMavenRepositoryTemplate
@@ -26,7 +27,7 @@ public abstract class AbstractMavenRepositoryTemplate
 {
     private RepositoryPolicy repositoryPolicy;
 
-    public AbstractMavenRepositoryTemplate( DefaultRepositoryTemplateProvider provider, String id, String description,
+    public AbstractMavenRepositoryTemplate( AbstractRepositoryTemplateProvider provider, String id, String description,
                                             ContentClass contentClass, Class<?> mainFacet,
                                             RepositoryPolicy repositoryPolicy )
     {


### PR DESCRIPTION
The constructor argument of AbstractMavenRepositoryTemplate should use AbstractRepositoryTemplateProvider like the super constructor does. This makes it much easier to register a new template because your TemplateProvider does not need to inherit from DefaultRepositoryTemplateProvider and override its methods and annotations.

Regards,
Sebastian Herold
