### PR TITLE
NEXUS-5249: Do not propagate exception in case that downloading the remote index failed

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -86,7 +86,6 @@ import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
-import org.sonatype.nexus.proxy.RemoteStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.attributes.inspectors.DigestCalculatingInspector;
@@ -1135,10 +1134,6 @@ public class DefaultIndexerManager
                     final FileNotFoundException fne = new FileNotFoundException( name + " (remote item not found)" );
                     fne.initCause( ex );
                     throw fne;
-                }
-                catch ( RemoteStorageException ex )
-                {
-                    throw new IOException( ex.getMessage(), ex );
                 }
             }
         } );

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
@@ -1,0 +1,114 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.util;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A composite {@link Exception} descendant, that is able to collect multiple causes to have them throw at the end of
+ * some batch processing for example. Inspired by code from <a href=
+ * "http://stackoverflow.com/questions/12481583/exception-composition-in-java-when-both-first-strategy-and-recovery-strategy-fai"
+ * >Stack Overflow</a>.
+ * 
+ * @author cstamas
+ * @since 2.2
+ */
+public class CompositeException
+    extends Exception
+{
+    private static final long serialVersionUID = 1386505977462170509L;
+
+    private final List<Throwable> causes;
+
+    // ==
+
+    public CompositeException( final Throwable... causes )
+    {
+        this( null, causes );
+    }
+
+    public CompositeException( final String message, final Throwable... causes )
+    {
+        this( message, Arrays.asList( causes ) );
+    }
+
+    public CompositeException( final List<? extends Throwable> causes )
+    {
+        this( null, causes );
+    }
+
+    public CompositeException( final String message, final List<? extends Throwable> causes )
+    {
+        super( message );
+        final ArrayList<Throwable> c = new ArrayList<Throwable>();
+        if ( causes != null && !causes.isEmpty() )
+        {
+            c.addAll( causes );
+        }
+        this.causes = Collections.unmodifiableList( c );
+    }
+
+    public List<Throwable> getCauses()
+    {
+        return causes;
+    }
+
+    // ==
+
+    @Override
+    public void printStackTrace()
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace();
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace();
+        }
+    }
+
+    @Override
+    public void printStackTrace( final PrintStream s )
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace( s );
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace( s );
+        }
+    }
+
+    @Override
+    public void printStackTrace( final PrintWriter s )
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace( s );
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace( s );
+        }
+    }
+}


### PR DESCRIPTION
This pull fixes the original issue, but also:
- still retains required behaviour from NEXUS-4275: If a remote index fails to download due to 401/403/50x problems we should end the "download index" task with a "broken" state
- implements NEXUS-3424 When remote index could not be downloaded, log stack trace only when debug is enabled

CI scheduled (prev job still running):
https://builds.sonatype.org/view/nexus-features/job/nexus-oss-its-feature/416/
