### PR TITLE
Use "proper" tattletale maven plugin.

### DIFF
--- a/nexus/nexus-oss-webapp-tattletale/pom.xml
+++ b/nexus/nexus-oss-webapp-tattletale/pom.xml
@@ -93,13 +93,13 @@
 
           <!-- do it! -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>tattletale-maven-plugin</artifactId>
-            <version>1.0</version>
+            <groupId>org.jboss.tattletale</groupId>
+            <artifactId>tattletale-maven</artifactId>
+            <version>1.1.2.Final</version>
             <executions>
               <execution>
                 <goals>
-                  <goal>tattletale</goal>
+                  <goal>report</goal>
                 </goals>
                 <configuration>
                   <source>${tattletale-source}</source>


### PR DESCRIPTION
Maven plugin for JBoss Tattletale was initially released
at 2010. March.

We "rolled" our own Tattletale Maven plugin at 2010. November,
based on proof-of-concept "hello tattletale" plugin created just
before "proper" JBoss plugin was released.
See http://code.google.com/p/indoorsdog-sandbox/source/browse/#svn/insuchaworld/hello-tattletale

Why didn't we go for "proper" JBoos plugin?

More details here:
https://issues.sonatype.org/browse/NXCM-2417

Note: JBoss plugin is LGPL licensed. But, this is about
plugin, has nothing to do with dependencies we ship.
It's part of the build only (maven-plugin)
