### PR TITLE
NEXUS-5292: Implemented connection eviction

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/ConnectionPoolEvictingThread.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/ConnectionPoolEvictingThread.java
@@ -1,0 +1,103 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.storage.remote.httpclient;
+
+import java.util.HashMap;
+
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Low priority daemon thread responsible to evic connection manager pools of HttpClient instances that were created
+ * with {@link HttpClientUtil} class.
+ * 
+ * @author cstamas
+ * @since 2.2
+ */
+class ConnectionPoolEvictingThread
+    extends Thread
+{
+    final static ConnectionPoolEvictingThread INSTANCE = new ConnectionPoolEvictingThread();
+
+    private final HashMap<String, HttpClient> managedClients;
+
+    private final Logger logger;
+
+    private ConnectionPoolEvictingThread()
+    {
+        super( "HC4x-ConnectionPoolEvictingThread" );
+        setDaemon( true );
+        setPriority( MIN_PRIORITY );
+        this.logger = LoggerFactory.getLogger( getClass() );
+        this.managedClients = new HashMap<String, HttpClient>();
+        logger.info( "Starting connection pool evicting thread..." );
+        start();
+    }
+
+    public synchronized HttpClient register( final HttpClient client )
+    {
+        final Object id = client.getParams().getParameter( HttpClientUtil.CLIENT_ID_KEY );
+        if ( id != null )
+        {
+            logger.debug( "Instance {} registered for eviction.", HttpClientUtil.getHttpClientDescription( client ) );
+            return managedClients.put( String.valueOf( id ), client );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "This is not a managed HTTPClient instance!" );
+        }
+    }
+
+    public synchronized HttpClient unregister( final HttpClient client )
+    {
+        final Object id = client.getParams().getParameter( HttpClientUtil.CLIENT_ID_KEY );
+        if ( id != null )
+        {
+            logger.debug( "Instance {} unregistered from eviction.", HttpClientUtil.getHttpClientDescription( client ) );
+            return managedClients.remove( String.valueOf( id ) );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "This is not a managed HTTPClient instance!" );
+        }
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            while ( true )
+            {
+                Thread.sleep( 5000 );
+                synchronized ( this )
+                {
+                    for ( HttpClient managedClient : managedClients.values() )
+                    {
+                        if ( logger.isTraceEnabled() )
+                        {
+                            logger.trace( "Evicting pool of instance {}.",
+                                HttpClientUtil.getHttpClientDescription( managedClient ) );
+                        }
+                        HttpClientUtil.evictConnectionManagerPool( managedClient );
+                    }
+                }
+            }
+        }
+        catch ( InterruptedException e )
+        {
+            // bye bye
+        }
+    }
+}

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
@@ -410,7 +410,7 @@ public class HttpClientRemoteStorage
         try
         {
             // and create a new one
-            HttpClientUtil.configure( CTX_KEY, ctx, getLogger() );
+            HttpClientUtil.configure( repository, CTX_KEY, ctx, getLogger() );
         }
         catch ( IllegalStateException e )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientRemoteStorage.java
@@ -67,7 +67,7 @@ import com.google.common.base.Stopwatch;
 
 /**
  * Apache HTTP client (4) {@link RemoteRepositoryStorage} implementation.
- *
+ * 
  * @since 2.0
  */
 @Named( HttpClientRemoteStorage.PROVIDER_STRING )
@@ -116,8 +116,8 @@ public class HttpClientRemoteStorage
 
     @Inject
     HttpClientRemoteStorage( final UserAgentBuilder userAgentBuilder,
-                             final ApplicationStatusSource applicationStatusSource,
-                             final MimeSupport mimeSupport, QueryStringBuilder queryStringBuilder)
+                             final ApplicationStatusSource applicationStatusSource, final MimeSupport mimeSupport,
+                             QueryStringBuilder queryStringBuilder )
     {
         super( userAgentBuilder, applicationStatusSource, mimeSupport );
         this.queryStringBuilder = queryStringBuilder;
@@ -134,8 +134,7 @@ public class HttpClientRemoteStorage
     }
 
     @Override
-    public AbstractStorageItem retrieveItem( final ProxyRepository repository,
-                                             final ResourceStoreRequest request,
+    public AbstractStorageItem retrieveItem( final ProxyRepository repository, final ResourceStoreRequest request,
                                              final String baseUrl )
         throws ItemNotFoundException, RemoteStorageException
     {
@@ -170,14 +169,14 @@ public class HttpClientRemoteStorage
                 String mimeType = ContentType.getOrDefault( httpResponse.getEntity() ).getMimeType();
                 if ( mimeType == null )
                 {
-                    mimeType = getMimeSupport().guessMimeTypeFromPath(
-                        repository.getMimeRulesSource(), request.getRequestPath()
-                    );
+                    mimeType =
+                        getMimeSupport().guessMimeTypeFromPath( repository.getMimeRulesSource(),
+                            request.getRequestPath() );
                 }
 
-                final DefaultStorageFileItem httpItem = new DefaultStorageFileItem(
-                    repository, request, CAN_READ, CAN_WRITE, new PreparedContentLocator( is, mimeType )
-                );
+                final DefaultStorageFileItem httpItem =
+                    new DefaultStorageFileItem( repository, request, CAN_READ, CAN_WRITE, new PreparedContentLocator(
+                        is, mimeType ) );
 
                 if ( httpResponse.getEntity().getContentLength() != -1 )
                 {
@@ -194,9 +193,8 @@ public class HttpClientRemoteStorage
             {
                 release( httpResponse );
                 throw new RemoteStorageException( "IO Error during response stream handling [repositoryId=\""
-                                                      + repository.getId() + "\", requestPath=\""
-                                                      + request.getRequestPath() + "\", remoteUrl=\""
-                                                      + remoteURL.toString() + "\"]!", ex );
+                    + repository.getId() + "\", requestPath=\"" + request.getRequestPath() + "\", remoteUrl=\""
+                    + remoteURL.toString() + "\"]!", ex );
             }
             catch ( RuntimeException ex )
             {
@@ -213,8 +211,8 @@ public class HttpClientRemoteStorage
                     "The remoteURL we requested does not exists on remote server (remoteUrl=\"" + remoteURL.toString()
                         + "\", response code is 404)", request, repository );
             }
-            else if ( httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_MOVED_TEMPORARILY ||
-                httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_MOVED_PERMANENTLY )
+            else if ( httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_MOVED_TEMPORARILY
+                || httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_MOVED_PERMANENTLY )
             {
                 // NEXUS-5125 unfollowed redirect means collection (path.endsWith("/"))
                 // see also HttpClientUtil#configure
@@ -224,16 +222,16 @@ public class HttpClientRemoteStorage
             }
             else
             {
-                throw new RemoteStorageException( "The method execution returned result code " + httpResponse.getStatusLine().getStatusCode()
-                    + " (expected 200). [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
-                    + "\", remoteUrl=\"" + remoteURL.toString() + "\"]" );
+                throw new RemoteStorageException( "The method execution returned result code "
+                    + httpResponse.getStatusLine().getStatusCode() + " (expected 200). [repositoryId=\""
+                    + repository.getId() + "\", requestPath=\"" + request.getRequestPath() + "\", remoteUrl=\""
+                    + remoteURL.toString() + "\"]" );
             }
         }
     }
 
     @Override
