### PR TITLE
NEXUS-5280: ContextMemberProvider should always return same list of members

### DIFF
--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexerNexusStoppedEventInspector.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/events/IndexerNexusStoppedEventInspector.java
@@ -31,7 +31,6 @@ import org.sonatype.plexus.appevents.Event;
 public class IndexerNexusStoppedEventInspector
     extends AbstractEventInspector
 {
-
     @Requirement
     private IndexerManager indexerManager;
 
@@ -40,13 +39,12 @@ public class IndexerNexusStoppedEventInspector
         return indexerManager;
     }
 
-    public boolean accepts( Event<?> evt )
+    public boolean accepts( final Event<?> evt )
     {
-        // listen for STORE, CACHE, DELETE only
-        return ( NexusStoppedEvent.class.isAssignableFrom( evt.getClass() ) );
+        return evt instanceof NexusStoppedEvent;
     }
 
-    public void inspect( Event<?> evt )
+    public void inspect( final Event<?> evt )
     {
         try
         {

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -409,7 +409,7 @@ public class DefaultIndexerManager
     public void updateRepositoryIndexContext( String repositoryId )
         throws IOException, NoSuchRepositoryException
     {
-        Repository repository = repositoryRegistry.getRepository( repositoryId );
+        final Repository repository = repositoryRegistry.getRepository( repositoryId );
 
         Lock lock = getLock( repository.getId() ).writeLock();
         lock.lock();
@@ -440,15 +440,19 @@ public class DefaultIndexerManager
             // get context for repository, check is change needed
             IndexingContext ctx = getRepositoryIndexContext( repository );
 
+            boolean propagateChangesToGroupsOfRepository = false;
+
             // remove context, if it already existed (ctx != null) and any of the following is true:
             // is a group OR repo path changed OR we have an isIndexed transition happening
             if ( ctx != null
                 && ( repository.getRepositoryKind().isFacetAvailable( GroupRepository.class )
-                    || !ctx.getRepository().getAbsolutePath().equals( repoRoot.getAbsolutePath() ) || ctx.isSearchable() != repository.isSearchable() ) )
+                    || !ctx.getRepository().getAbsolutePath().equals( repoRoot.getAbsolutePath() )
+                    || !repository.isIndexable() || ctx.isSearchable() != repository.isSearchable() ) )
             {
                 // remove the context
                 removeRepositoryIndexContext( repositoryId, false );
                 ctx = null;
+                propagateChangesToGroupsOfRepository = true;
             }
 
             // add context, if it did not existed yet (ctx == null) or any of the following is true:
@@ -457,6 +461,18 @@ public class DefaultIndexerManager
             {
                 // recreate the context
                 addRepositoryIndexContext( repositoryId );
+                propagateChangesToGroupsOfRepository = true;
+            }
+
+            if ( propagateChangesToGroupsOfRepository )
+            {
+                // propagate changes to the repositor's groups (where it is a member)
+                // as a "stale" context would remain in the list returned by ContextMemberProvider
+                final List<GroupRepository> groupsOfRepository = repositoryRegistry.getGroupsOfRepository( repository );
+                for ( GroupRepository group : groupsOfRepository )
+                {
+                    updateRepositoryIndexContext( group.getId() );
+                }
             }
         }
         finally

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -340,20 +340,12 @@ public class DefaultIndexerManager
                     repositoryRegistry.getRepositoryWithFacet( repositoryId, GroupRepository.class );
 
                 final File repoRoot = getRepositoryLocalStorageAsFile( repository );
-                final List<IndexingContext> memberContexts =
-                    Collections.unmodifiableList( getMemberIndexingContexts( groupRepository ) );
-                final ContextMemberProvider localCtxProvider = new ContextMemberProvider()
-                {
-                    @Override
-                    public Collection<IndexingContext> getMembers()
-                    {
-                        return memberContexts;
-                    }
-                };
-
+                // a lazy context provider
+                final LazyContextMemberProvider memberContextProvider =
+                    new LazyContextMemberProvider( this, groupRepository.getMemberRepositoryIds() );
                 ctx =
                     nexusIndexer.addMergedIndexingContext( getContextId( repository.getId() ), repository.getId(),
-                        repoRoot, indexDirectory, repository.isSearchable(), localCtxProvider );
+                        repoRoot, indexDirectory, repository.isSearchable(), memberContextProvider );
                 ctx.setSearchable( repository.isSearchable() );
             }
             else
