### PR TITLE
Let UI logging also use the LogHelper resource

### DIFF
--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/ithelper/log/LogHelperNexusIndexHtmlCustomizer.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/ithelper/log/LogHelperNexusIndexHtmlCustomizer.java
@@ -1,0 +1,40 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.ithelper.log;
+
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.plugins.rest.AbstractNexusIndexHtmlCustomizer;
+
+/**
+ * This customizer adds Nexus.Log.js to the Nexus UI.
+ */
+@Named
+@Singleton
+public class LogHelperNexusIndexHtmlCustomizer
+    extends AbstractNexusIndexHtmlCustomizer
+{
+
+    @Override
+    public String getPostHeadContribution( final Map<String, Object> context )
+    {
+        final String version =
+            getVersionFromJarFile( "/META-INF/maven/org.sonatype.nexus/nexus-it-helper-plugin/pom.properties" );
+
+        return "<script src=\"static/loghelper/js/Nexus.Log.js?" + version +
+            "\" type=\"text/javascript\" charset=\"utf-8\"></script>";
+    }
+}

--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/resources/static/loghelper/js/Nexus.Log.js
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/resources/static/loghelper/js/Nexus.Log.js
@@ -1,0 +1,43 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+/*global Ext, Sonatype, Nexus*/
+
+(function() {
+  var
+        log = function(level, msg) {
+          Ext.Ajax.request({
+            url : Sonatype.config.servicePath + "/loghelper?loggerName=Nexus.ui&level=" + level + "&message=" + msg,
+            suppressStatus : true
+          });
+        },
+        curry = function(fn, arg) {
+          var array = [arg];
+          return function()
+          {
+            // arguments is not a real array, concat et. al. won't work
+            Ext.each(arguments, function(item) {
+              array.push(item);
+            });
+
+            fn.apply(this, array);
+          };
+        };
+
+  Nexus.Log.debug = Nexus.Log.debug.createSequence(curry(log, 'DEBUG'));
+  Nexus.Log.info = Nexus.Log.info.createSequence(curry(log, "INFO"));
+  Nexus.Log.warn = Nexus.Log.warn.createSequence(curry(log, "WARN"));
+  Nexus.Log.error = Nexus.Log.error.createSequence(curry(log, "ERROR"));
+  Nexus.log = Nexus.log.createSequence(curry(log, "DEBUG"));
+
+}());


### PR DESCRIPTION
This change lets UI log to the nexus.log file when the it-helper plugin is installed.

Useful IMO because you can get real debug logging (if used in the UI, ATM it's only usertoken that uses this), but it potentially adds many GET requests to the loghelper resource when clicking through the UI.
