### PR TITLE
Changes related to running ITs against a specified bundle

### DIFF
--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-plugin-it/pom.xml
@@ -159,16 +159,13 @@
         </executions>
         <configuration>
           <nexusBundleArtifact>
-            <groupId>org.sonatype.nexus</groupId>
-            <artifactId>nexus-oss-webapp</artifactId>
-            <version>${project.version}</version>
+            <groupId>${it.nexus.bundle.groupId}</groupId>
+            <artifactId>${it.nexus.bundle.artifactId}</artifactId>
+            <version>${it.nexus.bundle.version}</version>
             <type>zip</type>
             <classifier>bundle</classifier>
           </nexusBundleArtifact>
-
-          <nexusBundleName>nexus-oss-webapp-${project.version}</nexusBundleName>
-
-          <nexusVersion>${project.version}</nexusVersion>
+          <nexusVersion>${it.nexus.bundle.version}</nexusVersion>
           <nexusPluginsArtifacts>
             <plugin>
               <groupId>org.sonatype.nexus</groupId>

--- a/nexus/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundle.java
+++ b/nexus/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundle.java
@@ -15,15 +15,20 @@ package org.sonatype.nexus.bundle.launcher.support;
 import static org.sonatype.nexus.bootstrap.monitor.CommandMonitorThread.LOCALHOST;
 import static org.sonatype.sisu.bl.jsw.JSWConfig.WRAPPER_JAVA_MAINCLASS;
 import static org.sonatype.sisu.filetasks.FileTaskRunner.onDirectory;
+import static org.sonatype.sisu.filetasks.builder.FileRef.file;
 import static org.sonatype.sisu.filetasks.builder.FileRef.path;
 import static org.sonatype.sisu.goodies.common.SimpleFormat.format;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -50,7 +55,9 @@ import org.sonatype.sisu.bl.support.TimedCondition;
 import org.sonatype.sisu.bl.support.port.PortReservationService;
 import org.sonatype.sisu.filetasks.FileTaskBuilder;
 import org.sonatype.sisu.goodies.common.Time;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
 
 /**
  * Default Nexus bundle implementation.
@@ -65,11 +72,20 @@ public class DefaultNexusBundle
 
     private static final Logger log = LoggerFactory.getLogger( DefaultNexusBundle.class );
 
+    private static final String USE_BUNDLE_PLUGINS_IF_PRESENT = "nexus.launcher.useBundlePluginsIfPresent";
+
     /**
      * File task builder.
      * Cannot be null.
      */
     private final FileTaskBuilder fileTaskBuilder;