@@ -524,21 +516,6 @@ public class DefaultIndexerManager
 
             ctx.setSearchable( searchable );
         }
-    }
-
-    protected List<IndexingContext> getMemberIndexingContexts( final GroupRepository groupRepository )
-    {
-        final List<Repository> members = groupRepository.getMemberRepositories();
-        final ArrayList<IndexingContext> result = new ArrayList<IndexingContext>( members.size() );
-        for ( Repository member : members )
-        {
-            final IndexingContext ctx = getRepositoryIndexContext( member );
-            if ( ctx != null )
-            {
-                result.add( ctx );
-            }
-        }
-        return result;
     }
 
     /**

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/LazyContextMemberProvider.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/LazyContextMemberProvider.java
@@ -1,0 +1,81 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.index;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.index.context.ContextMemberProvider;
+import org.apache.maven.index.context.IndexingContext;
+import org.sonatype.nexus.proxy.NoSuchRepositoryException;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * A lazy {@link ContextMemberProvider} that uses a fixed list of members, but fetches {@link IndexingContext} on
+ * demand. This is needed as without being lazy, Nexus looses it's capability to load up Nexus XML configuration that
+ * has forward references in groups of groups (ie. a group references another group as member that is not yet loaded
+ * up), as without being lazy, it ends up with {@link NoSuchRepositoryException}, in a moment method
+ * {@link GroupRepository#getMemberRepositories()} is invoked. When needed (group member change, member indexing
+ * disabled), this instance will be replaced anyway, as IndexingManager will update the contexts. All this
+ * {@link ContextMemberProvider} needs to do for us is to defer "resolving" repository ID and trying to grab the
+ * {@link IndexingContext} to as late as possible, but we need to created it early, as part of boot. Another approach
+ * would be to "rewire" all the contexts upon Nexus boot, but that would require more changes in {@link IndexerManager}
+ * itself.
+ * 
+ * @since 2.2
+ * @author cstamas
+ */
+public class LazyContextMemberProvider
+    implements ContextMemberProvider
+{
+    private final DefaultIndexerManager indexerManager;
+
+    private final List<String> memberIds;
+
+    private Collection<IndexingContext> contexts;
+
+    public LazyContextMemberProvider( final DefaultIndexerManager indexerManager, final List<String> memberIds )
+    {
+        this.indexerManager = Preconditions.checkNotNull( indexerManager );
+        this.memberIds = Preconditions.checkNotNull( memberIds );
+    }
+
+    @Override
+    public synchronized Collection<IndexingContext> getMembers()
+    {
+        if ( contexts == null )
+        {
+            contexts = new ArrayList<IndexingContext>( memberIds.size() );
+            for ( String member : memberIds )
+            {
+                try
+                {
+                    final IndexingContext indexingContext = indexerManager.getRepositoryIndexContext( member );
+                    if ( indexingContext != null )
+                    {
+                        contexts.add( indexingContext );
+                    }
+                }
+                catch ( NoSuchRepositoryException e )
+                {
+
+                }
+            }
+        }
+        return contexts;
+    }
+
+}

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/GroupUpdateIndexerManagerIT.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/GroupUpdateIndexerManagerIT.java
@@ -20,9 +20,9 @@ import org.sonatype.nexus.proxy.repository.GroupRepository;
 import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
- * UT for Indexer related to Group repositories.
+ * IT for Indexer related to Group repositories.
  */
