### PR TITLE
HttpClient 4x being slow with HTTPS connections.

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -911,7 +911,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.1.2</version>
+        <version>4.2.1</version>
         <type>jar</type>
         <exclusions>
           <exclusion>
@@ -919,6 +919,18 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpmime</artifactId>
+        <version>4.2.1</version>
+        <type>jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.2.2</version>
+        <type>jar</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Changes in here:
- bumped version to httpclient 4.2.1 + httpcore 4.2.2 (latest GA)
- applied recommended changes to connManager, parameters handling
- catching IllegalStateException thrown by httpClient connmgr in case when JVM lacks support for TLS (was swallowed without this!)
- removing explicit connection close, to make use of pooling
- hostname verification for HTTPS connections (new in HC4x, not done by HC3x!) left in place, but due to pooling it is made only once, when connection created and not after it (when connection is reused).

These changes makes the originally 2.5x times slower HC4 (vs HC3) against HTTPS servers about 3.0x times faster!

Related issue: https://issues.sonatype.org/browse/NEXUS-5291