+
+    /**
+     * Whether plugins installed in "sonatype-work/nexus/plugin-repository" should not be used in case they are present
+     * in "nexus/WEB-INF/plugin-repository". This is mainly used by tests that wish to test against a bundle that
+     * already contains the plugins installed by tests.
+     */
+    private final Boolean useBundlePluginsIfPresent;
 
     /**
      * Port on which Nexus Command Monitor is running. 0 (zero) if application is not running.
@@ -92,10 +108,13 @@ public class DefaultNexusBundle
     public DefaultNexusBundle( final Provider<NexusBundleConfiguration> configurationProvider,
                                final RunningBundles runningBundles,
                                final FileTaskBuilder fileTaskBuilder,
-                               final PortReservationService portReservationService )
+                               final PortReservationService portReservationService,
+                               final @Named( "${" + USE_BUNDLE_PLUGINS_IF_PRESENT
+                                                 + ":-false}" ) Boolean useBundlePluginsIfPresent )
     {
         super( "nexus", configurationProvider, runningBundles, fileTaskBuilder, portReservationService );
         this.fileTaskBuilder = fileTaskBuilder;
+        this.useBundlePluginsIfPresent = useBundlePluginsIfPresent;
     }
 
     /**
@@ -195,7 +214,7 @@ public class DefaultNexusBundle
             protected boolean isSatisfied()
                 throws Exception
             {
-                new CommandMonitorTalker( LOCALHOST, commandMonitorPort ).send(PingCommand.NAME);
+                new CommandMonitorTalker( LOCALHOST, commandMonitorPort ).send( PingCommand.NAME );
                 return true;
             }
         }.await( Time.seconds( 1 ), Time.seconds( 10 ), Time.seconds( 1 ) );
@@ -256,6 +275,122 @@ public class DefaultNexusBundle
         {
             return false;
         }
+    }
+
+    @Override
+    public void doPrepare()
+    {
+        super.doPrepare();
+        if ( useBundlePluginsIfPresent )
+        {
+            removePluginsPresentInBundle();
+        }
+    }
+
+    private void removePluginsPresentInBundle()
+    {
+        final Map<String, File> workDirPlugins = listPlugins(
+            new File( getWorkDirectory(), "plugin-repository" )
+        );
+        if ( workDirPlugins.size() > 0 )
+        {
+            final Map<String, File> bundlePlugins = listPlugins(
+                new File( getNexusDirectory(), "nexus/WEB-INF/plugin-repository" )
+            );
+            for ( final Map.Entry<String, File> entry : workDirPlugins.entrySet() )
+            {
+                if ( bundlePlugins.containsKey( entry.getKey() ) )
+                {
+                    log.info(
+                        "Removing plugin '{}' as is already present in extracted bundle", entry.getValue().getName()
+                    );
+                    fileTaskBuilder.delete().directory( file( entry.getValue() ) ).run();
+                }
+            }
+        }
+    }
+
+    private Map<String, File> listPlugins( final File pluginsDir )
+    {
+        final Map<String, File> plugins = Maps.newHashMap();
+        final File[] foundPlugins = pluginsDir.listFiles( new FileFilter()
+        {
+            @Override
+            public boolean accept( final File file )
+            {
+                return file.isDirectory();
+            }
+        } );
+        if ( foundPlugins != null && foundPlugins.length > 0 )
+        {
+            for ( final File plugin : foundPlugins )
+            {
+                final Optional<File> mainJar = getPluginMainJar( plugin );
+                if ( mainJar.isPresent() )
+                {
+                    final Optional<String> gaCoordinates = getPluginGACoordinates( mainJar.get() );
+                    if ( gaCoordinates.isPresent() )
+                    {
+                        plugins.put( gaCoordinates.get(), plugin );
+                    }
+                }
+            }
+        }
+        return plugins;
+    }
+
+    private Optional<String> getPluginGACoordinates( final File mainJar )
+    {
+        try
+        {
+            final ZipFile jarFile = new ZipFile( mainJar );
+            final Enumeration<? extends ZipEntry> entries = jarFile.entries();
+            if ( entries != null )
+            {
+                while ( entries.hasMoreElements() )
+                {
+                    final ZipEntry zipEntry = entries.nextElement();
+                    if ( zipEntry.getName().startsWith( "META-INF/maven" )
+                        && zipEntry.getName().endsWith( "pom.properties" ) )
+                    {
+                        final Properties props = new Properties();
+                        props.load( jarFile.getInputStream( zipEntry ) );
+                        return Optional.of( props.getProperty( "groupId" ) + ":" + props.getProperty( "artifactId" ) );
+                    }
+                }
+            }
+        }
+        catch ( IOException e )
+        {
+            throw Throwables.propagate( e );
+        }
+        return Optional.absent();
+    }
+
+    private Optional<File> getPluginMainJar( final File plugin )
+    {
+        final String[] mainJars = plugin.list( new FilenameFilter()
+        {
+            @Override
+            public boolean accept( final File dir, final String name )
+            {
+                return name.endsWith( ".jar" );
+            }
+        } );
+        if ( mainJars != null && mainJars.length > 0 )
+        {
+            if ( mainJars.length > 1 )
+            {
+                throw new IllegalStateException(
+                    "Plugin '" + plugin.getAbsolutePath() + "' contains more then one jar"
+                );
+            }
+            else
+            {
+                return Optional.of( new File( plugin, mainJars[0] ) );
+            }
+        }
+        return Optional.absent();
     }
 
     /**
@@ -385,7 +520,7 @@ public class DefaultNexusBundle
         log.debug( "Sending stop command to Nexus" );
         try
         {
-            new CommandMonitorTalker( LOCALHOST, commandPort ).send(StopApplicationCommand.NAME);
+            new CommandMonitorTalker( LOCALHOST, commandPort ).send( StopApplicationCommand.NAME );
         }
         catch ( Exception e )
         {
@@ -396,8 +531,9 @@ public class DefaultNexusBundle
         }
     }
 
-    private static void terminateRemoteNexus( final int commandPort ) {
-        log.debug("Attempting to terminate remote nexus");
+    private static void terminateRemoteNexus( final int commandPort )
+    {
+        log.debug( "Attempting to terminate remote nexus" );
 
         // First attempt graceful shutdown
         sendStopToNexus( commandPort );
@@ -408,35 +544,44 @@ public class DefaultNexusBundle
         long period = 1000;
 
         // Then ping for a bit and finally give up and ask it to halt
-        while (true) {
-            try {
+        while ( true )
+        {
+            try
+            {
                 talker.send( PingCommand.NAME );
             }
-            catch (ConnectException e) {
+            catch ( ConnectException e )
+            {
                 // likely its shutdown already
                 break;
             }
-            catch (Exception e) {
+            catch ( Exception e )
+            {
                 // ignore, not sure there is much we can do
             }
 
             // If we have waited long enough, then ask remote to halt
-            if (System.currentTimeMillis() - started > max) {
-                try {
+            if ( System.currentTimeMillis() - started > max )
+            {
+                try
+                {
                     talker.send( HaltCommand.NAME );
                     break;
                 }
-                catch (Exception e) {
+                catch ( Exception e )
+                {
                     // ignore, not sure there is much we can do
                     break;
                 }
             }
 
             // Wait a wee bit and try again
-            try {
-                Thread.sleep(period);
+            try
+            {
+                Thread.sleep( period );
             }
-            catch (InterruptedException e) {
+            catch ( InterruptedException e )
+            {
                 // ignore
             }
         }

--- a/nexus/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundle.java
+++ b/nexus/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundle.java
@@ -72,7 +72,7 @@ public class DefaultNexusBundle
 
     private static final Logger log = LoggerFactory.getLogger( DefaultNexusBundle.class );
 
-    private static final String USE_BUNDLE_PLUGINS_IF_PRESENT = "nexus.launcher.useBundlePluginsIfPresent";
+    private static final String USE_BUNDLE_PLUGINS_IF_PRESENT = "useBundlePluginsIfPresent";
 
     /**
      * File task builder.

--- a/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
@@ -26,13 +26,6 @@
   <name>Nexus : Test Harness : Core ITs</name>
 
   <properties>
-    <!-- Below is the "product", the subject of the ITs -->
-    <product-groupId>org.sonatype.nexus</product-groupId>
-    <product-artifactId>nexus-oss-webapp</product-artifactId>
-    <product-version>${project.version}</product-version>
-    <product-classifier>bundle</product-classifier>
-    <product-type>zip</product-type>
-
     <cargo.version>1.0.4</cargo.version>
   </properties>
 
@@ -124,13 +117,12 @@
           <setupEmma>true</setupEmma>
           <setupMaven>true</setupMaven>
           <nexusBundleArtifact>
-            <groupId>${product-groupId}</groupId>
-            <artifactId>${product-artifactId}</artifactId>
-            <version>${product-version}</version>
-            <classifier>${product-classifier}</classifier>
-            <type>${product-type}</type>
+            <groupId>${it.nexus.bundle.groupId}</groupId>
+            <artifactId>${it.nexus.bundle.artifactId}</artifactId>
+            <version>${it.nexus.bundle.version}</version>
+            <type>zip</type>
+            <classifier>bundle</classifier>
           </nexusBundleArtifact>
-          <nexusBundleName>nexus-oss-webapp-${project.version}</nexusBundleName>
           <nexusPluginsArtifacts>
             <plugin>
               <groupId>org.sonatype.nexus</groupId>

--- a/nexus/nexus-test-harness/nexus-test-harness-selenium/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-selenium/pom.xml
@@ -63,15 +63,12 @@
         <configuration>
 
           <nexusBundleArtifact>
-            <groupId>org.sonatype.nexus</groupId>
-            <artifactId>nexus-oss-webapp</artifactId>
-            <version>${project.version}</version>
+            <groupId>${it.nexus.bundle.groupId}</groupId>
+            <artifactId>${it.nexus.bundle.artifactId}</artifactId>
+            <version>${it.nexus.bundle.version}</version>
             <type>zip</type>
             <classifier>bundle</classifier>
           </nexusBundleArtifact>
-
-          <nexusBundleName>nexus-oss-webapp-${project.version}</nexusBundleName>
-
           <!-- | Remove the non-AOP Guice JAR from the unpacked Nexus distro -->
           <nexusBundleExcludes>
             **/sisu-guice-*.jar

