### PR TITLE
[NEXUS-5246] Use status 307 (temporary redirect) instead of 301 (permanent redact) to avoid browser caching

### DIFF
--- a/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/artifact/AbstractArtifactPlexusResource.java
+++ b/nexus/nexus-rest-api/src/main/java/org/sonatype/nexus/rest/artifact/AbstractArtifactPlexusResource.java
@@ -257,7 +257,7 @@ public abstract class AbstractArtifactPlexusResource
 
                 response.setLocationRef( fileReference );
 
-                response.setStatus( Status.REDIRECTION_PERMANENT );
+                response.setStatus( Status.REDIRECTION_TEMPORARY );
 
                 String redirectMessage =
                     "If you are not automatically redirected use this url: " + fileReference.toString();


### PR DESCRIPTION
Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