-    public void storeItem( final ProxyRepository repository,
-                           final StorageItem item )
+    public void storeItem( final ProxyRepository repository, final StorageItem item )
         throws UnsupportedStorageOperationException, RemoteStorageException
     {
         if ( !( item instanceof StorageFileItem ) )
@@ -256,14 +254,9 @@ public class HttpClientRemoteStorage
         }
         catch ( IOException e )
         {
-            throw new RemoteStorageException(
-                e.getMessage()
-                    + " [repositoryId=\"" + repository.getId()
-                    + "\", requestPath=\"" + request.getRequestPath()
-                    + "\", remoteUrl=\"" + remoteUrl.toString()
-                    + "\"]",
-                e
-            );
+            throw new RemoteStorageException( e.getMessage() + " [repositoryId=\"" + repository.getId()
+                + "\", requestPath=\"" + request.getRequestPath() + "\", remoteUrl=\"" + remoteUrl.toString() + "\"]",
+                e );
         }
 
         entity.setContentType( fileItem.getMimeType() );
@@ -276,18 +269,14 @@ public class HttpClientRemoteStorage
             && statusCode != HttpStatus.SC_NO_CONTENT && statusCode != HttpStatus.SC_ACCEPTED )
         {
             throw new RemoteStorageException( "Unexpected response code while executing " + method.getMethod()
-                                                  + " method [repositoryId=\"" + repository.getId()
-                                                  + "\", requestPath=\"" + request.getRequestPath()
-                                                  + "\", remoteUrl=\"" + remoteUrl.toString()
-                                                  + "\"]. Expected: \"any success (2xx)\". Received: "
-                                                  + statusCode + " : "
-                                                  + httpResponse.getStatusLine().getReasonPhrase() );
+                + " method [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                + "\", remoteUrl=\"" + remoteUrl.toString() + "\"]. Expected: \"any success (2xx)\". Received: "
+                + statusCode + " : " + httpResponse.getStatusLine().getReasonPhrase() );
         }
     }
 
     @Override
-    public void deleteItem( final ProxyRepository repository,
-                            final ResourceStoreRequest request )
+    public void deleteItem( final ProxyRepository repository, final ResourceStoreRequest request )
         throws ItemNotFoundException, UnsupportedStorageOperationException, RemoteStorageException
     {
         final URL remoteUrl = appendQueryString( getAbsoluteUrlFromBase( repository, request ), repository );
@@ -297,24 +286,19 @@ public class HttpClientRemoteStorage
         final HttpResponse httpResponse = executeRequestAndRelease( repository, request, method );
         final int statusCode = httpResponse.getStatusLine().getStatusCode();
 
-        if ( statusCode != HttpStatus.SC_OK
-            && statusCode != HttpStatus.SC_NO_CONTENT
+        if ( statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_NO_CONTENT
             && statusCode != HttpStatus.SC_ACCEPTED )
         {
             throw new RemoteStorageException( "The response to HTTP " + method.getMethod()
-                                                  + " was unexpected HTTP Code " + statusCode + " : "
-                                                  + httpResponse.getStatusLine().getReasonPhrase()
-                                                  + " [repositoryId=\"" + repository.getId() + "\", requestPath=\""
-                                                  + request.getRequestPath()
-                                                  + "\", remoteUrl=\"" + remoteUrl.toString() + "\"]" );
+                + " was unexpected HTTP Code " + statusCode + " : " + httpResponse.getStatusLine().getReasonPhrase()
+                + " [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                + "\", remoteUrl=\"" + remoteUrl.toString() + "\"]" );
         }
     }
 
     @Override
-    protected boolean checkRemoteAvailability( final long newerThen,
-                                               final ProxyRepository repository,
-                                               final ResourceStoreRequest request,
-                                               final boolean isStrict )
+    protected boolean checkRemoteAvailability( final long newerThen, final ProxyRepository repository,
+                                               final ResourceStoreRequest request, final boolean isStrict )
         throws RemoteStorageException
     {
         final URL remoteUrl = appendQueryString( getAbsoluteUrlFromBase( repository, request ), repository );
@@ -390,12 +374,9 @@ public class HttpClientRemoteStorage
             else
             {
                 throw new RemoteStorageException( "Unexpected response code while executing " + method.getMethod()
-                                                      + " method [repositoryId=\"" + repository.getId()
-                                                      + "\", requestPath=\"" + request.getRequestPath()
-                                                      + "\", remoteUrl=\"" + remoteUrl.toString()
-                                                      + "\"]. Expected: \"SUCCESS (200)\". Received: "
-                                                      + statusCode + " : " +
-                                                      httpResponse.getStatusLine().getReasonPhrase() );
+                    + " method [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                    + "\", remoteUrl=\"" + remoteUrl.toString() + "\"]. Expected: \"SUCCESS (200)\". Received: "
+                    + statusCode + " : " + httpResponse.getStatusLine().getReasonPhrase() );
             }
         }
     }
@@ -431,18 +412,17 @@ public class HttpClientRemoteStorage
     /**
      * Executes the HTTP request.
      * <p/>
-     * In case of any exception thrown by HttpClient, it will release the connection. In other cases it
-     * is the duty of caller to do it, or process the input stream.
-     *
-     * @param repository  to execute the HTTP method fpr
-     * @param request     resource store request that triggered the HTTP request
+     * In case of any exception thrown by HttpClient, it will release the connection. In other cases it is the duty of
+     * caller to do it, or process the input stream.
+     * 
+     * @param repository to execute the HTTP method fpr
+     * @param request resource store request that triggered the HTTP request
      * @param httpRequest HTTP request to be executed
      * @return response of making the request
      * @throws RemoteStorageException If an error occurred during execution of HTTP request
      */
     @VisibleForTesting
-    HttpResponse executeRequest( final ProxyRepository repository,
-                                 final ResourceStoreRequest request,
+    HttpResponse executeRequest( final ProxyRepository repository, final ResourceStoreRequest request,
                                  final HttpUriRequest httpRequest )
         throws RemoteStorageException
     {
@@ -456,16 +436,13 @@ public class HttpClientRemoteStorage
             if ( stopwatch != null )
             {
                 stopwatch.stop();
-                timingLog.debug(
-                    "[{}] {} {} took {}",
-                    new Object[]{ repository.getId(), httpRequest.getMethod(), httpRequest.getURI(), stopwatch }
-                );
+                timingLog.debug( "[{}] {} {} took {}", new Object[] { repository.getId(), httpRequest.getMethod(),
+                    httpRequest.getURI(), stopwatch } );
             }
         }
     }
 
-    private HttpResponse doExecuteRequest( final ProxyRepository repository,
-                                           final ResourceStoreRequest request,
+    private HttpResponse doExecuteRequest( final ProxyRepository repository, final ResourceStoreRequest request,
                                            final HttpUriRequest httpRequest )
         throws RemoteStorageException
     {
@@ -474,8 +451,7 @@ public class HttpClientRemoteStorage
         if ( getLogger().isDebugEnabled() )
         {
             getLogger().debug(
-                "Invoking HTTP " + httpRequest.getMethod() + " method against remote location " + methodUri
-            );
+                "Invoking HTTP " + httpRequest.getMethod() + " method against remote location " + methodUri );
         }
 
         final RemoteStorageContext ctx = getRemoteStorageContext( repository );
@@ -495,9 +471,8 @@ public class HttpClientRemoteStorage
             final int statusCode = httpResponse.getStatusLine().getStatusCode();
 
             final Header httpServerHeader = httpResponse.getFirstHeader( "server" );
-            checkForRemotePeerAmazonS3Storage(
-                repository, httpServerHeader == null ? null : httpServerHeader.getValue()
-            );
+            checkForRemotePeerAmazonS3Storage( repository,
+                httpServerHeader == null ? null : httpServerHeader.getValue() );
 
             Header proxyReturnedErrorHeader = httpResponse.getFirstHeader( NEXUS_MISSING_ARTIFACT_HEADER );
             boolean proxyReturnedError =
@@ -505,21 +480,18 @@ public class HttpClientRemoteStorage
 
             if ( statusCode == HttpStatus.SC_FORBIDDEN )
             {
-                throw new RemoteAccessDeniedException(
-                    repository, methodUri.toASCIIString(), httpResponse.getStatusLine().getReasonPhrase()
-                );
+                throw new RemoteAccessDeniedException( repository, methodUri.toASCIIString(),
+                    httpResponse.getStatusLine().getReasonPhrase() );
             }
             else if ( statusCode == HttpStatus.SC_UNAUTHORIZED )
             {
-                throw new RemoteAuthenticationNeededException(
-                    repository, httpResponse.getStatusLine().getReasonPhrase()
-                );
+                throw new RemoteAuthenticationNeededException( repository,
+                    httpResponse.getStatusLine().getReasonPhrase() );
             }
             else if ( statusCode == HttpStatus.SC_OK && proxyReturnedError )
             {
                 throw new RemoteStorageException(
-                    "Invalid artifact found, most likely a proxy redirected to an HTML error page."
-                );
+                    "Invalid artifact found, most likely a proxy redirected to an HTML error page." );
             }
 
             return httpResponse;
