### PR TITLE
o [NEXUS-5118] Set org.eclipse.jetty logging to INFO

### DIFF
--- a/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
+++ b/nexus/nexus-logging-extras/src/main/resources/META-INF/log/logback-nexus.xml
@@ -38,6 +38,7 @@
   <logger name="org.restlet" level="WARN" />
   <logger name="org.apache.commons" level="WARN" />
   <logger name="org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter" level="INFO" />
+  <logger name="org.eclipse.jetty" level="INFO" />
   
   <root level="${root.level}">
     <appender-ref ref="console" />


### PR DESCRIPTION
With the changes for the bundle logging, Nexus logback controls jetty logging as well. So if you set the logback.properties to DEBUG, you would also get lots of jetty logging...

Please sanity check this. Is this logback-nexus.xml used throughout the bundles or are there other places that need changes?
