### PR TITLE
[NEXUS-5294] Display warning and disable save for users from external realms

### DIFF
--- a/nexus/nexus-webapp/src/main/webapp/js/nexus/profile/Summary.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/nexus/profile/Summary.js
@@ -30,6 +30,15 @@ Nexus.profile.Summary = function(config) {
 
   items = [
     {
+      // NEXUS-5294 Disable Save for external users
+      xtype : 'panel',
+      cls : 'x-form-invalid-msg',
+      border : false,
+      html : 'Externally configured users are read-only (' + Sonatype.user.curr.loggedInUserSource + ')',
+      hidden : !isExternalUser,
+      width : this.FIELD_WIDTH * 2
+    },
+    {
       xtype : 'textfield',
       fieldLabel : 'User ID',
       itemCls : 'required-field',
@@ -130,6 +139,11 @@ Nexus.profile.Summary = function(config) {
   // otherwise, `payload.data.resourceUri` is used as is.
   this.payload = {
     id : this.username
+  };
+
+  // NEXUS-5294 Disable Save for external users
+  this.isValid = function() {
+    return !isExternalUser && Nexus.profile.Summary.superclass.isValid.apply(this, arguments);
   };
 
   // mandatory call


### PR DESCRIPTION
External users had all fields disabled but still could save their data,
resulting in a message box stating that LDAP is a read-only realm.

This pull adds a warning message above all fields that external users are read-only, and disables 'Save' functionality.

I scheduled [the issue](https://issues.sonatype.org/browse/NEXUS-5294) as 2.2/next because it's an easy "fix" but does not need to go into 2.2.
