### PR TITLE
MavenRepositoryReaderTest hits some external urls, move to IT (could spl...

### DIFF
--- a/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReaderIT.java
+++ b/nexus/nexus-core-plugins/nexus-rrb-plugin/src/test/java/org/sonatype/nexus/plugins/rrb/MavenRepositoryReaderIT.java
@@ -51,7 +51,7 @@ import com.ning.http.client.AsyncHttpClient;
  * 
  * @author bjorne
  */
-public class MavenRepositoryReaderTest
+public class MavenRepositoryReaderIT
 {
     MavenRepositoryReader reader; // The "class under test"
 


### PR DESCRIPTION
...it up non-external vs. external into 2 tests + support class, this was easier)

Minor change to avoid hitting external urls from unit test execution