@@ -533,32 +505,29 @@ public class HttpClientRemoteStorage
         {
             release( httpResponse );
             throw new RemoteStorageException( "Protocol error while executing " + httpRequest.getMethod()
-                                                  + " method. [repositoryId=\"" + repository.getId()
-                                                  + "\", requestPath=\"" + request.getRequestPath()
-                                                  + "\", remoteUrl=\"" + methodUri.toASCIIString() + "\"]", ex );
+                + " method. [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                + "\", remoteUrl=\"" + methodUri.toASCIIString() + "\"]", ex );
         }
         catch ( IOException ex )
         {
             release( httpResponse );
             throw new RemoteStorageException( "Transport error while executing " + httpRequest.getMethod()
-                                                  + " method [repositoryId=\"" + repository.getId()
-                                                  + "\", requestPath=\"" + request.getRequestPath()
-                                                  + "\", remoteUrl=\"" + methodUri.toASCIIString() + "\"]", ex );
+                + " method [repositoryId=\"" + repository.getId() + "\", requestPath=\"" + request.getRequestPath()
+                + "\", remoteUrl=\"" + methodUri.toASCIIString() + "\"]", ex );
         }
     }
 
     /**
      * Executes the HTTP request and automatically releases any related resources.
-     *
-     * @param repository  to execute the HTTP method fpr
-     * @param request     resource store request that triggered the HTTP request
+     * 
+     * @param repository to execute the HTTP method fpr
+     * @param request resource store request that triggered the HTTP request
      * @param httpRequest HTTP request to be executed
      * @return response of making the request
      * @throws RemoteStorageException If an error occurred during execution of HTTP request
      */
     private HttpResponse executeRequestAndRelease( final ProxyRepository repository,
-                                                   final ResourceStoreRequest request,
-                                                   final HttpUriRequest httpRequest )
+                                                   final ResourceStoreRequest request, final HttpUriRequest httpRequest )
         throws RemoteStorageException
     {
         final HttpResponse httpResponse = executeRequest( repository, request, httpRequest );
@@ -568,7 +537,7 @@ public class HttpClientRemoteStorage
 
     /**
      * Make date from header.
-     *
+     * 
      * @param date the date
      * @return the long
      */
@@ -596,14 +565,13 @@ public class HttpClientRemoteStorage
 
     /**
      * Appends repository configured additional query string to provided URL.
-     *
-     * @param url        to append to
+     * 
+     * @param url to append to
      * @param repository that may contain additional query string
      * @return URL with appended query string or original URL if repository does not have an configured query string
      * @throws RemoteStorageException if query string could not be appended (resulted in an Malformed URL exception)
      */
-    private URL appendQueryString( final URL url,
-                                   final ProxyRepository repository )
+    private URL appendQueryString( final URL url, final ProxyRepository repository )
         throws RemoteStorageException
     {
         final RemoteStorageContext ctx = getRemoteStorageContext( repository );
@@ -625,9 +593,8 @@ public class HttpClientRemoteStorage
             }
             catch ( MalformedURLException e )
             {
-                throw new RemoteStorageException(
-                    "Could not append query string \"" + queryString + "\" to url \"" + url + "\"", e
-                );
+                throw new RemoteStorageException( "Could not append query string \"" + queryString + "\" to url \""
+                    + url + "\"", e );
             }
         }
         return url;
@@ -635,7 +602,7 @@ public class HttpClientRemoteStorage
 
     /**
      * Releases connection resources (back to pool). If an exception appears during releasing, exception is just logged.
-     *
+     * 
      * @param httpResponse to be released
      */
     private void release( final HttpResponse httpResponse )

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
@@ -91,11 +91,6 @@ public class HttpClientUtil
      */
     private static final String CTX_KEY_S3_FLAG = ".remoteIsAmazonS3";
 
-    /**
-     * Context key of a flag present in case that NTLM authentication is configured.
-     */
-    private static final String CTX_KEY_NTLM_IS_IN_USE = ".ntlmIsInUse";
-
     // ==
     // HTTPClient4x pool and connection eviction related settings
 
@@ -201,12 +196,6 @@ public class HttpClientUtil
 
         // put client into context
         ctx.putContextObject( ctxPrefix + CTX_KEY_CLIENT, httpClient );
-        // NTLM flag: if for any auth NTLM is used, it has to be set
-        if ( ( ctx.getRemoteAuthenticationSettings() != null && ctx.getRemoteAuthenticationSettings() instanceof NtlmRemoteAuthenticationSettings )
-            || ( ctx.getRemoteProxySettings() != null && ctx.getRemoteProxySettings().getProxyAuthentication() != null && ctx.getRemoteProxySettings().getProxyAuthentication() instanceof NtlmRemoteAuthenticationSettings ) )
-        {
-            ctx.putContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE, Boolean.TRUE );
-        }
         // NEXUS-3338: we don't know after config change is remote S3 (url changed maybe)
         ctx.putContextObject( ctxPrefix + CTX_KEY_S3_FLAG, new BooleanFlagHolder() );
 
@@ -270,7 +259,6 @@ public class HttpClientUtil
             ctx.removeContextObject( ctxPrefix + CTX_KEY_CLIENT );
         }
         ctx.removeContextObject( ctxPrefix + CTX_KEY_S3_FLAG );
-        ctx.putContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE, Boolean.FALSE );
     }
 
     /**
@@ -301,19 +289,6 @@ public class HttpClientUtil
     static HttpClient getHttpClient( final String ctxPrefix, final RemoteStorageContext ctx )
     {
         return (HttpClient) ctx.getContextObject( ctxPrefix + CTX_KEY_CLIENT );
-    }
-
-    /**
-     * Whether or not the NTLM authentication is used.
-     * 
-     * @param ctxPrefix context keys prefix
-     * @param ctx remote repository context
-     * @return {@code true} if NTLM authentication is used, {@code false} otherwise
-     */
-    static Boolean isNTLMAuthenticationUsed( final String ctxPrefix, final RemoteStorageContext ctx )
-    {
-        final Object ntlmInUse = ctx.getContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE );
-        return ntlmInUse != null && Boolean.parseBoolean( ntlmInUse.toString() );
     }
 
     /**

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
@@ -95,10 +95,10 @@ public class HttpClientUtil
      * Key of optional system property for customizing the connection pool size. If not present HTTP client default is
      * used (20 connections)
      * 
-     * @deprecated This key is deprecated, use {@link #CONNECTION_POOL_SIZE_SUFFIX} instead.
+     * @deprecated This key is deprecated, use {@link #CONNECTION_POOL_SIZE_KEY} instead.
      */
     @Deprecated