-public class GroupUpdateIndexerManagerTest
+public class GroupUpdateIndexerManagerIT
     extends AbstractIndexerManagerTest
 {
 

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/GroupUpdateIndexerManagerTest.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/GroupUpdateIndexerManagerTest.java
@@ -14,8 +14,10 @@ package org.sonatype.nexus.index;
 
 import junit.framework.Assert;
 
+import org.apache.maven.index.context.ContextMemberProvider;
 import org.junit.Test;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
 
 /**
  * UT for Indexer related to Group repositories.
@@ -96,4 +98,76 @@ public class GroupUpdateIndexerManagerTest
         searchFor( "org.sonatype.test-evict", 1, "apache-snapshots" ); // is in this repo
         searchFor( "org.sonatype.test-evict", 1, group.getId() ); // apache-snapshots is a member of public
     }
+
+    /**
+     * Testing is a group member's configuration change correctly propagated to Maven Indexer IndexingContexts. This
+     * propagation become needed as {@link ContextMemberProvider} implementations were changed to serve up unmodified
+     * pre-built lists. But in special case that is NOT member removal (config change made on group, see above), but
+     * rather making a repository non-indexable (config change made against one of the member), the context of given
+     * member repo is being shut down and removed. Hence, the list returned by ContextMemberProvider needs change too,
+     * as it would return a "shut down" context.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testGroupMemberUpdate()
+        throws Exception
+    {
+        // add repo content
+        fillInRepo();
+
+        // our patients, group and one member
+        final GroupRepository group = (GroupRepository) repositoryRegistry.getRepository( "public" );
+        final Repository member = repositoryRegistry.getRepository( "snapshots" );
+
+        // reindex
+        indexerManager.reindexAllRepositories( null, true );
+
+        // Note: public by default contains snapshots repository as member
+        // Snapshots repository is the only one that contains GroupID "org.sonatype.plexus".
+        // Meaning, the presence of this search (is in result set or not) is used
+        // to validate the group member changes.
+
+        // assure context does exists (if Igor comments out few lines or so, as MI will plainly swallow targeted search
+        // against nonexistent context!)
+        Assert.assertNotNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( group ) );
+        Assert.assertNotNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( member ) );
+
+        // do searches
+        searchFor( "org.sonatype.plexus", 1, member.getId() ); // is in this repo
+        searchFor( "org.sonatype.plexus", 1, group.getId() ); // snapshots is member of public
+
+        // reconfigure group member: make it non-indexable
+        member.setSearchable( false );
+        member.setIndexable( false );
+        nexusConfiguration.saveConfiguration();
+        waitForTasksToStop();
+        wairForAsyncEventsToCalmDown();
+
+        // assure context does exists (if Igor comments out few lines or so, as MI will plainly swallow targeted search
+        // against nonexistent context!)
+        Assert.assertNotNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( group ) );
+        Assert.assertNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( member ) );
+
+        // do searches
+        searchFor( "org.sonatype.plexus", 0, member.getId() ); // is in this repo
+        searchFor( "org.sonatype.plexus", 0, group.getId() ); // snapshots is not member of public
+
+        // reconfigure group: add apache-snapshots
+        member.setSearchable( true );
+        member.setIndexable( true );
+        nexusConfiguration.saveConfiguration();
+        waitForTasksToStop();
+        wairForAsyncEventsToCalmDown();
+
+        // assure context does exists (if Igor comments out few lines or so, as MI will plainly swallow targeted search
+        // against nonexistent context!)
+        Assert.assertNotNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( group ) );
+        Assert.assertNotNull( ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( member ) );
+
+        // do searches
+        searchFor( "org.sonatype.plexus", 1, member.getId() ); // is in this repo
+        searchFor( "org.sonatype.plexus", 1, group.getId() ); // snapshots is not member of public
+    }
+
 }


### PR DESCRIPTION
But, we forgot to handle a special case: there is one case, when instead
of the group member change, a member configuration change might cause that
group context list MUST change, the groups
ContextMemberProvider pre-built list must change: that when
Repository#setIndexable() is changed (if change from true to false, context
is removed from NexusIndexer, if changed from false to true, context is being
created). This case was not handled, and groups (who's member was made
non-indexable) was still containing and handing over a "stale", already
shut down context to indexer components.

In other words, with original change, the list remain unchanged, even if the context was
shut down and removed from NexusIndexer, but group continued to use it, that
caused NPE (IndexSearcher is closed and nullified on shut down contexts),
but also some cleanup problem exists in MI and NPE caused IllegalMonitorState
(NPE happened during locking, so not all context were actually locked,
but against all were unlock tried).

Now, repository updates are propagated to groups where it is contained.

Added UT that tests exactly this case: making a repo from indexable
to non-indexable and back to indexable, while verifying that it's group
is not running into those sort of problems.

CI:
https://builds.sonatype.org/view/nexus-features/job/nexus-oss-its-feature/426/
