### PR TITLE
NEXUS-5288: Appender class changed.

### DIFF
--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LogConfigurationParticipant.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/LogConfigurationParticipant.java
@@ -14,11 +14,28 @@ package org.sonatype.nexus.log;
 
 import java.io.InputStream;
 
+/**
+ * A component contract that wants to provide extra logging configuration, participate in configuration of logging in
+ * Nexus.
+ * 
+ * @author adreghiciu
+ */
 public interface LogConfigurationParticipant
 {
-    
     String getName();
 
     InputStream getConfiguration();
 
+    /**
+     * Marker interface to be implemented by {@link LogConfigurationParticipant} instances that provide configurations
+     * which should not be tampered with, changed by users. These participant configurations will be written out
+     * (probably overwriting existing file) always, at every boot.
+     * 
+     * @author cstamas
+     * @since 2.2
+     */
+    public interface NonEditable
+    {
+
+    }
 }

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackLogManager.java
@@ -397,7 +397,7 @@ public class LogbackLogManager
             {
                 String name = participant.getName();
                 File logConfigFile = new File( logConfigDir, name );
-                if ( !logConfigFile.exists() )
+                if ( participant instanceof LogConfigurationParticipant.NonEditable || !logConfigFile.exists() )
                 {
                     InputStream in = null;
                     try

--- a/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackNexusEventSystemLogConfigurationParticipant.java
+++ b/nexus/nexus-logging-extras/src/main/java/org/sonatype/nexus/log/internal/LogbackNexusEventSystemLogConfigurationParticipant.java
@@ -26,7 +26,7 @@ import org.sonatype.nexus.log.LogConfigurationParticipant;
  */
 @Component( role = LogConfigurationParticipant.class, hint="logback-events" )
 public class LogbackNexusEventSystemLogConfigurationParticipant
-    implements LogConfigurationParticipant
+    implements LogConfigurationParticipant, LogConfigurationParticipant.NonEditable
 {
     
     


### PR DESCRIPTION
The appender did change between 2.1 and 2.2. Problem with
"upgrade step" is that log manager is started from a servlet
context listener, way before nexus is, hence, nexus upgrade
step would be able to do anything way after logback configuration
is loaded (and errors would be emitted about Appender).

After chatting with Alin, this looked the simplest: introduce
a marker interface, that would be implemented by those
implementations of LogConfigurationParticipant, that does NOT
want to let users tamper with their configuration. Event system
config participant is such LogConfigurationParticipant (see it's
config file, states "DO NOT EDIT").

When LogbackLogManager detects that a participant implements this
marker interface, it will not check for config file existence
(as it happened before this change) and write it out when not present,
but it will "blindly", always write it out, potentially replacing
the changed file.

Now, the LogbackNexusEventSystemLogConfigurationParticipant implements
the NonEditable marker interface and this resolves the problem,
as on upgrade (from X to 2.2), 2.2 will simply overwrite the
logback-event.xml.
