### PR TITLE
NEXUS-5249: Update Indexes task stops processing on RemoteItemNotFoundException

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -86,7 +86,6 @@ import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
-import org.sonatype.nexus.proxy.RemoteStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.attributes.inspectors.DigestCalculatingInspector;
@@ -1135,10 +1134,6 @@ public class DefaultIndexerManager
                     final FileNotFoundException fne = new FileNotFoundException( name + " (remote item not found)" );
                     fne.initCause( ex );
                     throw fne;
-                }
-                catch ( RemoteStorageException ex )
-                {
-                    throw new IOException( ex.getMessage(), ex );
                 }
             }
         } );

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -114,6 +114,8 @@ import org.sonatype.nexus.util.SystemPropertiesHelper;
 import org.sonatype.scheduling.TaskInterruptedException;
 import org.sonatype.scheduling.TaskUtil;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * <p>
  * Indexer Manager. This is a thin layer above Nexus Indexer and simply manages indexingContext additions, updates and
@@ -193,6 +195,18 @@ public class DefaultIndexerManager
             DefaultIndexingContext.BLOCKING_COMMIT = true;
         }
         // This above is needed and used in ITs only!
+    }
+
+    @VisibleForTesting
+    protected void setIndexUpdater( final IndexUpdater indexUpdater )
+    {
+        this.indexUpdater = indexUpdater;
+    }
+
+    @VisibleForTesting
+    protected void setNexusIndexer( final NexusIndexer nexusIndexer )
+    {
+        this.nexusIndexer = nexusIndexer;
     }
 
     protected Logger getLogger()

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
@@ -66,7 +66,8 @@ public class Nexus5249IndexerManagerTest
     protected void prepare( final IOException failure )
         throws Exception
     {
-        // count total of indexed, and total of indexed proxy repositories, and set the one to make it really go remotely
+        // count total of indexed, and total of indexed proxy repositories, and set the one to make it really go
+        // remotely
         indexedRepositories = 0;
         indexedProxyRepositories = 0;
         for ( Repository repository : repositoryRegistry.getRepositories() )
@@ -77,13 +78,21 @@ public class Nexus5249IndexerManagerTest
             {
                 indexedRepositories++;
             }
-            if ( repository.getId().equals( apacheSnapshots.getId() ) )
+            // leave only one to download remote indexes explicitly
+            if ( repository.getRepositoryKind().isFacetAvailable( MavenProxyRepository.class ) )
             {
                 final MavenProxyRepository mavenProxyRepository = repository.adaptToFacet( MavenProxyRepository.class );
-                mavenProxyRepository.setDownloadRemoteIndexes( true );
+                if ( repository.getId().equals( apacheSnapshots.getId() ) )
+                {
+                    mavenProxyRepository.setDownloadRemoteIndexes( true );
+                    failingRepository = mavenProxyRepository;
+                    indexedProxyRepositories++;
+                }
+                else
+                {
+                    mavenProxyRepository.setDownloadRemoteIndexes( false );
+                }
                 mavenProxyRepository.commitChanges();
-                failingRepository = mavenProxyRepository;
-                indexedProxyRepositories++;
             }
         }
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
@@ -108,6 +108,10 @@ public class Nexus5249IndexerManagerTest
             }
         }
 
+        // as things above will trigger some bg tasks (failingRepository will be reindexed with a task)
+        waitForTasksToStop();
+        wairForAsyncEventsToCalmDown();
+
         // faking IndexUpdater that will fail with given exception for given "failing" repository
         final IndexUpdater realUpdater = lookup( IndexUpdater.class );
         // predicate to match invocation when the arguments are for the failingRepository

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
@@ -1,3 +1,15 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.index;
 
 import java.io.FileNotFoundException;

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
@@ -6,11 +6,12 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import javax.annotation.Nullable;
+
 import org.apache.maven.index.ArtifactScanningListener;
 import org.apache.maven.index.NexusIndexer;
 import org.apache.maven.index.context.IndexingContext;
 import org.apache.maven.index.updater.IndexUpdateRequest;