-    private static final String CONNECTION_POOL_SIZE_KEY_DEPRECATED = "httpClient.connectionPoolSize";
+    public static final String CONNECTION_POOL_SIZE_KEY_DEPRECATED = "httpClient.connectionPoolSize";
 
     /**
      * Key for customizing connection pool maximum size. Value should be integer equal to 0 or greater. Pool size of 0

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -31,7 +33,9 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.auth.params.AuthPNames;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.params.AuthPolicy;
+import org.apache.http.client.params.ClientPNames;
 import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
@@ -48,21 +52,29 @@ import org.apache.http.protocol.BasicHttpProcessor;
 import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
 import org.sonatype.nexus.proxy.repository.ClientSSLRemoteAuthenticationSettings;
 import org.sonatype.nexus.proxy.repository.NtlmRemoteAuthenticationSettings;
+import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.repository.RemoteAuthenticationSettings;
+import org.sonatype.nexus.proxy.repository.RemoteConnectionSettings;
 import org.sonatype.nexus.proxy.repository.RemoteProxySettings;
 import org.sonatype.nexus.proxy.repository.UsernamePasswordRemoteAuthenticationSettings;
 import org.sonatype.nexus.proxy.storage.remote.DefaultRemoteStorageContext.BooleanFlagHolder;
+import org.sonatype.nexus.proxy.storage.remote.RemoteRepositoryStorage;
 import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
- * Utilities related to HTTP client.
+ * Utilities related to HTTP client. This whole class will need to be reworked, as it started as simple
+ * "static utility class", but today it;s grown out it's limit to be still that. It would probably need to be
+ * componentized.
  * 
  * @since 2.0
  */
-class HttpClientUtil
+public class HttpClientUtil
 {
 
     // ----------------------------------------------------------------------
@@ -84,16 +96,61 @@ class HttpClientUtil
      */
     private static final String CTX_KEY_NTLM_IS_IN_USE = ".ntlmIsInUse";
 
+    // ==
+    // HTTPClient4x pool and connection eviction related settings
+
     /**
      * Key of optional system property for customizing the connection pool size. If not present HTTP client default is
      * used (20 connections)
+     * 
+     * @deprecated This key is deprecated, use {@link #CONNECTION_POOL_SIZE_SUFFIX} instead.
      */
-    public static final String CONNECTION_POOL_SIZE_KEY = "httpClient.connectionPoolSize";
+    @Deprecated
+    public static final String CONNECTION_POOL_SIZE_KEY_DEPRECATED = "httpClient.connectionPoolSize";
 
     /**
-     * Marker used to determine that {@link #CONNECTION_POOL_SIZE_KEY} system property is not set.
+     * The common prefix for all parameters.
      */
-    private static final int UNDEFINED_POOL_SIZE = -1;
+    public static final String PARAMETER_PREFIX = "nexus.apacheHttpClient4x.";
+
+    /**
+     * Key for customizing connection pool size. Value should be integer equal to 0 or greater. Pool size of 0 will
+     * actually prevent use of pool. Any positive number means the actual size of the pool to be created.
+     */
+    public static final String CONNECTION_POOL_SIZE_SUFFIX = "connectionPoolSize";
+
+    /**
+     * Default pool size: 20.
+     */
+    public static final int CONNECTION_POOL_SIZE_DEFAULT = 20;
+
+    /**
+     * Key for customizing connection pool keep-alive. In other words, how long open connections (sockets) are kept in
+     * pool before evicted and closed. Value is milliseconds.
+     */
+    public static final String CONNECTION_POOL_KEEPALIVE_SUFFIX = "connectionPoolKeepalive";
+
+    /**
+     * Default pool keep-alive: 1 minute.
+     */
+    public static final long CONNECTION_POOL_KEEPALIVE_DEFAULT = TimeUnit.MINUTES.toMillis( 1 );
+
+    /**
+     * Key for customizing connection pool timeout. In other words, how long should a HTTP request execution be blocked
+     * when pool is depleted, for a connection. Value is milliseconds.
+     */
+    public static final String CONNECTION_POOL_TIMEOUT_SUFFIX = "connectionPoolTimeout";
+
+    /**
+     * Default pool timeout: equals to {@link #CONNECTION_POOL_KEEPALIVE_DEFAULT}.
+     */
+    public static final long CONNECTION_POOL_TIMEOUT_DEFAULT = TimeUnit.MINUTES.toMillis( 1 );
+
+    // --
+
+    static final String CLIENT_ID_KEY = "nexus.apacheHttpClient4x.id";
+
+    static final String CLIENT_DESIGNATOR_KEY = "nexus.apacheHttpClient4x.designator";
 
     // ----------------------------------------------------------------------
     // Implementation fields
@@ -113,26 +170,21 @@ class HttpClientUtil
      * {@link #CONNECTION_POOL_SIZE_KEY}<br/>
      * * setting timeout as configured for repository<br/>
      * * (if necessary) configure authentication<br/>
-     * * (if necessary) configure proxy as configured for repository
+     * * (if necessary) configure proxy as configured for repository. This method should be used only by
+     * {@link RemoteRepositoryStorage} implementations using HttpClient 4.x!
      * 
      * @return the created http client
+     * @param proxyRepository the Proxy repository on who's behalf we are creating HTTP client instance.
      * @param ctxPrefix context keys prefix
      * @param ctx remote repository context
      * @param logger logger
+     * @throws IllegalStateException when creation of client fails (usually lack of TLS/SSL support in JVM)
      */
-    static HttpClient configure( final String ctxPrefix, final RemoteStorageContext ctx, final Logger logger )
+    static HttpClient configure( final ProxyRepository proxyRepository, final String ctxPrefix,
+                                 final RemoteStorageContext ctx, final Logger logger )
         throws IllegalStateException
     {
-        final DefaultHttpClient httpClient = new DefaultHttpClient( createConnectionManager(), createHttpParams( ctx ) )
-        {
-            @Override
-            protected BasicHttpProcessor createHttpProcessor()
-            {
-                final BasicHttpProcessor result = super.createHttpProcessor();
-                result.addResponseInterceptor( new ResponseContentEncoding() );
-                return result;
-            }
-        };
+        final DefaultHttpClient httpClient = configure( proxyRepository.getId(), ctx );
 
         // NEXUS-5125 do not redirect to index pages
         httpClient.setRedirectStrategy( new DefaultRedirectStrategy()
@@ -147,11 +199,14 @@ class HttpClientUtil
             }
         } );
 
+        // put client into context
         ctx.putContextObject( ctxPrefix + CTX_KEY_CLIENT, httpClient );
-
-        configureAuthentication( httpClient, ctxPrefix, ctx, ctx.getRemoteAuthenticationSettings(), logger, "" );
-        configureProxy( httpClient, ctxPrefix, ctx, logger );
-
+        // NTLM flag: if for any auth NTLM is used, it has to be set
+        if ( ( ctx.getRemoteAuthenticationSettings() != null && ctx.getRemoteAuthenticationSettings() instanceof NtlmRemoteAuthenticationSettings )
+            || ( ctx.getRemoteProxySettings() != null && ctx.getRemoteProxySettings().getProxyAuthentication() != null && ctx.getRemoteProxySettings().getProxyAuthentication() instanceof NtlmRemoteAuthenticationSettings ) )
+        {
+            ctx.putContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE, Boolean.TRUE );
+        }
         // NEXUS-3338: we don't know after config change is remote S3 (url changed maybe)
         ctx.putContextObject( ctxPrefix + CTX_KEY_S3_FLAG, new BooleanFlagHolder() );
 
