### PR TITLE
o [NEXUS-5227] Set 'jettyPlexusCompatibility=true' by default

### DIFF
--- a/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -26,11 +26,12 @@ wrapper.java.classpath.3=./conf/
 wrapper.java.library.path.1=bin/jsw/lib
 
 # Additional JVM parameters (tune if needed, but match the sequence of numbers!)
-#wrapper.java.additional.1=-Xdebug
-#wrapper.java.additional.2=-Xnoagent
-#wrapper.java.additional.3=-Djava.compiler=NONE
-#wrapper.java.additional.4=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#wrapper.java.additional.5=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.1=-DjettyPlexusCompatibility=true
+#wrapper.java.additional.2=-Xdebug
+#wrapper.java.additional.3=-Xnoagent
+#wrapper.java.additional.4=-Djava.compiler=NONE
+#wrapper.java.additional.5=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#wrapper.java.additional.6=-XX:+HeapDumpOnOutOfMemoryError
 
 wrapper.app.parameter.1=./conf/jetty.xml
 


### PR DESCRIPTION
Properties were removed with the comment that all those are set in default.properties from nexus-bootstrap, but jettyPlexusCompatibility is not.
