### PR TITLE
Automatically include nexus-it-helper-plugin

### DIFF
--- a/nexus/nexus-test/nexus-testsuite-client/pom.xml
+++ b/nexus/nexus-test/nexus-testsuite-client/pom.xml
@@ -1,0 +1,42 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2012 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus</groupId>
+    <artifactId>nexus-test</artifactId>
+    <version>2.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-testsuite-client</artifactId>
+
+  <name>Nexus : Test : Test Suite Client</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus.client</groupId>
+      <artifactId>nexus-client-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/RemoteLoggerFactory.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/RemoteLoggerFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client;
+
+import org.slf4j.Logger;
+
+/**
+ * Remote Logger Nexus Client Subsystem. Created logger will forward logging to a Nexus REST resource, so log messages
+ * will appear in nexus.log.
+ *
+ * @since 2.2
+ */
+public interface RemoteLoggerFactory
+{
+
+    /**
+     * Return a logger named according to the name parameter.
+     *
+     * @param name of the logger
+     * @return logger. Never null.
+     */
+    Logger getLogger( final String name );
+
+    /**
+     * Return a logger named corresponding to the class passed as parameter.
+     *
+     * @param clazz the returned logger will be named after clazz
+     * @return logger. Never null.
+     */
+    Logger getLogger( final Class clazz );
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyRemoteLogger.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyRemoteLogger.java
@@ -1,0 +1,451 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.internal;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+import org.sonatype.nexus.client.core.spi.SubsystemSupport;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+/**
+ * Jersey based {@link Logger} Nexus Client Subsystem implementation.
+ *
+ * @since 2.2
+ */
+public class JerseyRemoteLogger
+    extends SubsystemSupport<JerseyNexusClient>
+    implements Logger
+{
+
+    private static String TRACE_STR = "TRACE";
+
+    private static String DEBUG_STR = "DEBUG";
+
+    private static String INFO_STR = "INFO";
+
+    private static String WARN_STR = "WARN";
+
+    private static String ERROR_STR = "ERROR";
+
+    private final String name;
+
+    public JerseyRemoteLogger( final JerseyNexusClient nexusClient,
+                               final String name )
+    {
+        super( nexusClient );
+        this.name = name;
+    }
+
+    private void log( final String level, final String message, final Throwable t )
+    {
+        final MultivaluedMap<String, String> queryParams = new MultivaluedMapImpl();
+        queryParams.add( "loggerName", name );
+        queryParams.add( "level", level );
+        queryParams.add( "message", message );
+        if ( t != null )
+        {
+            queryParams.add( "exceptionType", t.getClass().getName() );
+            final String exceptionMessage = t.getMessage();
+            if ( exceptionMessage != null )
+            {
+                queryParams.add( "exceptionMessage", exceptionMessage );
+            }
+        }
+        getNexusClient().serviceResource( "loghelper", queryParams ).get( ClientResponse.class ).close();
+    }
+
+    private void formatAndLog( final String level, final String format, final Object arg1, final Object arg2 )
+    {
+        final FormattingTuple tp = MessageFormatter.format( format, arg1, arg2 );
+        log( level, tp.getMessage(), tp.getThrowable() );
+    }
+
+    private void formatAndLog( final String level, final String format, final Object[] argArray )
+    {
+        final FormattingTuple tp = MessageFormatter.arrayFormat( format, argArray );
+        log( level, tp.getMessage(), tp.getThrowable() );
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void trace( final String msg )
+    {
+        log( TRACE_STR, msg, null );
+    }
+
+    @Override
+    public void trace( final String format, final Object arg )
+    {
+        formatAndLog( TRACE_STR, format, arg, null );
+    }
+
+    @Override
+    public void trace( final String format, final Object arg1, final Object arg2 )
+    {
+        formatAndLog( TRACE_STR, format, arg1, arg2 );
+    }
+
+    @Override
+    public void trace( final String format, final Object[] argArray )
+    {
+        formatAndLog( TRACE_STR, format, argArray );
+    }
+
+    @Override
+    public void trace( final String msg, final Throwable t )
+    {
+        log( TRACE_STR, msg, t );
+    }
+
+    @Override
+    public boolean isTraceEnabled( final Marker marker )
+    {
+        return isTraceEnabled();
+    }
+
+    @Override
+    public void trace( final Marker marker, final String msg )
+    {
+        trace( msg );
+    }
+
+    @Override
+    public void trace( final Marker marker, final String format, final Object arg )
+    {
+        trace( format, arg );
+    }
+
+    @Override
+    public void trace( final Marker marker, final String format, final Object arg1, final Object arg2 )
+    {
+        trace( format, arg1, arg2 );
+    }
+
+    @Override
+    public void trace( final Marker marker, final String format, final Object[] argArray )
+    {
+        trace( format, argArray );
+    }
+
+    @Override
+    public void trace( final Marker marker, final String msg, final Throwable t )
+    {
+        trace( msg, t );
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void debug( final String msg )
+    {
+        log( DEBUG_STR, msg, null );
+    }
+
+    @Override
+    public void debug( final String format, final Object arg )
+    {
+        formatAndLog( DEBUG_STR, format, arg, null );
+    }
+
+    @Override
+    public void debug( final String format, final Object arg1, final Object arg2 )
+    {
+        formatAndLog( DEBUG_STR, format, arg1, arg2 );
+    }
+
+    @Override
+    public void debug( final String format, final Object[] argArray )
+    {
+        formatAndLog( DEBUG_STR, format, argArray );
+    }
+
+    @Override
+    public void debug( final String msg, final Throwable t )
+    {
+        log( DEBUG_STR, msg, t );
+    }
+
+    @Override
+    public boolean isDebugEnabled( final Marker marker )
+    {
+        return isDebugEnabled();
+    }
+
+    @Override
+    public void debug( final Marker marker, final String msg )
+    {
+        debug( msg );
+    }
+
+    @Override
+    public void debug( final Marker marker, final String format, final Object arg )
+    {
+        debug( format, arg );
+    }
+
+    @Override
+    public void debug( final Marker marker, final String format, final Object arg1, final Object arg2 )
+    {
+        debug( format, arg1, arg2 );
+    }
+
+    @Override
+    public void debug( final Marker marker, final String format, final Object[] argArray )
+    {
+        debug( format, argArray );
+    }
+
+    @Override
+    public void debug( final Marker marker, final String msg, final Throwable t )
+    {
+        debug( msg, t );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void info( final String msg )
+    {
+        log( INFO_STR, msg, null );
+    }
+
+    @Override
+    public void info( final String format, final Object arg )
+    {
+        formatAndLog( INFO_STR, format, arg, null );
+    }
+
+    @Override
+    public void info( final String format, final Object arg1, final Object arg2 )
+    {
+        formatAndLog( INFO_STR, format, arg1, arg2 );
+    }
+
+    @Override
+    public void info( final String format, final Object[] argArray )
+    {
+        formatAndLog( INFO_STR, format, argArray );
+    }
+
+    @Override
+    public void info( final String msg, final Throwable t )
+    {
+        log( INFO_STR, msg, t );
+    }
+
+    @Override
+    public boolean isInfoEnabled( final Marker marker )
+    {
+        return true;
+    }
+
+    @Override
+    public void info( final Marker marker, final String msg )
+    {
+        info( msg );
+    }
+
+    @Override
+    public void info( final Marker marker, final String format, final Object arg )
+    {
+        info( format, arg );
+    }
+
+    @Override
+    public void info( final Marker marker, final String format, final Object arg1, final Object arg2 )
+    {
+        info( format, arg1, arg2 );
+    }
+
+    @Override
+    public void info( final Marker marker, final String format, final Object[] argArray )
+    {
+        info( format, argArray );
+    }
+
+    @Override
+    public void info( final Marker marker, final String msg, final Throwable t )
+    {
+        info( msg, t );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void warn( final String msg )
+    {
+        log( WARN_STR, msg, null );
+    }
+
+    @Override
+    public void warn( final String format, final Object arg )
+    {
+        formatAndLog( WARN_STR, format, arg, null );
+    }
+
+    @Override
+    public void warn( final String format, final Object[] argArray )
+    {
+        formatAndLog( WARN_STR, format, argArray );
+    }
+
+    @Override
+    public void warn( final String format, final Object arg1, final Object arg2 )
+    {
+        formatAndLog( WARN_STR, format, arg1, arg2 );
+    }
+
+    @Override
+    public void warn( final String msg, final Throwable t )
+    {
+        log( WARN_STR, msg, t );
+    }
+
+    @Override
+    public boolean isWarnEnabled( final Marker marker )
+    {
+        return isWarnEnabled();
+    }
+
+    @Override
+    public void warn( final Marker marker, final String msg )
+    {
+        warn( msg );
+    }
+
+    @Override
+    public void warn( final Marker marker, final String format, final Object arg )
+    {
+        warn( format, arg );
+    }
+
+    @Override
+    public void warn( final Marker marker, final String format, final Object arg1, final Object arg2 )
+    {
+        warn( format, arg1, arg2 );
+    }
+
+    @Override
+    public void warn( final Marker marker, final String format, final Object[] argArray )
+    {
+        warn( format, argArray );
+    }
+
+    @Override
+    public void warn( final Marker marker, final String msg, final Throwable t )
+    {
+        warn( msg, t );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void error( final String msg )
+    {
+        log( ERROR_STR, msg, null );
+    }
+
+    @Override
+    public void error( final String format, final Object arg )
+    {
+        formatAndLog( ERROR_STR, format, arg, null );
+    }
+
+    @Override
+    public void error( final String format, final Object arg1, final Object arg2 )
+    {
+        formatAndLog( ERROR_STR, format, arg1, arg2 );
+    }
+
+    @Override
+    public void error( final String format, final Object[] argArray )
+    {
+        formatAndLog( ERROR_STR, format, argArray );
+    }
+
+    @Override
+    public void error( final String msg, final Throwable t )
+    {
+        log( ERROR_STR, msg, t );
+    }
+
+    @Override
+    public boolean isErrorEnabled( final Marker marker )
+    {
+        return isErrorEnabled();
+    }
+
+    @Override
+    public void error( final Marker marker, final String msg )
+    {
+        error( msg );
+    }
+
+    @Override
+    public void error( final Marker marker, final String format, final Object arg )
+    {
+        error( format, arg );
+    }
+
+    @Override
+    public void error( final Marker marker, final String format, final Object arg1, final Object arg2 )
+    {
+        error( format, arg1, arg2 );
+    }
+
+    @Override
+    public void error( final Marker marker, final String format, final Object[] argArray )
+    {
+        error( format, argArray );
+    }
+
+    @Override
+    public void error( final Marker marker, final String msg, final Throwable t )
+    {
+        error( msg, t );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyRemoteLoggerFactory.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyRemoteLoggerFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.internal;
+
+import org.slf4j.Logger;
+import org.sonatype.nexus.client.core.spi.SubsystemSupport;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.RemoteLoggerFactory;
+
+/**
+ * Jersey based {@link RemoteLoggerFactory} Nexus Client Subsystem implementation.
+ *
+ * @since 2.2
+ */
+public class JerseyRemoteLoggerFactory
+    extends SubsystemSupport<JerseyNexusClient>
+    implements RemoteLoggerFactory
+{
+
+    public JerseyRemoteLoggerFactory( final JerseyNexusClient nexusClient )
+    {
+        super( nexusClient );
+    }
+
+    @Override
+    public Logger getLogger( final String name )
+    {
+        return new JerseyRemoteLogger( getNexusClient(), name );
+    }
+
+    @Override
+    public Logger getLogger( final Class clazz )
+    {
+        return getLogger( clazz.getName() );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyRemoteLoggerFactorySubsystemFactory.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyRemoteLoggerFactorySubsystemFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.client.core.Condition;
+import org.sonatype.nexus.client.core.condition.NexusStatusConditions;
+import org.sonatype.nexus.client.core.spi.SubsystemFactory;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.RemoteLoggerFactory;
+import org.sonatype.nexus.testsuite.client.internal.JerseyRemoteLoggerFactory;
+
+/**
+ * Jersey based {@link RemoteLoggerFactory} Nexus Client Subsystem factory.
+ *
+ * @since 2.2
+ */
+@Named
+@Singleton
+public class JerseyRemoteLoggerFactorySubsystemFactory
+    implements SubsystemFactory<RemoteLoggerFactory, JerseyNexusClient>
+{
+
+    @Override
+    public Condition availableWhen()
+    {
+        return NexusStatusConditions.any20AndLater();
+    }
+
+    @Override
+    public Class<RemoteLoggerFactory> getType()
+    {
+        return RemoteLoggerFactory.class;
+    }
+
+    @Override
+    public RemoteLoggerFactory create( final JerseyNexusClient nexusClient )
+    {
+        return new JerseyRemoteLoggerFactory( nexusClient );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-support/pom.xml
+++ b/nexus/nexus-test/nexus-testsuite-support/pom.xml
@@ -70,6 +70,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-testsuite-client</artifactId>
+      <version>2.2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.sonatype.sisu.goodies</groupId>
       <artifactId>goodies-marshal</artifactId>
       <version>1.4</version>

--- a/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/NexusITSupport.java
+++ b/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/NexusITSupport.java
@@ -13,11 +13,14 @@
 package org.sonatype.nexus.testsuite.support;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static org.sonatype.nexus.client.rest.BaseUrl.baseUrlFrom;
 import static org.sonatype.nexus.testsuite.support.NexusITFilter.contextEntry;
 import static org.sonatype.nexus.testsuite.support.filters.TestProjectFilter.TEST_PROJECT_POM_FILE;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URL;
 import java.util.List;
 import java.util.Properties;
 import javax.inject.Inject;
@@ -39,6 +42,7 @@ import org.sonatype.sisu.bl.support.resolver.BundleResolver;
 import org.sonatype.sisu.bl.support.resolver.MavenBridgedBundleResolver;
 import org.sonatype.sisu.bl.support.resolver.TargetDirectoryResolver;
 import org.sonatype.sisu.filetasks.FileTaskBuilder;
+import org.sonatype.sisu.goodies.common.Properties2;
 import org.sonatype.sisu.litmus.testsupport.TestData;
 import org.sonatype.sisu.litmus.testsupport.TestIndex;
 import org.sonatype.sisu.litmus.testsupport.inject.InjectedTestSupport;
@@ -46,6 +50,7 @@ import org.sonatype.sisu.litmus.testsupport.junit.TestDataRule;
 import org.sonatype.sisu.litmus.testsupport.junit.TestIndexRule;
 import org.sonatype.sisu.maven.bridge.MavenArtifactResolver;
 import org.sonatype.sisu.maven.bridge.MavenModelResolver;
+import com.google.common.base.Throwables;
 import com.google.inject.Binder;
 
 /**
@@ -360,6 +365,25 @@ public abstract class NexusITSupport
         if ( !StringUtils.isEmpty( logLevel ) )
         {
             checkNotNull( nexus ).getConfiguration().setLogLevel( logLevel );
+        }
+
+        final URL pomUrl = getClass().getResource(
+            "/META-INF/maven/org.sonatype.nexus/nexus-testsuite-support/pom.properties"
+        );
+
+        checkState( pomUrl != null, "Missing pom.properties for org.sonatype.nexus:nexus-testsuite-support" );
+
+        try
+        {
+            final Properties props = Properties2.load( pomUrl );
+            final String version = props.getProperty( "version" );
+            nexus.getConfiguration().addPlugins(
+                artifactResolver().resolveArtifact( "org.sonatype.nexus:nexus-it-helper-plugin:zip:bundle:" + version )
+            );
+        }
+        catch ( final IOException e )
+        {
+            throw Throwables.propagate( e );
         }
 
         return nexus;

--- a/nexus/nexus-test/nexus-testsuite-support/src/test/filtered-resources/META-INF/maven/org.sonatype.nexus/nexus-testsuite-support/pom.properties
+++ b/nexus/nexus-test/nexus-testsuite-support/src/test/filtered-resources/META-INF/maven/org.sonatype.nexus/nexus-testsuite-support/pom.properties
@@ -1,0 +1,3 @@
+version=${project.version}
+groupId=${project.groupId}
+artifactId=${project.artifactId}

--- a/nexus/nexus-test/pom.xml
+++ b/nexus/nexus-test/pom.xml
@@ -31,6 +31,7 @@
 
   <modules>
     <module>nexus-test-common</module>
+    <module>nexus-testsuite-client</module>
     <module>nexus-testsuite-support</module>
   </modules>
 


### PR DESCRIPTION
- By default all NexusITSupport based ITs will include the nexus-it-helper-plugin.
- Create a new module for nexus clients for REST resources available in above plugin.
- Automatically log start/end of tests. This info will appear in nexus.log and will make easier to track what happened in nexus dring test