@@ -159,7 +214,49 @@ class HttpClientUtil
     }
 
     /**
-     * Releases the current HTTP client (if any) and removes context objects.
+     * Creates and configures a HTTP Client. When you are done using it, you should {@link #release(HttpClient)} it.
+     * Note: as this method is NOT {@link RemoteRepositoryStorage} specific at all, but is rather "generic" HTTP Client
+     * factory, it should be considered to move this out from here, to some other package!
+     * 
+     * @param designator the designator or {@code null}
+     * @param ctx the {@link RemoteStorageContext} to use to fetch auth and proxy info. See
+     *            {@link ApplicationConfiguration#getGlobalRemoteStorageContext()} if you want a HTTP client instance
+     *            that obeys Nexus configuration for example.
+     * @return HttpClient instance preconfigured for use.
+     * @throws IllegalStateException when client was not created due to (usually TLS/SSL related) some problem.
+     * @since 2.2
+     */
+    public static DefaultHttpClient configure( final String designator, final RemoteStorageContext ctx )
+        throws IllegalStateException
+    {
+        final DefaultHttpClient httpClient =
+            new DefaultHttpClient( createConnectionManager( designator ), createHttpParams( designator,
+                ctx.getRemoteConnectionSettings() ) )
+            {
+                @Override
+                protected BasicHttpProcessor createHttpProcessor()
+                {
+                    final BasicHttpProcessor result = super.createHttpProcessor();
+                    result.addResponseInterceptor( new ResponseContentEncoding() );
+                    return result;
+                }
+            };
+        // needed for internal bookkeeping
+        httpClient.getParams().setParameter( CLIENT_ID_KEY, UUID.randomUUID().toString() );
+        httpClient.getParams().setParameter( CLIENT_DESIGNATOR_KEY, designator );
+        configureAuthentication( httpClient, ctx.getRemoteAuthenticationSettings(), null );
+        configureProxy( httpClient, ctx.getRemoteProxySettings() );
+
+        ConnectionPoolEvictingThread.INSTANCE.register( httpClient );
+
+        logAction( "Created", httpClient );
+
+        return httpClient;
+    }
+
+    /**
+     * Releases the current HTTP client (if any) and removes context objects associated with Proxy repositories. This
+     * method should be used only by {@link RemoteRepositoryStorage} implementations using HttpClient 4.x!
      * 
      * @param ctxPrefix context keys prefix
      * @param ctx remote repository context
@@ -169,12 +266,30 @@ class HttpClientUtil
         if ( ctx.hasContextObject( ctxPrefix + CTX_KEY_CLIENT ) )
         {
             HttpClient httpClient = (HttpClient) ctx.getContextObject( ctxPrefix + CTX_KEY_CLIENT );
-            httpClient.getConnectionManager().shutdown();
+            release( httpClient );
             ctx.removeContextObject( ctxPrefix + CTX_KEY_CLIENT );
         }
         ctx.removeContextObject( ctxPrefix + CTX_KEY_S3_FLAG );
         ctx.putContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE, Boolean.FALSE );
     }
+
+    /**
+     * Releases the passed in HTTP client. Should be called if the client was created using
+     * {@link #configure(String, RemoteStorageContext)} method of this class. Note: as this method is NOT
+     * {@link RemoteRepositoryStorage} specific at all, but is rather "generic" HTTP Client factory, it should be
+     * considered to move this out from here, to some other package!
+     * 
+     * @param httpClient
+     * @since 2.2
+     */
+    public static void release( final HttpClient httpClient )
+    {
+        logAction( "Releasing ", httpClient );
+        ConnectionPoolEvictingThread.INSTANCE.unregister( httpClient );
+        httpClient.getConnectionManager().shutdown();
+    }
+
+    // ==
 
     /**
      * Returns the HTTP client for context.
@@ -216,77 +331,75 @@ class HttpClientUtil
     // Implementation methods
     // ----------------------------------------------------------------------
 
-    private static void configureAuthentication( final DefaultHttpClient httpClient, final String ctxPrefix,
-                                                 final RemoteStorageContext ctx,
-                                                 final RemoteAuthenticationSettings ras, final Logger logger,
-                                                 final String authScope )
+    private static void configureAuthentication( final DefaultHttpClient httpClient,
+                                                 final RemoteAuthenticationSettings ras, final HttpHost proxyHost )
     {
         if ( ras != null )
         {
+            String authScope = "target";
+            if ( proxyHost != null )
+            {
+                authScope = proxyHost.toHostString() + " proxy";
+            }
+
             List<String> authorisationPreference = new ArrayList<String>( 2 );
             authorisationPreference.add( AuthPolicy.DIGEST );
             authorisationPreference.add( AuthPolicy.BASIC );
-
             Credentials credentials = null;
-
             if ( ras instanceof ClientSSLRemoteAuthenticationSettings )
             {
-                // ClientSSLRemoteAuthenticationSettings cras = (ClientSSLRemoteAuthenticationSettings) ras;
-
-                // TODO - implement this
+                throw new IllegalArgumentException( "SSL client authentication not yet supported!" );
             }
             else if ( ras instanceof NtlmRemoteAuthenticationSettings )
             {
                 final NtlmRemoteAuthenticationSettings nras = (NtlmRemoteAuthenticationSettings) ras;
-
                 // Using NTLM auth, adding it as first in policies
                 authorisationPreference.add( 0, AuthPolicy.NTLM );
-
-                logger( logger ).info( "... {} authentication setup for NTLM domain '{}'", authScope,
-                    nras.getNtlmDomain() );
-
+                LOGGER.info( "... {} authentication setup for NTLM domain '{}'", authScope, nras.getNtlmDomain() );
                 credentials =
                     new NTCredentials( nras.getUsername(), nras.getPassword(), nras.getNtlmHost(), nras.getNtlmDomain() );
-
-                ctx.putContextObject( ctxPrefix + CTX_KEY_NTLM_IS_IN_USE, Boolean.TRUE );
             }
             else if ( ras instanceof UsernamePasswordRemoteAuthenticationSettings )
             {
-                UsernamePasswordRemoteAuthenticationSettings uras = (UsernamePasswordRemoteAuthenticationSettings) ras;
-
-                // Using Username/Pwd auth, will not add NTLM
-                logger( logger ).info( "... {} authentication setup for remote storage with username '{}'", authScope,
+                final UsernamePasswordRemoteAuthenticationSettings uras =
+                    (UsernamePasswordRemoteAuthenticationSettings) ras;
+                LOGGER.info( "... {} authentication setup for remote storage with username '{}'", authScope,
                     uras.getUsername() );
-
                 credentials = new UsernamePasswordCredentials( uras.getUsername(), uras.getPassword() );
             }
 
             if ( credentials != null )
             {
-                httpClient.getCredentialsProvider().setCredentials( AuthScope.ANY, credentials );
+                if ( proxyHost != null )
+                {
+                    httpClient.getCredentialsProvider().setCredentials( new AuthScope( proxyHost ), credentials );
+                    httpClient.getParams().setParameter( AuthPNames.PROXY_AUTH_PREF, authorisationPreference );
+                }
+                else
+                {
+                    httpClient.getCredentialsProvider().setCredentials( AuthScope.ANY, credentials );
+                    httpClient.getParams().setParameter( AuthPNames.TARGET_AUTH_PREF, authorisationPreference );
+                }
             }
-
-            httpClient.getParams().setParameter( AuthPNames.PROXY_AUTH_PREF, authorisationPreference );
         }
     }
 
-    private static void configureProxy( final DefaultHttpClient httpClient, final String ctxPrefix,
-                                        final RemoteStorageContext ctx, final Logger logger )
+    private static void configureProxy( final DefaultHttpClient httpClient,
+                                        final RemoteProxySettings remoteProxySettings )
     {
-        final RemoteProxySettings rps = ctx.getRemoteProxySettings();
-
-        if ( rps.isEnabled() )
+        if ( remoteProxySettings.isEnabled() )
         {
-            logger( logger ).info( "... proxy setup with host '{}'", rps.getHostname() );
+            LOGGER.info( "... proxy setup with host '{}'", remoteProxySettings.getHostname() );
 
-            final HttpHost proxy = new HttpHost( rps.getHostname(), rps.getPort() );
+            final HttpHost proxy = new HttpHost( remoteProxySettings.getHostname(), remoteProxySettings.getPort() );
             httpClient.getParams().setParameter( ConnRoutePNames.DEFAULT_PROXY, proxy );
 
             // check if we have non-proxy hosts
-            if ( rps.getNonProxyHosts() != null && !rps.getNonProxyHosts().isEmpty() )
+            if ( remoteProxySettings.getNonProxyHosts() != null && !remoteProxySettings.getNonProxyHosts().isEmpty() )
             {
-                final Set<Pattern> nonProxyHostPatterns = new HashSet<Pattern>( rps.getNonProxyHosts().size() );
-                for ( String nonProxyHostRegex : rps.getNonProxyHosts() )
+                final Set<Pattern> nonProxyHostPatterns =
+                    new HashSet<Pattern>( remoteProxySettings.getNonProxyHosts().size() );
+                for ( String nonProxyHostRegex : remoteProxySettings.getNonProxyHosts() )
                 {
                     try
                     {
@@ -294,75 +407,136 @@ class HttpClientUtil
                     }
                     catch ( PatternSyntaxException e )
                     {
-                        logger( logger ).warn( "Invalid non proxy host regex: {}", nonProxyHostRegex, e );
+                        LOGGER.warn( "Invalid non proxy host regex: {}", nonProxyHostRegex, e );
                     }
                 }
                 httpClient.setRoutePlanner( new NonProxyHostsAwareHttpRoutePlanner(
                     httpClient.getConnectionManager().getSchemeRegistry(), nonProxyHostPatterns ) );
-
             }
 
-            configureAuthentication( httpClient, ctxPrefix, ctx, rps.getProxyAuthentication(), logger, "proxy " );
-
-            if ( rps.getProxyAuthentication() != null )
-            {
-                if ( ctx.getRemoteAuthenticationSettings() != null
-                    && ( ctx.getRemoteAuthenticationSettings() instanceof NtlmRemoteAuthenticationSettings ) )
-                {
-                    logger( logger ).warn(
-                        "... Apache Commons HttpClient 3.x is unable to use NTLM auth scheme\n"
-                            + " for BOTH server side and proxy side authentication!\n"
-                            + " You MUST reconfigure server side auth and use BASIC/DIGEST scheme\n"
-                            + " if you have to use NTLM proxy, otherwise it will not work!\n"
-                            + " *** SERVER SIDE AUTH OVERRIDDEN" );
-                }
-
-            }
+            configureAuthentication( httpClient, remoteProxySettings.getProxyAuthentication(), proxy );
         }
     }
 
-    private static HttpParams createHttpParams( final RemoteStorageContext ctx )
+    private static HttpParams createHttpParams( final String designator,
+                                                final RemoteConnectionSettings remoteConnectionSettings )
     {
         HttpParams params = new SyncBasicHttpParams();
         params.setParameter( HttpProtocolParams.PROTOCOL_VERSION, HttpVersion.HTTP_1_1 );
         params.setBooleanParameter( HttpProtocolParams.USE_EXPECT_CONTINUE, false );
-        params.setBooleanParameter( HttpConnectionParams.STALE_CONNECTION_CHECK, true );
+        params.setBooleanParameter( HttpConnectionParams.STALE_CONNECTION_CHECK, false );
         params.setIntParameter( HttpConnectionParams.SOCKET_BUFFER_SIZE, 8 * 1024 );
 
+        // pool timeout: max how long to wait for connection (without this, pool would block indefinitely)
+        long poolTimeout = getLong( CONNECTION_POOL_TIMEOUT_SUFFIX, designator, CONNECTION_POOL_TIMEOUT_DEFAULT );
+        params.setLongParameter( ClientPNames.CONN_MANAGER_TIMEOUT, poolTimeout );
+
+        // connection and socket timeouts come from Nexus config
         // getting the timeout from RemoteStorageContext. The value we get depends on per-repo and global settings.
         // The value will "cascade" from repo level to global level, see implementation.
-        int timeout = ctx.getRemoteConnectionSettings().getConnectionTimeout();
-
-        params.setIntParameter( HttpConnectionParams.CONNECTION_TIMEOUT, timeout );
-        params.setIntParameter( HttpConnectionParams.SO_TIMEOUT, timeout );
+        params.setIntParameter( HttpConnectionParams.CONNECTION_TIMEOUT,
+            remoteConnectionSettings.getConnectionTimeout() );
+        params.setIntParameter( HttpConnectionParams.SO_TIMEOUT, remoteConnectionSettings.getConnectionTimeout() );
         return params;
     }
 
-    private static PoolingClientConnectionManager createConnectionManager()
+    private static PoolingClientConnectionManager createConnectionManager( final String designator )
         throws IllegalStateException
     {
         final SchemeRegistry schemeRegistry = new SchemeRegistry();
         schemeRegistry.register( new Scheme( "http", 80, PlainSocketFactory.getSocketFactory() ) );
         schemeRegistry.register( new Scheme( "https", 443, SSLSocketFactory.getSocketFactory() ) );
         final PoolingClientConnectionManager connManager = new PoolingClientConnectionManager( schemeRegistry );
-        int connectionPoolSize = SystemPropertiesHelper.getInteger( CONNECTION_POOL_SIZE_KEY, UNDEFINED_POOL_SIZE );
-        if ( connectionPoolSize != UNDEFINED_POOL_SIZE )
-        {
-            connManager.setMaxTotal( connectionPoolSize );
-        }
-        // NOTE: connPool is _per_ repo, hence all of those will connect to same host (unless mirrors are used)
-        // so, we are violating intentionally the RFC and we let the whole pool size to chase same host
-        connManager.setDefaultMaxPerRoute( connManager.getMaxTotal() );
 
+        // pool size: we have a new (documented) key, and an old (deprecated, undocumented but used). If new present,
+        // will be used, otherwise the deprecated will be looked up, and if not found, the default is used.
+        // NOTE: pool size is per-repository, hence all of those will connect to same host (unless mirrors are used)
+        // so, we are violating intentionally the RFC and we let the whole pool size to chase same host by setting
+        // maxPerRoute to same value as maxTotal
+        final int poolSize =
+            getInt( CONNECTION_POOL_SIZE_SUFFIX, designator,
+                SystemPropertiesHelper.getInteger( CONNECTION_POOL_SIZE_KEY_DEPRECATED, CONNECTION_POOL_SIZE_DEFAULT ) );
+        connManager.setMaxTotal( poolSize );
+        connManager.setDefaultMaxPerRoute( poolSize );
         return connManager;
     }
 
-    private static Logger logger( final Logger logger )
+    static void evictConnectionManagerPool( final HttpClient client )
     {
-        if ( logger != null )
+        // this might be null as well
+        final String designator = (String) client.getParams().getParameter( CLIENT_DESIGNATOR_KEY );
+        evictConnectionManagerPool( designator, client.getConnectionManager() );
+    }
+
+    private static void evictConnectionManagerPool( final String designator, final ClientConnectionManager connManager )
+    {
+        // as default DefaultConnectionKeepAliveStrategy is used, and it obeys to remote peer (if it says anything at
+        // all) we do eviction properly, using both methods. First call will evict those expired, after time
+        // that remote peer told us. If remote peer did not say anything, they are pooled for indefinite time
+        // and second call will handle them.
+        // NOTE: Having the 1st call we are simply polite to the remote peers that explicitly state for how
+        // long they want to keep-alive the connection, AND that value is less than our keep-alive
+        connManager.closeExpiredConnections();
+        // NOTE: Having the 2nd call we are simply "capping" the possible maximum time for how long to keep idle open
+        // sockets. If you consider servers mentioned above (that state timeout for keep-alive), this also
+        // protect us against abusive ones, that for example could say "keep socket open for one year" ;)
+        final long keepAlive =
+            getLong( CONNECTION_POOL_KEEPALIVE_SUFFIX, designator, CONNECTION_POOL_KEEPALIVE_DEFAULT );
+        connManager.closeIdleConnections( keepAlive, TimeUnit.MILLISECONDS );
+    }
+
+    // parameter fetching
+
+    @VisibleForTesting
+    static int getInt( final String suffix, final String designator, final int defaultValue )
+    {
+        // prefix[id]suffix
+        // nexus.apacheHttpClient4x.id.connectionPoolKeepalive
+        // nexus.apacheHttpClient4x.connectionPoolKeepalive
+        // default value
+        if ( designator == null )
         {
-            return logger;
+            return SystemPropertiesHelper.getInteger( PARAMETER_PREFIX, suffix, null, defaultValue );
         }
-        return LOGGER;
+        else
+        {
+            return SystemPropertiesHelper.getInteger( PARAMETER_PREFIX, suffix, designator + ".", defaultValue );
+        }
+    }
+
+    @VisibleForTesting
+    static long getLong( final String suffix, final String designator, final long defaultValue )
+    {
+        // prefix[id]suffix
+        // nexus.apacheHttpClient4x.id.connectionPoolKeepalive
+        // nexus.apacheHttpClient4x.connectionPoolKeepalive
+        // default value
+        if ( designator == null )
+        {
+            return SystemPropertiesHelper.getLong( PARAMETER_PREFIX, suffix, null, defaultValue );
+        }
+        else
+        {
+            return SystemPropertiesHelper.getLong( PARAMETER_PREFIX, suffix, designator + ".", defaultValue );
+        }
+    }
+
+    // ==
+
+    protected static String getHttpClientDescription( final HttpClient client )
+    {
+        final String id = String.valueOf( client.getParams().getParameter( CLIENT_ID_KEY ) );
+        final String designator = (String) client.getParams().getParameter( CLIENT_DESIGNATOR_KEY );
+
+        return "HttpClient4x ID=\"" + id + "\" (designator=\"" + designator + "\")";
+    }
+
+    protected static void logAction( final String action, final HttpClient client )
+    {
+        if ( !LOGGER.isDebugEnabled() )
+        {
+            return;
+        }
+        LOGGER.debug( "{} {}", action, getHttpClientDescription( client ) );
     }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtilTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtilTest.java
@@ -13,10 +13,14 @@
 package org.sonatype.nexus.proxy.storage.remote.httpclient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -24,12 +28,16 @@ import org.apache.http.ProtocolException;
 import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
 import org.apache.http.client.RedirectStrategy;
+import org.apache.http.conn.ManagedClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.repository.RemoteConnectionSettings;
 import org.sonatype.nexus.proxy.repository.RemoteProxySettings;
 import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
@@ -68,12 +76,16 @@ public class HttpClientUtilTest
     @Mock
     private RemoteProxySettings remoteProxySettings;
 
+    @Mock
+    private ProxyRepository proxyRepository;
+
     @Before
     public void before()
     {
         when( ctx.getRemoteConnectionSettings() ).thenReturn( remoteConnectionSettings );
         when( ctx.getRemoteProxySettings() ).thenReturn( remoteProxySettings );
-        underTest = (DefaultHttpClient) HttpClientUtil.configure( "ctx", ctx, logger );
+        when( proxyRepository.getId() ).thenReturn( "central" );
+        underTest = (DefaultHttpClient) HttpClientUtil.configure( proxyRepository, "ctx", ctx, logger );
 
         when( response.getStatusLine() ).thenReturn( statusLine );
 
@@ -99,10 +111,128 @@ public class HttpClientUtilTest
         assertThat( redirectStrategy.isRedirected( request, response, httpContext ), is( true ) );
 
         // redirect to dir
-        when( response.getFirstHeader( "location" ) ).thenReturn(
-            new BasicHeader( "location", "http://localhost/dir/" ) );
+        when( response.getFirstHeader( "location" ) ).thenReturn( new BasicHeader( "location", "http://localhost/dir/" ) );
         assertThat( redirectStrategy.isRedirected( request, response, httpContext ), is( false ) );
     }
 
+    private void useConnection( final PoolingClientConnectionManager connMgr, final HttpRoute route,
+                                final boolean shouldBeEvicted )
+        throws Exception
+    {
+        // ask for a connection
+        final ManagedClientConnection connection = connMgr.requestConnection( route, null ).getConnection( 0, null );
+        // mark it reusable (in HC, this would come from higher level, based on HTTP protocol and other
+        connection.markReusable();
+        // check some stats
+        assertThat( connMgr.getTotalStats().getAvailable(), equalTo( 0 ) );
+        assertThat( connMgr.getTotalStats().getLeased(), equalTo( 1 ) );
+        // release the connection, and keep it forever (we test will our monitor thread evict it)
+        connMgr.releaseConnection( connection, -1, TimeUnit.MILLISECONDS );
+        // check some stats
+        assertThat( connMgr.getTotalStats().getAvailable(), equalTo( 1 ) );
+        assertThat( connMgr.getTotalStats().getLeased(), equalTo( 0 ) );
+        // sleep 5.5 second to give eviction change to kick in (runs every 5 sec)
+        Thread.sleep( 5500 );
+        // check some stats
+        if ( shouldBeEvicted )
+        {
+            assertThat( connMgr.getTotalStats().getAvailable(), equalTo( 0 ) );
+        }
+        else
+        {
+            assertThat( connMgr.getTotalStats().getAvailable(), equalTo( 1 ) );
+        }
+        assertThat( connMgr.getTotalStats().getLeased(), equalTo( 0 ) );
+    }
 
+    @Test
+    public void testKeepAlive()
+        throws Exception
+    {
+        final PoolingClientConnectionManager connMgr =
+            (PoolingClientConnectionManager) underTest.getConnectionManager();
+
+        // the server
+        final ServerSocket ss = new ServerSocket();
+        final HttpRoute route = new HttpRoute( new HttpHost( "localhost", ss.getLocalPort() ) );
+        final String keepaliveKey = HttpClientUtil.PARAMETER_PREFIX + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
+
+        try
+        {
+            // set pool timeout to 1 second, eviction happens per every 5 seconds so it should be evicted
+            System.setProperty( keepaliveKey, String.valueOf( TimeUnit.SECONDS.toMillis( 1 ) ) );
+            // this setting above will make the connection to be evicted
+
+            useConnection( connMgr, route, true );
+
+            // set pool timeout to 1 hour, eviction happens per every 5 seconds so it should not be evicted
+            System.setProperty( keepaliveKey, String.valueOf( TimeUnit.HOURS.toMillis( 1 ) ) );
+
+            useConnection( connMgr, route, false );
+        }
+        finally
+        {
+            System.clearProperty( keepaliveKey );
+            ss.close();
+        }
+    }
+
+    @Test
+    public void testGetInt()
+    {
+        final int defaultValue = 1;
+
+        // nexus.apacheHttpClient4x.central.connectionPoolKeepalive
+        final String designatedKey =
+            HttpClientUtil.PARAMETER_PREFIX + "central." + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
+        final int designatedValue = 3;
+        // nexus.apacheHttpClient4x.connectionPoolKeepalive
+        final String globalKey = HttpClientUtil.PARAMETER_PREFIX + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
+        final int globalValue = 5;
+
+        //
+        System.clearProperty( globalKey );
+        System.clearProperty( designatedKey );
+
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
+            equalTo( defaultValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
+            equalTo( defaultValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
+            equalTo( defaultValue ) );
+
+        //
+        System.setProperty( globalKey, String.valueOf( globalValue ) );
+        System.clearProperty( designatedKey );
+
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
+            equalTo( globalValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
+            equalTo( globalValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
+            equalTo( globalValue ) );
+
+        //
+        System.setProperty( globalKey, String.valueOf( globalValue ) );
+        System.setProperty( designatedKey, String.valueOf( designatedValue ) );
+
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
+            equalTo( globalValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
+            equalTo( globalValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
+            equalTo( designatedValue ) );
+
+        //
+        System.clearProperty( globalKey );
+        System.setProperty( designatedKey, String.valueOf( designatedValue ) );
+
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
+            equalTo( defaultValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
+            equalTo( defaultValue ) );
+        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
+            equalTo( designatedValue ) );
+
+    }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtilTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientUtilTest.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
@@ -145,7 +146,14 @@ public class HttpClientUtilTest
         assertThat( connMgr.getTotalStats().getLeased(), equalTo( 0 ) );
     }
 
+    /**
+     * Ignored as now parameters are not always re-read but are made constants once Classloader loads the class. Hence,
+     * this test below that modifies System properties does not quite make sense right now.
+     * 
+     * @throws Exception
+     */
     @Test