--- a/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/NexusITFilter.java
+++ b/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/NexusITFilter.java
@@ -87,6 +87,27 @@ public class NexusITFilter
         return filter( defaultContext, value );
     }
 
+    @Override
+    public String filter( final Map<String, String> context, final String value )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+
+        // filter the value until filters does not do any more changes
+        String previousValue;
+        String filteredValue = value;
+        do
+        {
+            previousValue = filteredValue;
+            filteredValue = super.filter( context, previousValue );
+        }
+        while ( filteredValue != null && !filteredValue.equals( previousValue ) );
+
+        return filteredValue;
+    }
+
     public static Map.Entry<String, String> contextEntry( final String key, final String value )
     {
         return new Map.Entry<String, String>()

--- a/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectDMFilter.java
+++ b/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectDMFilter.java
@@ -21,6 +21,7 @@ import javax.inject.Singleton;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.inject.Parameters;
 import org.sonatype.nexus.testsuite.support.Filter;
 import org.sonatype.sisu.maven.bridge.MavenModelResolver;
 import com.google.common.collect.Maps;
@@ -45,10 +46,10 @@ public class TestProjectDMFilter
      * @param modelResolver Model resolver used to resolve effective model of test project (pom). Cannot be null.
      */
     @Inject
-    public TestProjectDMFilter( @Named( "remote-model-resolver-using-settings" )
-                                final MavenModelResolver modelResolver )
+    public TestProjectDMFilter( @Named( "remote-model-resolver-using-settings" ) final MavenModelResolver modelResolver,
+                                @Parameters final Map<String, String> properties )
     {
-        super( modelResolver );
+        super( modelResolver, properties );
     }
 
     /**

--- a/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectFilter.java
+++ b/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectFilter.java
@@ -18,6 +18,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.model.Model;
+import org.sonatype.inject.Parameters;
 import org.sonatype.nexus.testsuite.support.Filter;
 import org.sonatype.sisu.maven.bridge.MavenModelResolver;
 import com.google.common.collect.Maps;
@@ -43,10 +44,10 @@ public class TestProjectFilter
      * @param modelResolver Model resolver used to resolve effective model of test project (pom). Cannot be null.
      */
     @Inject
-    public TestProjectFilter( @Named( "remote-model-resolver-using-settings" )
-                              final MavenModelResolver modelResolver )
+    public TestProjectFilter( @Named( "remote-model-resolver-using-settings" ) final MavenModelResolver modelResolver,
+                              @Parameters final Map<String, String> properties )
     {
-        super( modelResolver );
+        super( modelResolver, properties );
     }
 
     /**
@@ -70,6 +71,8 @@ public class TestProjectFilter
         {
             mappings.putAll( Maps.fromProperties( model.getProperties() ) );
         }
+
+        mappings.putAll( getProperties() );
 
         return mappings;
     }

--- a/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectFilterSupport.java
+++ b/nexus/nexus-test/nexus-testsuite-support/src/main/java/org/sonatype/nexus/testsuite/support/filters/TestProjectFilterSupport.java
@@ -17,8 +17,7 @@ import static org.sonatype.sisu.maven.bridge.support.ModelBuildingRequestBuilder
 
 import java.io.File;
 import java.util.Map;
-import javax.inject.Inject;
-import javax.inject.Named;
+import java.util.Properties;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuildingException;
@@ -45,15 +44,21 @@ public abstract class TestProjectFilterSupport
     private final MavenModelResolver modelResolver;
 
     /**
+     * Properties used to resolve model.
+     */
+    private final Map<String, String> properties;
+
+    /**
      * Constructor.
      *
      * @param modelResolver Model resolver used to resolve effective model of test project (pom). Cannot be null.
+     * @param properties    used to resolve model
      */
-    @Inject
-    public TestProjectFilterSupport( @Named( "remote-model-resolver-using-settings" )
-                                     final MavenModelResolver modelResolver )
+    public TestProjectFilterSupport( final MavenModelResolver modelResolver,
+                                     final Map<String, String> properties )
     {
         this.modelResolver = checkNotNull( modelResolver );
+        this.properties = checkNotNull( properties );
     }
 
     /**
@@ -77,7 +82,12 @@ public abstract class TestProjectFilterSupport
         {
             try
             {
-                final Model model = modelResolver.resolveModel( model().pom( new File( testProjectPomFile ) ) );
+                final Properties userProperties = new Properties();
+                userProperties.putAll( properties );
+
+                final Model model = modelResolver.resolveModel(
+                    model().pom( new File( testProjectPomFile ) ).setUserProperties( userProperties )
+                );
 
                 return mappings( context, value, model );
             }
@@ -88,6 +98,11 @@ public abstract class TestProjectFilterSupport
         }
 
         return mappings;
+    }
+
+    protected Map<String, String> getProperties()
+    {
+        return properties;
     }
 
     /**

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -189,6 +189,11 @@
     <surefire.version>2.10</surefire.version>
     <!-- HACK: Workaround for issue with IDEA loading nexus-plugins -->
     <nexus-plugin.type>nexus-plugin</nexus-plugin.type>
+
+    <it.nexus.bundle.groupId>org.sonatype.nexus</it.nexus.bundle.groupId>
+    <it.nexus.bundle.artifactId>nexus-oss-webapp</it.nexus.bundle.artifactId>
+    <it.nexus.bundle.version>${project.version}</it.nexus.bundle.version>
+
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
1. Switch to not install plugins if they exist in bundle used by IT
   This switch will allow running ITs against a bundle without installing the plugins specified by IT, in case that those plugins already exist in bundle (compared by grouped / artifactId)
2. Make possible to filter nexus bundle coordinates passed to its
   The new ITs are passing as ctor the coordinates fo teh bundle to run against. Make possible to filter that value using project/system properties
