### PR TITLE
NEXUS-5216: Using released nexus-archetype-commons.

### DIFF
--- a/nexus/nexus-core-plugins/nexus-archetype-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-archetype-plugin/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.sonatype.spice</groupId>
       <artifactId>nexus-archetype-common</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Just parked on branch, as upon release there is some time
needed to make the artifact appear in Central, until then
the build would become broken?

So, this trivial pull is only here, that when 1.2 appears here:
http://repo1.maven.org/maven2/org/sonatype/spice/nexus-archetype-common/

Then just press merge.