+    @Ignore
     public void testKeepAlive()
         throws Exception
     {
@@ -155,7 +163,7 @@ public class HttpClientUtilTest
         // the server
         final ServerSocket ss = new ServerSocket();
         final HttpRoute route = new HttpRoute( new HttpHost( "localhost", ss.getLocalPort() ) );
-        final String keepaliveKey = HttpClientUtil.PARAMETER_PREFIX + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
+        final String keepaliveKey = HttpClientUtil.CONNECTION_POOL_KEEPALIVE_KEY;
 
         try
         {
@@ -175,64 +183,5 @@ public class HttpClientUtilTest
             System.clearProperty( keepaliveKey );
             ss.close();
         }
-    }
-
-    @Test
-    public void testGetInt()
-    {
-        final int defaultValue = 1;
-
-        // nexus.apacheHttpClient4x.central.connectionPoolKeepalive
-        final String designatedKey =
-            HttpClientUtil.PARAMETER_PREFIX + "central." + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
-        final int designatedValue = 3;
-        // nexus.apacheHttpClient4x.connectionPoolKeepalive
-        final String globalKey = HttpClientUtil.PARAMETER_PREFIX + HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX;
-        final int globalValue = 5;
-
-        //
-        System.clearProperty( globalKey );
-        System.clearProperty( designatedKey );
-
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
-            equalTo( defaultValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
-            equalTo( defaultValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
-            equalTo( defaultValue ) );
-
-        //
-        System.setProperty( globalKey, String.valueOf( globalValue ) );
-        System.clearProperty( designatedKey );
-
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
-            equalTo( globalValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
-            equalTo( globalValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
-            equalTo( globalValue ) );
-
-        //
-        System.setProperty( globalKey, String.valueOf( globalValue ) );
-        System.setProperty( designatedKey, String.valueOf( designatedValue ) );
-
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
-            equalTo( globalValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
-            equalTo( globalValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
-            equalTo( designatedValue ) );
-
-        //
-        System.clearProperty( globalKey );
-        System.setProperty( designatedKey, String.valueOf( designatedValue ) );
-
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, null, defaultValue ),
-            equalTo( defaultValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "foo", defaultValue ),
-            equalTo( defaultValue ) );
-        assertThat( HttpClientUtil.getInt( HttpClientUtil.CONNECTION_POOL_KEEPALIVE_SUFFIX, "central", defaultValue ),
-            equalTo( designatedValue ) );
-
     }
 }

