### PR TITLE
[NEXUS-5325] Remove plexus-swizzle from depMgmt

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -182,7 +182,6 @@
     <plexus-jetty-testsuite.version>2.1</plexus-jetty-testsuite.version>
     <plexus.restlet.bridge.version>1.22</plexus.restlet.bridge.version>
     <plexus-security.version>2.8.3-SNAPSHOT</plexus-security.version>
-    <plexus-swizzle.version>1.2</plexus-swizzle.version>
     <plexus-task-scheduler.version>1.6.0</plexus-task-scheduler.version>
     <restlet.version>1.1.6-SONATYPE-5348-V4</restlet.version>
     <shiro.version>1.2.1</shiro.version>
@@ -1224,28 +1223,12 @@
       </dependency>
       <dependency>
         <groupId>org.sonatype.spice</groupId>
-        <artifactId>plexus-swizzle</artifactId>
-        <version>${plexus-swizzle.version}</version>
+        <artifactId>plexus-encryptor</artifactId>
+        <version>1.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>velocity</groupId>
-            <artifactId>velocity</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
This dependency was previously used by old problem reporting,
and is now unused.

https://builds.sonatype.org/job/nexus-oss-its-feature/447/
