### PR TITLE
[NXCM-4764] Locking resource did not used the correct path

### DIFF
--- a/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/uid/UIDLockResource.java
+++ b/nexus/nexus-test-harness/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/uid/UIDLockResource.java
@@ -55,7 +55,7 @@ public class UIDLockResource
     public static final String PATH = "path";
 
     public static final String RESOURCE_URI =
-        "/nexus-it-helper-plugin/uid/lock/{" + REPOSITORY + "}/{" + LOCK_TYPE + "}/{" + PATH + "}";
+        "/nexus-it-helper-plugin/uid/lock/{" + REPOSITORY + "}/{" + LOCK_TYPE + "}";
 
     private final RepositoryRegistry repositoryRegistry;
 
@@ -138,7 +138,7 @@ public class UIDLockResource
 
     private String getPath( final Request request )
     {
-        return request.getAttributes().get( PATH ).toString();
+        return request.getResourceRef().getRemainingPart( false, false );
     }
 
     private class LockThread


### PR DESCRIPTION
If for example path was  ending with g/a/a-v.jar the path was incorrectly set to "g".

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