-import org.apache.maven.index.updater.IndexUpdateResult;
 import org.apache.maven.index.updater.IndexUpdater;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,52 +22,113 @@ import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
 import org.sonatype.nexus.util.CompositeException;
 
+import com.google.common.base.Predicate;
+
 /**
  * Test for NEXUS-5249 and related ones (see linked issues). In general, we ensure that 404 happened during remote
  * update does not break the batch-processing of ALL repositories (task should not stop and should go on process other
  * repositories). Also, 401/403/50x errors will throw IOException at the processng end (and hence, make the task
  * failed), but again, the batch is not broken due to one repo being broken, the exceptions are supressed until batch
  * end.
+ * <p>
+ * {@link DefaultIndexerManager} "reindex" operation (invoked multiple times by "all" operations tested here) actually
+ * does two things: first, if needed (repo is proxy, index download enabled), will try to update index from remote
+ * (using {@link IndexUpdater#fetchAndUpdateIndex(IndexUpdateRequest)} component, and then, will invoke
+ * {@link NexusIndexer#scan(IndexingContext, String, ArtifactScanningListener, boolean)}. This UT assumes this order of
+ * invocation, and that following conditions are true:
+ * <ul>
+ * <li>if {@link IndexUpdater#fetchAndUpdateIndex(IndexUpdateRequest)} hits HTTP 404 response, no interruption of
+ * execution happens at all (not for given repo being processed, nor for the "all" operation), this was the bug
+ * NEXUS-5249</li>
+ * <li>if if {@link IndexUpdater#fetchAndUpdateIndex(IndexUpdateRequest)} hits any other unexpected HTTP response other
+ * than 404, no interruption of "all" operation happens (but currently processed repository is stopped from being
+ * processed, no scan is invoked), and the "all" operation should fail at end</li>
+ * <li></li>
+ * </ul>
  * 
  * @author cstamas
  */
 public class Nexus5249IndexerManagerTest
     extends AbstractIndexerManagerTest
 {
-    protected CountingInvocationHandler cih;
+    protected int indexedRepositories;
 
-    protected int getIndexableRepositories()
+    protected int indexedProxyRepositories;
+
+    protected MavenProxyRepository failingRepository;
+
+    protected FailingInvocationHandler fetchFailingInvocationHandler;
+
+    protected CountingInvocationHandler fetchCountingInvocationHandler;
+
+    protected CountingInvocationHandler scanCountingInvocationHandler;
+
+    protected void prepare( final IOException failure )
+        throws Exception
     {
-        int result = 0;
+        // count total of indexed, and total of indexed proxy repositories, and set the one to make it really go remotely
+        indexedRepositories = 0;
+        indexedProxyRepositories = 0;
         for ( Repository repository : repositoryRegistry.getRepositories() )
         {
             if ( !repository.getRepositoryKind().isFacetAvailable( ShadowRepository.class )
                 && !repository.getRepositoryKind().isFacetAvailable( GroupRepository.class )
                 && repository.getRepositoryKind().isFacetAvailable( MavenRepository.class ) && repository.isIndexable() )
             {
-                result++;
+                indexedRepositories++;
+            }
+            if ( repository.getId().equals( apacheSnapshots.getId() ) )
+            {
+                final MavenProxyRepository mavenProxyRepository = repository.adaptToFacet( MavenProxyRepository.class );
+                mavenProxyRepository.setDownloadRemoteIndexes( true );
+                mavenProxyRepository.commitChanges();
+                failingRepository = mavenProxyRepository;
+                indexedProxyRepositories++;
             }
         }
-        return result;
-    }
 
-    protected void prepare( final IOException failure )
-        throws Exception
-    {
-        final MavenProxyRepository failingRepository = apacheSnapshots.adaptToFacet( MavenProxyRepository.class );
-        failingRepository.setDownloadRemoteIndexes( true );
-        failingRepository.commitChanges();
-
+        // faking IndexUpdater that will fail with given exception for given "failing" repository
         final IndexUpdater realUpdater = lookup( IndexUpdater.class );
-        final IndexUpdater fakeUpdater = new FakeIndexUpdater( realUpdater, failingRepository.getId(), failure );
+        // predicate to match invocation when the arguments are for the failingRepository
+        final Predicate<Object[]> fetchAndUpdateIndexMethodArgumentsPredicate = new Predicate<Object[]>()
+        {
+            @Override
+            public boolean apply( @Nullable Object[] input )
+            {
+                if ( input != null )
+                {
+                    final IndexUpdateRequest req = (IndexUpdateRequest) input[0];
+                    if ( req != null )
+                    {
+                        return req.getIndexingContext().getId().startsWith( failingRepository.getId() );
+                    }
+                }
+                return false;
+            }
+        };
+        // method we want to fail and count
+        final Method fetchAndUpdateIndexMethod =
+            IndexUpdater.class.getMethod( "fetchAndUpdateIndex", new Class[] { IndexUpdateRequest.class } );
+        fetchFailingInvocationHandler =
+            new FailingInvocationHandler( new PassThruInvocationHandler( realUpdater ), fetchAndUpdateIndexMethod,
+                fetchAndUpdateIndexMethodArgumentsPredicate, failure );
+        fetchCountingInvocationHandler =
+            new CountingInvocationHandler( fetchFailingInvocationHandler, fetchAndUpdateIndexMethod );
+        final IndexUpdater fakeUpdater =
+            (IndexUpdater) Proxy.newProxyInstance( getClass().getClassLoader(), new Class[] { IndexUpdater.class },
+                fetchCountingInvocationHandler );
 
+        // faking NexusIndexer, invoked by tested IndexerManager to perform scans only to count scan invocations
         final NexusIndexer realIndexer = lookup( NexusIndexer.class );
-        cih =
-            new CountingInvocationHandler( realIndexer, NexusIndexer.class.getMethod( "scan", new Class[] {
-                IndexingContext.class, String.class, ArtifactScanningListener.class, boolean.class } ) );
+        scanCountingInvocationHandler =
+            new CountingInvocationHandler( new PassThruInvocationHandler( realIndexer ), NexusIndexer.class.getMethod(
+                "scan", new Class[] { IndexingContext.class, String.class, ArtifactScanningListener.class,
+                    boolean.class } ) );
         final NexusIndexer fakeIndexer =
-            (NexusIndexer) Proxy.newProxyInstance( getClass().getClassLoader(), new Class[] { NexusIndexer.class }, cih );
+            (NexusIndexer) Proxy.newProxyInstance( getClass().getClassLoader(), new Class[] { NexusIndexer.class },
+                scanCountingInvocationHandler );
 
+        // applying faked components
         final DefaultIndexerManager dim = (DefaultIndexerManager) indexerManager;
         dim.setIndexUpdater( fakeUpdater );
         dim.setNexusIndexer( fakeIndexer );
@@ -85,8 +147,11 @@ public class Nexus5249IndexerManagerTest
             indexerManager.reindexAllRepositories( null, false );
 
             // we continue here as 404 should not end up with exception (is "swallowed")
-            // ensure we scanned all the repositories, even the one having 404 on remote update
-            Assert.assertEquals( getIndexableRepositories(), cih.getInvocationCount() );
+
+            // ensure we fetched from one we wanted (failingRepository)
+            Assert.assertEquals( indexedProxyRepositories, fetchCountingInvocationHandler.getInvocationCount() );
+            // ensure we scanned all the repositories, even the failing one, having 404 on remote update
+            Assert.assertEquals( indexedRepositories, scanCountingInvocationHandler.getInvocationCount() );
         }
         catch ( IOException e )
         {
@@ -112,8 +177,10 @@ public class Nexus5249IndexerManagerTest
         }
         catch ( IOException e )
         {
+            // ensure we fetched from one we wanted (failingRepository)
+            Assert.assertEquals( indexedProxyRepositories, fetchCountingInvocationHandler.getInvocationCount() );
             // ensure we scanned all the repositories (minus the one failed, as it failed _BEFORE_ scan invocation)
-            Assert.assertEquals( getIndexableRepositories() - 1, cih.getInvocationCount() );
+            Assert.assertEquals( indexedRepositories - 1, scanCountingInvocationHandler.getInvocationCount() );
             // ensure we have composite exception
             Assert.assertEquals( CompositeException.class, e.getCause().getClass() );
             // ensure we got back our bad exception
@@ -123,12 +190,15 @@ public class Nexus5249IndexerManagerTest
 
     // ==
 
-    public static class DelegatingInvocationHandler
+    /**
+     * {@link InvocationHandler} that simply passes the invocations to it's target.
+     */
+    public static class PassThruInvocationHandler
         implements InvocationHandler
     {
         private final Object delegate;
 
-        public DelegatingInvocationHandler( final Object delegate )
+        public PassThruInvocationHandler( final Object delegate )
         {
             this.delegate = delegate;
         }
@@ -141,6 +211,30 @@ public class Nexus5249IndexerManagerTest
         }
     }
 
+    /**
+     * {@link InvocationHandler} that delegates the call to another {@link InvocationHandler}.
+     */
+    public static class DelegatingInvocationHandler
+        implements InvocationHandler
+    {
+        private final InvocationHandler delegate;
+
+        public DelegatingInvocationHandler( final InvocationHandler delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke( final Object proxy, final Method method, final Object[] args )
+            throws Throwable
+        {
+            return delegate.invoke( proxy, method, args );
+        }
+    }
+
+    /**
+     * {@link InvocationHandler} that counts the invocations of specified {@link Method}.
+     */
     public static class CountingInvocationHandler
         extends DelegatingInvocationHandler
     {
@@ -148,7 +242,7 @@ public class Nexus5249IndexerManagerTest
 
         private int count;
 
-        public CountingInvocationHandler( final Object delegate, final Method countedMethod )
+        public CountingInvocationHandler( final InvocationHandler delegate, final Method countedMethod )
         {
             super( delegate );
             this.method = countedMethod;
@@ -172,35 +266,39 @@ public class Nexus5249IndexerManagerTest
         }
     }
 
-    public static class FakeIndexUpdater
-        implements IndexUpdater
+    /**
+     * {@link InvocationHandler} that fails if specified {@link Method} with specified arguments (as matched by
+     * {@link Predicate}) is invoked. Failing is simulated with preset {@link Exception}.
+     */
+    public static class FailingInvocationHandler
+        extends DelegatingInvocationHandler
     {
-        private final IndexUpdater delegate;
+        private final Method method;
 
-        private final String failingRepositoryId;
+        private final Predicate<Object[]> methodArgumentsPredicate;
 
-        private final IOException failure;
+        private final Exception failure;
 
-        private FakeIndexUpdater( final IndexUpdater delegate, final String failingRepositoryId,
-                                  final IOException failure )
+        public FailingInvocationHandler( final InvocationHandler delegate, final Method failingMethod,
+                                         final Predicate<Object[]> methodArgumentsPredicate, final Exception failure )
         {
-            this.delegate = delegate;
-            this.failingRepositoryId = failingRepositoryId;
+            super( delegate );
+            this.method = failingMethod;
+            this.methodArgumentsPredicate = methodArgumentsPredicate;
             this.failure = failure;
         }
 
         @Override
-        public IndexUpdateResult fetchAndUpdateIndex( final IndexUpdateRequest updateRequest )
-            throws IOException
+        public Object invoke( final Object proxy, final Method method, final Object[] args )
+            throws Throwable
         {
-            // ctx is is "${repoId}-ctx"
-            if ( updateRequest.getIndexingContext().getId().startsWith( failingRepositoryId ) )
+            if ( method.equals( this.method ) && methodArgumentsPredicate.apply( args ) )
             {
                 throw failure;
             }
             else
             {
-                return delegate.fetchAndUpdateIndex( updateRequest );
+                return super.invoke( proxy, method, args );
             }
         }
     }

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus5249IndexerManagerTest.java
@@ -1,0 +1,207 @@
+package org.sonatype.nexus.index;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.apache.maven.index.ArtifactScanningListener;
+import org.apache.maven.index.NexusIndexer;
+import org.apache.maven.index.context.IndexingContext;
+import org.apache.maven.index.updater.IndexUpdateRequest;
+import org.apache.maven.index.updater.IndexUpdateResult;
+import org.apache.maven.index.updater.IndexUpdater;
+import org.junit.Assert;
+import org.junit.Test;
+import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
+import org.sonatype.nexus.proxy.maven.MavenRepository;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.repository.ShadowRepository;
+import org.sonatype.nexus.util.CompositeException;
+
+/**
+ * Test for NEXUS-5249 and related ones (see linked issues). In general, we ensure that 404 happened during remote
+ * update does not break the batch-processing of ALL repositories (task should not stop and should go on process other
+ * repositories). Also, 401/403/50x errors will throw IOException at the processng end (and hence, make the task
+ * failed), but again, the batch is not broken due to one repo being broken, the exceptions are supressed until batch
+ * end.
+ * 
+ * @author cstamas
+ */
+public class Nexus5249IndexerManagerTest
+    extends AbstractIndexerManagerTest
+{
+    protected CountingInvocationHandler cih;
+
+    protected int getIndexableRepositories()
+    {
+        int result = 0;
+        for ( Repository repository : repositoryRegistry.getRepositories() )
+        {
+            if ( !repository.getRepositoryKind().isFacetAvailable( ShadowRepository.class )
+                && !repository.getRepositoryKind().isFacetAvailable( GroupRepository.class )
+                && repository.getRepositoryKind().isFacetAvailable( MavenRepository.class ) && repository.isIndexable() )
+            {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    protected void prepare( final IOException failure )
+        throws Exception
+    {
+        final MavenProxyRepository failingRepository = apacheSnapshots.adaptToFacet( MavenProxyRepository.class );
+        failingRepository.setDownloadRemoteIndexes( true );
+        failingRepository.commitChanges();
+
+        final IndexUpdater realUpdater = lookup( IndexUpdater.class );
+        final IndexUpdater fakeUpdater = new FakeIndexUpdater( realUpdater, failingRepository.getId(), failure );
+
+        final NexusIndexer realIndexer = lookup( NexusIndexer.class );
+        cih =
+            new CountingInvocationHandler( realIndexer, NexusIndexer.class.getMethod( "scan", new Class[] {
+                IndexingContext.class, String.class, ArtifactScanningListener.class, boolean.class } ) );
+        final NexusIndexer fakeIndexer =
+            (NexusIndexer) Proxy.newProxyInstance( getClass().getClassLoader(), new Class[] { NexusIndexer.class }, cih );
+
+        final DefaultIndexerManager dim = (DefaultIndexerManager) indexerManager;
+        dim.setIndexUpdater( fakeUpdater );
+        dim.setNexusIndexer( fakeIndexer );
+    }
+
+    @Test
+    public void remote404ResponseDoesNotFailsProcessing()
+        throws Exception
+    {
+        // HTTP 404 pops up as FileNotFoundEx
+        prepare( new FileNotFoundException( "fluke" ) );
+
+        try
+        {
+            // reindex all
+            indexerManager.reindexAllRepositories( null, false );
+
+            // we continue here as 404 should not end up with exception (is "swallowed")
+            // ensure we scanned all the repositories, even the one having 404 on remote update
+            Assert.assertEquals( getIndexableRepositories(), cih.getInvocationCount() );
+        }
+        catch ( IOException e )
+        {
+            Assert.fail( "There should be no exception thrown!" );
+        }
+    }
+
+    @Test
+    public void remoteNon404ResponseFailsProcessingAtTheEnd()
+        throws Exception
+    {
+        // HTTP 401/403/etc boils down as some other IOException
+        final IOException ex = new IOException( "something bad happened" );
+        prepare( ex );
+
+        try
+        {
+            // reindex all
+            indexerManager.reindexAllRepositories( null, false );
+
+            // the above line should throw IOex
+            Assert.fail( "There should be exception thrown!" );
+        }
+        catch ( IOException e )
+        {
+            // ensure we scanned all the repositories (minus the one failed, as it failed _BEFORE_ scan invocation)
+            Assert.assertEquals( getIndexableRepositories() - 1, cih.getInvocationCount() );
+            // ensure we have composite exception
+            Assert.assertEquals( CompositeException.class, e.getCause().getClass() );
+            // ensure we got back our bad exception
+            Assert.assertEquals( ex, ( (CompositeException) e.getCause() ).getCauses().iterator().next() );
+        }
+    }
+
+    // ==
+
+    public static class DelegatingInvocationHandler
+        implements InvocationHandler
+    {
+        private final Object delegate;
+
+        public DelegatingInvocationHandler( final Object delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke( final Object proxy, final Method method, final Object[] args )
+            throws Throwable
+        {
+            return method.invoke( delegate, args );
+        }
+    }
+
+    public static class CountingInvocationHandler
+        extends DelegatingInvocationHandler
+    {
+        private final Method method;
+
+        private int count;
+
+        public CountingInvocationHandler( final Object delegate, final Method countedMethod )
+        {
+            super( delegate );
+            this.method = countedMethod;
+            this.count = 0;
+        }
+
+        @Override
+        public Object invoke( final Object proxy, final Method method, final Object[] args )
+            throws Throwable
+        {
+            if ( method.equals( this.method ) )
+            {
+                count++;
+            }
+            return super.invoke( proxy, method, args );
+        }
+
+        public int getInvocationCount()
+        {
+            return count;
+        }
+    }
+
+    public static class FakeIndexUpdater
+        implements IndexUpdater
+    {
+        private final IndexUpdater delegate;
+
+        private final String failingRepositoryId;
+
+        private final IOException failure;
+
+        private FakeIndexUpdater( final IndexUpdater delegate, final String failingRepositoryId,
+                                  final IOException failure )
+        {
+            this.delegate = delegate;
+            this.failingRepositoryId = failingRepositoryId;
+            this.failure = failure;
+        }
+
+        @Override
+        public IndexUpdateResult fetchAndUpdateIndex( final IndexUpdateRequest updateRequest )
+            throws IOException
+        {
+            // ctx is is "${repoId}-ctx"
+            if ( updateRequest.getIndexingContext().getId().startsWith( failingRepositoryId ) )
+            {
+                throw failure;
+            }
+            else
+            {
+                return delegate.fetchAndUpdateIndex( updateRequest );
+            }
+        }
+    }
+}

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
@@ -1,0 +1,114 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.util;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A composite {@link Exception} descendant, that is able to collect multiple causes to have them throw at the end of
+ * some batch processing for example. Inspired by code from <a href=
+ * "http://stackoverflow.com/questions/12481583/exception-composition-in-java-when-both-first-strategy-and-recovery-strategy-fai"
+ * >Stack Overflow</a>.
+ * 
+ * @author cstamas
+ * @since 2.2
+ */
+public class CompositeException
+    extends Exception
+{
+    private static final long serialVersionUID = 1386505977462170509L;
+
+    private final List<Throwable> causes;
+
+    // ==
+
+    public CompositeException( final Throwable... causes )
+    {
+        this( null, causes );
+    }
+
+    public CompositeException( final String message, final Throwable... causes )
+    {
+        this( message, Arrays.asList( causes ) );
+    }
+
+    public CompositeException( final List<? extends Throwable> causes )
+    {
+        this( null, causes );
+    }
+
+    public CompositeException( final String message, final List<? extends Throwable> causes )
+    {
+        super( message );
+        final ArrayList<Throwable> c = new ArrayList<Throwable>();
+        if ( causes != null && !causes.isEmpty() )
+        {
+            c.addAll( causes );
+        }
+        this.causes = Collections.unmodifiableList( c );
+    }
+
+    public List<Throwable> getCauses()
+    {
+        return causes;
+    }
+
+    // ==
+
+    @Override
+    public void printStackTrace()
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace();
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace();
+        }
+    }
+
+    @Override
+    public void printStackTrace( final PrintStream s )
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace( s );
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace( s );
+        }
+    }
+
+    @Override
+    public void printStackTrace( final PrintWriter s )
+    {
+        if ( causes.isEmpty() )
+        {
+            super.printStackTrace( s );
+            return;
+        }
+        for ( Throwable cause : causes )
+        {
+            cause.printStackTrace( s );
+        }
+    }
+}

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/CompositeException.java
@@ -23,7 +23,11 @@ import java.util.List;
  * A composite {@link Exception} descendant, that is able to collect multiple causes to have them throw at the end of
  * some batch processing for example. Inspired by code from <a href=
  * "http://stackoverflow.com/questions/12481583/exception-composition-in-java-when-both-first-strategy-and-recovery-strategy-fai"
- * >Stack Overflow</a>.
+ * >Stack Overflow</a>. Note: this exception merely serves the purpose to hold multiple causes, but it not quite usable
+ * to log them. As today, Nexus uses SLF4J as logging API, that might be backed by any backend out of many existing
+ * (think WAR, but today logback is used) the overridden methods are not used. Hence, in case of logging
+ * {@link CompositeException}, the multiple causes will not be logged, you still need to manually log them, or process
+ * in any other way, if needed.
  * 
  * @author cstamas
  * @since 2.2

--- a/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/CompositeExceptionTest.java
+++ b/nexus/nexus-utils/src/test/java/org/sonatype/nexus/util/CompositeExceptionTest.java
@@ -1,0 +1,65 @@
+package org.sonatype.nexus.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * {@link CompositeException} unit tests.
+ * 
+ * @since 2.2
+ */
+public class CompositeExceptionTest
+{
+    /**
+     * All constructors should work with {@code null}s. But the constructor exception's causes list should never be
+     * {@code null}.
+     */
+    @Test
+    public void constructorWithNull()
+    {
+        final CompositeException c1 = new CompositeException( (Throwable) null );
+        Assert.assertNotNull( c1.getCauses() );
+        final CompositeException c2 = new CompositeException( (String) null, (Throwable) null );
+        Assert.assertNotNull( c2.getCauses() );
+        final CompositeException c3 = new CompositeException( (List<Throwable>) null );
+        Assert.assertNotNull( c3.getCauses() );
+        final CompositeException c4 = new CompositeException( (String) null, (List<Throwable>) null );
+        Assert.assertNotNull( c4.getCauses() );
+    }
+
+    /**
+     * Sanity check, is this class actually doing what is meant to do using vararg accepting constructor.
+     */
+    @Test
+    public void simpleUseVarargs()
+    {
+        final RuntimeException re = new RuntimeException( "runtime" );
+        final IOException io = new IOException( "io" );
+
+        final CompositeException ce = new CompositeException( "composite", re, io );
+
+        Assert.assertEquals( 2, ce.getCauses().size() );
+        Assert.assertEquals( re, ce.getCauses().get( 0 ) );
+        Assert.assertEquals( io, ce.getCauses().get( 1 ) );
+    }
+
+    /**
+     * Sanity check, is this class actually doing what is meant to do using list accepting constructor.
+     */
+    @Test
+    public void simpleUseList()
+    {
+        final RuntimeException re = new RuntimeException( "runtime" );
+        final IOException io = new IOException( "io" );
+
+        final CompositeException ce = new CompositeException( "composite", Arrays.asList( re, io ) );
+
+        Assert.assertEquals( 2, ce.getCauses().size() );
+        Assert.assertEquals( re, ce.getCauses().get( 0 ) );
+        Assert.assertEquals( io, ce.getCauses().get( 1 ) );
+    }
+}


### PR DESCRIPTION
This pull fixes the original issue, but also:
- still retains required behaviour from NEXUS-4275: If a remote index fails to download due to 401/403/50x problems we should end the "download index" task with a "broken" state
- implements NEXUS-3424 When remote index could not be downloaded, log stack trace only when debug is enabled
