### PR TITLE
update cargo containers

### DIFF
--- a/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/pom.xml
@@ -303,22 +303,18 @@
                     <artifactItem>
                       <groupId>org.apache.tomcat</groupId>
                       <artifactId>apache-tomcat</artifactId>
-                      <version>6.0.29</version>
-                      <classifier>bundle</classifier>
-                      <type>tar.gz</type>
+                      <version>6.0.36</version>
+                      <type>zip</type>
                       <outputDirectory>${project.build.directory}/containers</outputDirectory>
-                      <!-- Excludes do not function with tar.gz bundles, and tar.gz bundle unpacking is very sloooooow -->
-                      <!--<excludes>**/webapps/**</excludes>-->
+                      <excludes>**/webapps/examples,**/webapps/docs,**webapps/ROOT,**/webapps/host-manager</excludes>
                     </artifactItem>
                     <artifactItem>
                       <groupId>org.apache.tomcat</groupId>
                       <artifactId>apache-tomcat</artifactId>
-                      <version>5.5.31</version>
-                      <classifier>bundle</classifier>
-                      <type>tar.gz</type>
+                      <version>7.0.32</version>
+                      <type>zip</type>
                       <outputDirectory>${project.build.directory}/containers</outputDirectory>
-                      <!-- Excludes do not function with tar.gz bundles, and tar.gz bundle unpacking is very sloooooow -->
-                      <!--<excludes>**/webapps/**</excludes>-->
+                      <excludes>**/webapps/examples,**/webapps/docs,**webapps/ROOT,**/webapps/host-manager</excludes>
                     </artifactItem>
                     <artifactItem>
                       <groupId>org.eclipse.jetty</groupId>

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Tomcat6WarCargoIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Tomcat6WarCargoIT.java
@@ -20,7 +20,7 @@ public class Nexus3860Tomcat6WarCargoIT
     @Override
     public File getContainerLocation()
     {
-        return util.resolveFile( "target/containers/apache-tomcat-6.0.29" );
+        return util.resolveFile( "target/containers/apache-tomcat-6.0.36" );
     }
 
     @Override

--- a/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Tomcat7WarCargoIT.java
+++ b/nexus/nexus-test-harness/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3860/Nexus3860Tomcat7WarCargoIT.java
@@ -14,18 +14,18 @@ package org.sonatype.nexus.integrationtests.nexus3860;
 
 import java.io.File;
 
-public class Nexus3860Tomcat5WarCargoIT
+public class Nexus3860Tomcat7WarCargoIT
     extends AbstractCargoIT
 {
     @Override
     public File getContainerLocation()
     {
-        return util.resolveFile( "target/containers/apache-tomcat-5.5.31" );
+        return util.resolveFile( "target/containers/apache-tomcat-7.0.32" );
     }
 
     @Override
     public String getContainer()
     {
-        return "tomcat5x";
+        return "tomcat7x";
     }
 }


### PR DESCRIPTION
- drop tomcat 5.5 as it is EOLed already
- add Tomcat 7
- use zip artifacts instead
- exclude web apps included with tomcat bundles to speed up startup time

as previously mentioned these containers are in the RSO third party repo.
