### PR TITLE
Extend RequestProcessor to be able to block item retrieval

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/RequestProcessor.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/repository/RequestProcessor.java
@@ -14,9 +14,13 @@ package org.sonatype.nexus.proxy.repository;
 
 import javax.inject.Singleton;
 
+import org.sonatype.nexus.proxy.AccessDeniedException;
+import org.sonatype.nexus.proxy.IllegalOperationException;
+import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
+import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.plugin.ExtensionPoint;
 
 /**
@@ -37,6 +41,18 @@ public interface RequestProcessor
      * @param action
      */
     boolean process( Repository repository, ResourceStoreRequest request, Action action );
+
+    /**
+     * Should the item be retrieved?
+     *
+     * @param repository from which the item is retrieved (not null)
+     * @param request    retrieval request (not null)
+     * @param item       item to be retrieved (not null
+     * @return true if item is allowed to be retrieved, false if item should be blocked. In case of false an generic
+     *         {@link org.sonatype.nexus.proxy.ItemNotFoundException} will be thrown.
+     */
+    boolean shouldRetrieve( Repository repository, ResourceStoreRequest request, StorageItem item )
+        throws IllegalOperationException, ItemNotFoundException, AccessDeniedException;
 
     /**
      * Request processor is able to override generic behaviour of Repositories in aspect of proxying.

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -653,6 +653,11 @@ public abstract class AbstractRepository
             throw new ItemNotFoundException( request, this );
         }
 
+        if ( !checkPostConditions( request, item ) )
+        {
+            throw new ItemNotFoundException( request, this );
+        }
+
         return item;
     }
 
@@ -1299,6 +1304,23 @@ public abstract class AbstractRepository
             for ( RequestProcessor processor : getRequestProcessors().values() )
             {
                 if ( !processor.process( this, request, action ) )
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean checkPostConditions( final ResourceStoreRequest request, final StorageItem item )
+        throws IllegalOperationException, ItemNotFoundException, AccessDeniedException
+    {
+        if ( getRequestProcessors().size() > 0 )
+        {
+            for ( RequestProcessor processor : getRequestProcessors().values() )
+            {
+                if ( !processor.shouldRetrieve( this, request, item ) )
                 {
                     return false;
                 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRequestProcessor.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRequestProcessor.java
@@ -12,9 +12,13 @@
  */
 package org.sonatype.nexus.proxy.repository;
 
+import org.sonatype.nexus.proxy.AccessDeniedException;
+import org.sonatype.nexus.proxy.IllegalOperationException;
+import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
+import org.sonatype.nexus.proxy.item.StorageItem;
 
 /**
  * A helper base class that makes it easier to create processors. Note: despite it's name, this class is not abstract
@@ -26,6 +30,15 @@ public abstract class AbstractRequestProcessor
     implements RequestProcessor
 {
     public boolean process( Repository repository, ResourceStoreRequest request, Action action )
+    {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRetrieve( final Repository repository,
+                                   final ResourceStoreRequest request,
+                                   final StorageItem item )
+        throws IllegalOperationException, ItemNotFoundException, AccessDeniedException
     {
         return true;
     }


### PR DESCRIPTION
Extends RequestProcessor to be able to block an item retrieve request.

For example a request processor could make a request to Insight to check if the item to be retrieved has any vulnerabilities.
Another example an blacklist could stop retrieval on an artifact that is know to have problems.

Also implemented the blocking to collections in case of a repo that is not browseable by using a request processor.

---

Signed-off-by: Alin Dreghiciu adreghiciu@gmail.com