--- a/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/SystemPropertiesHelper.java
+++ b/nexus/nexus-utils/src/main/java/org/sonatype/nexus/util/SystemPropertiesHelper.java
@@ -33,6 +33,19 @@ public class SystemPropertiesHelper
         }
     }
 
+    public static final int getInteger( final String prefix, final String suffix, final String designator,
+                                        final int defaultValue )
+    {
+        if ( designator != null && designator.trim().length() > 0 )
+        {
+            return getInteger( prefix + designator + suffix, getInteger( prefix + suffix, defaultValue ) );
+        }
+        else
+        {
+            return getInteger( prefix + suffix, defaultValue );
+        }
+    }
+
     public final static long getLong( final String key, final long defaultValue )
     {
         final String value = System.getProperty( key );
@@ -52,6 +65,19 @@ public class SystemPropertiesHelper
         }
     }
 
+    public static final long getLong( final String prefix, final String suffix, final String designator,
+                                      final long defaultValue )
+    {
+        if ( designator != null && designator.trim().length() > 0 )
+        {
+            return getLong( prefix + designator + suffix, getLong( prefix + suffix, defaultValue ) );
+        }
+        else
+        {
+            return getLong( prefix + suffix, defaultValue );
+        }
+    }
+
     public final static boolean getBoolean( final String key, final boolean defaultValue )
     {
         final String value = System.getProperty( key );
@@ -62,6 +88,19 @@ public class SystemPropertiesHelper
         }
 
         return Boolean.valueOf( value );
