### PR TITLE
NEXUS-5280: ContextMemberProvider should always return same list

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexingRepositoryRegistryRepositoryEventInspector.java
@@ -94,7 +94,6 @@ public class IndexingRepositoryRegistryRepositoryEventInspector
             if ( evt instanceof RepositoryRegistryEventAdd )
             {
                 getIndexerManager().addRepositoryIndexContext( repository.getId() );
-                getIndexerManager().setRepositoryIndexContextSearchable( repository.getId(), repository.isSearchable() );
             }
             else if ( evt instanceof RepositoryRegistryEventRemove )
             {


### PR DESCRIPTION
... of members.

At least during search processing is running. As it is now, it is directly
hooked onto group, that if group changed during search, causes to have
different repositories locked or unlocked. In case of member addition,
an IllegalMonitorStateEx would happen (a non-locked context would
be unlocked) and in case of member removal, the context of
removed member would remain locked.
