### PR TITLE
Use HC4 client 4.2.x from DM

### DIFF
--- a/nexus/nexus-client-core/pom.xml
+++ b/nexus/nexus-client-core/pom.xml
@@ -122,6 +122,7 @@
       <version>1.12</version>
       <scope>compile</scope>
     </dependency>
+
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-apache-client4</artifactId>
@@ -132,8 +133,28 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- Exclude HC4 4.1.x and use 4.2.x instead, else Maven detects conflicts and will omit these required dependencies -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>


### PR DESCRIPTION
This should help resolve issues with nexus-launcher changes... mvn was completely omitting the httpclient dependencies as jetty hc4client depends on hc4 4.1, but we have 4.2 on everything else.

Fun!