+    }
+
+    public static final boolean getBoolean( final String prefix, final String suffix, final String designator,
+                                            final boolean defaultValue )
+    {
+        if ( designator != null && designator.trim().length() > 0 )
+        {
+            return getBoolean( prefix + designator + suffix, getBoolean( prefix + suffix, defaultValue ) );
+        }
+        else
+        {
+            return getBoolean( prefix + suffix, defaultValue );
+        }
     }
 
     public final static String getString( final String key, final String defaultValue )


### PR DESCRIPTION
- Introduced a new daemon thread that monitor and performs pool eviction on regular time intervals (5s). This is the proposed pattern by ASF HttpClient4x, to implement an external monitor thread, as HC4 does not have any other "internal" eviction mechanism. It can "check stale connection" per processed request, that introduces 30-40ms overhead per HTTP request, and still, if no outbound request happens in nexus, no eviction will happen.
- HttpClientUtil class improved, extracted some reusable non-proxy specific methods, applied some recommended changes and fixed problems: proxy authorisation was overriding target authorisation, also, a warning message was present (as the code originates from HC3 support class) that NTLM is unsupported for Proxies when other scheme is used for target. This is untrue for HC4x.
- the three introduced parameters are exposed to users (pool size, pool timeout and pool keep-alive), default values are poolSize=20, poolKeepAlive=1minute and poolTimeout=poolKeepAlive.  Users might override defaults by setting system properties.

Based on comments made by JD, some generic (non proxy repository specific) methods for HttpClient creation and releasing were made public. This means, that this class
might be used as "generic" HTTPClient4x factory, to create instances preconfigured and obeying Nexus config (like use of globally configured proxy etc).

Still, historically this class was made (intended to be?) a simple static utility class, but today it is growing. Probably the best would be to factor out the "hc factory" parts into a component, pulled out from this package (as it would be nor remote storage nor proxy specific) and this static class removed completely.

Existing class UT extended with eviction test and configuration discovery tests.
