### PR TITLE
NEXUS-5250: Update to latest MI

### DIFF
--- a/nexus/nexus-core-plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/ArchetypeContentGenerator.java
+++ b/nexus/nexus-core-plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/ArchetypeContentGenerator.java
@@ -39,6 +39,9 @@ import org.sonatype.nexus.rest.RepositoryURLBuilder;
 public class ArchetypeContentGenerator
     implements ContentGenerator
 {
+    /**
+     * ID used as named parameter and as key in Item context to mark it as generated.
+     */
     public static final String ID = "ArchetypeContentGenerator";
 
     @Inject
@@ -67,9 +70,8 @@ public class ArchetypeContentGenerator
         item.setLength( -1 );
 
         return new ArchetypeContentLocator( repository,
-            repositoryURLBuilder.getExposedRepositoryContentUrl( repository ),
-            ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext( repository ), macPlugin,
-            new ArtifactInfoFilter()
+            repositoryURLBuilder.getExposedRepositoryContentUrl( repository ), (DefaultIndexerManager) indexerManager,
+            macPlugin, new ArtifactInfoFilter()
             {
                 public boolean accepts( IndexingContext ctx, ArtifactInfo ai )
                 {

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/pom.xml
@@ -29,8 +29,7 @@
   <name>Nexus Maven Indexer :: Plugin</name>
 
   <properties>
-    <maven.indexer.version>4.1.3-SONATYPE</maven.indexer.version>
-
+    <maven.indexer.version>5.0.0</maven.indexer.version>
     <nexus.plugin.name>Nexus Indexer Lucene Plugin</nexus.plugin.name>
     <nexus.plugin.description>Adds search capabilities for repository content.</nexus.plugin.description>
   </properties>

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/IndexerManager.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/IndexerManager.java
@@ -45,7 +45,8 @@ public interface IndexerManager
     /**
      * Shutdown of Indexer, with cleanup. It remove index files if needed.
      * 
-     * @param deleteFile set to true if you want to completely remove index files.
+     * @param deleteFiles set to true if you want to completely remove index files.
+     * @throws IOException
      */
     void shutdown( boolean deleteFiles )
         throws IOException;

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/NexusIndexingContext.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/NexusIndexingContext.java
@@ -1,0 +1,516 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.maven.index.artifact.GavCalculator;
+import org.apache.maven.index.context.DocumentFilter;
+import org.apache.maven.index.context.IndexCreator;
+import org.apache.maven.index.context.IndexingContext;
+import org.sonatype.scheduling.TaskUtil;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Nexus specific wrapper for Maven Indexer {@link IndexingContext}.
+ * 
+ * @author cstamas
+ * @since 2.3
+ */
+public class NexusIndexingContext
+    implements IndexingContext
+{
+    /**
+     * The MI context this instance delegates to.
+     */
+    private final IndexingContext delegate;
+
+    /**
+     * {@link ReentrantReadWriteLock} instance, used to synchronize access. The nice thing, is that this lock will obey
+     * the "sisu-resource-locks" property (possible values: "local" or "hazelcast"), and will expose lock and thread
+     * informations over JMX usable for debug, or just inspection.
+     */
+    private final ReentrantReadWriteLock lock;
+
+    /**
+     * Flag marking this context as closed. Returns {@code true} if {@link #close(boolean)} operation has been invoked
+     * on this instance.
+     */
+    private volatile boolean closed;
+
+    /**
+     * Constructor.
+     * 
+     * @param delegate
+     */
+    public NexusIndexingContext( final IndexingContext delegate )
+    {
+        this.delegate = Preconditions.checkNotNull( delegate );
+        this.lock = new ReentrantReadWriteLock();
+        this.closed = false;
+    }
+
+    /**
+     * Returns the MI "native" {@link IndexingContext}. The returned instance is unprotected!
+     * 
+     * @return native context.
+     */
+    public IndexingContext getDelegate()
+    {
+        return delegate;
+    }
+
+    /**
+     * Returns the lock of this context.
+     * 
+     * @return the lock.
+     */
+    public ReentrantReadWriteLock getLock()
+    {
+        return lock;
+    }
+
+    // ==
+
+    protected void failIfClosedOrInterrupted()
+    {
+        if ( closed )
+        {
+            throw new IllegalStateException( "IndexingContext is closed!" );
+        }
+        TaskUtil.checkInterruption();
+    }
+    
+    // ==
+
+    @Override
+    public void close( boolean deleteFiles )
+        throws IOException
+    {
+        lock.writeLock().lock();
+        try
+        {
+            delegate.close( deleteFiles );
+        }
+        finally
+        {
+            closed = true;
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void purge()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.writeLock().lock();
+        try
+        {
+            delegate.purge();
+        }
+        finally
+        {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void replace( Directory directory )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.writeLock().lock();
+        try
+        {
+            delegate.replace( directory );
+        }
+        finally
+        {
+            lock.writeLock().unlock();
+        }
+    }
+
+    // ==
+    // These below operate on IndexSearcher, excluded by operations above
+    // that nullifies it
+
+    @Override
+    public void merge( Directory directory )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.merge( directory );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void merge( Directory directory, DocumentFilter filter )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.merge( directory, filter );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Date getTimestamp()
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            return delegate.getTimestamp();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void updateTimestamp()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.updateTimestamp();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void updateTimestamp( boolean save )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.updateTimestamp( save );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void updateTimestamp( boolean save, Date date )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.updateTimestamp( save, date );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public int getSize()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            return delegate.getSize();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public IndexSearcher acquireIndexSearcher()
+        throws IOException
+    {
+        TaskUtil.checkInterruption();
+        // acquire searcher should NOT fail if it is closed when it comes to search
+        lock.readLock().lock();
+        if ( closed )
+        {
+            return DefaultIndexerManager.EMPTY_CTX.acquireIndexSearcher();
+        }
+        else
+        {
+            return delegate.acquireIndexSearcher();
+        }
+    }
+
+    @Override
+    public void releaseIndexSearcher( IndexSearcher s )
+        throws IOException
+    {
+        // acquire searcher should NOT fail if it is closed when it comes to search
+        // not: we were HOLDING read (shared) lock, so it is not possible to have it closed
+        // between acquireIndexSearcher() and this method call
+        if ( closed )
+        {
+            DefaultIndexerManager.EMPTY_CTX.releaseIndexSearcher( s );
+        }
+        else
+        {
+            try
+            {
+                // we must release even if closed 1st, since refCounting needs to be notified
+                // imple of Lucene refMgr will just decrement the counter
+                delegate.releaseIndexSearcher( s );
+                // after that above, we can fail to show an apparent bug: this method is invoked when it should not have
+                // been
+                failIfClosedOrInterrupted();
+            }
+            finally
+            {
+                lock.readLock().unlock();
+            }
+        }
+    }
+
+    @Override
+    public IndexWriter getIndexWriter()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        return delegate.getIndexWriter();
+    }
+
+    @Override
+    public void commit()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        delegate.commit();
+    }
+
+    @Override
+    public void rollback()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        delegate.rollback();
+    }
+
+    @Override
+    public void optimize()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.optimize();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void setAllGroups( Collection<String> groups )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.setAllGroups( groups );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<String> getAllGroups()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            return delegate.getAllGroups();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void setRootGroups( Collection<String> groups )
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.setRootGroups( groups );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<String> getRootGroups()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            return delegate.getRootGroups();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void rebuildGroups()
+        throws IOException
+    {
+        failIfClosedOrInterrupted();
+        lock.readLock().lock();
+        try
+        {
+            delegate.rebuildGroups();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    // these below do not affect indexer persisted state nor internal state (lucene indexes)
+    // so are not protected
+
+    @Override
+    public String getId()
+    {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getRepositoryId()
+    {
+        return delegate.getRepositoryId();
+    }
+
+    @Override
+    public File getRepository()
+    {
+        return delegate.getRepository();
+    }
+
+    @Override
+    public String getRepositoryUrl()
+    {
+        return delegate.getRepositoryUrl();
+    }
+
+    @Override
+    public String getIndexUpdateUrl()
+    {
+        return delegate.getIndexUpdateUrl();
+    }
+
+    @Override
+    public boolean isSearchable()
+    {
+        return delegate.isSearchable();
+    }
+
+    @Override
+    public void setSearchable( boolean searchable )
+    {
+        delegate.setSearchable( searchable );
+    }
+
+    @Override
+    public List<IndexCreator> getIndexCreators()
+    {
+        return delegate.getIndexCreators();
+    }
+
+    @Override
+    public Analyzer getAnalyzer()
+    {
+        return delegate.getAnalyzer();
+    }
+
+    @Override
+    public File getIndexDirectoryFile()
+    {
+        return delegate.getIndexDirectoryFile();
+    }
+
+    @Override
+    public Directory getIndexDirectory()
+    {
+        return delegate.getIndexDirectory();
+    }
+
+    @Override
+    public GavCalculator getGavCalculator()
+    {
+        return delegate.getGavCalculator();
+    }
+
+    @Override
+    public boolean isReceivingUpdates()
+    {
+        return delegate.isReceivingUpdates();
+    }
+}

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/index/AbstractIndexPlexusResource.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/index/AbstractIndexPlexusResource.java
@@ -156,86 +156,74 @@ public abstract class AbstractIndexPlexusResource
         // doing "plain search"
         final int RETRIES = 3;
 
-        int runCount = 0;
-
-        while ( runCount < RETRIES )
+        try
         {
             try
             {
-                try
+                int countRequested = count == null ? HIT_LIMIT : count;
+
+                searchResult =
+                    searchByTerms( terms, getRepositoryId( request ), from, countRequested, exact, expandVersion,
+                        expandPackaging, expandClassifier, collapseResults );
+
+                result.setTooManyResults( searchResult.getTotalHitsCount() > countRequested );
+
+                result.setTotalCount( searchResult.getTotalHitsCount() );
+
+                result.setFrom( from == null ? -1 : from.intValue() );
+
+                result.setCount( count == null ? -1 : count );
+
+                result.setData( new ArrayList<NexusArtifact>( ai2NaColl( request, searchResult.getResults() ) ) );
+
+                // if we had collapseResults ON, and the totalHits are larger than actual (filtered) results,
+                // and
+                // the actual result count is below COLLAPSE_OVERRIDE_TRESHOLD,
+                // and full result set is smaller than HIT_LIMIT
+                // then repeat without collapse
+                if ( collapseResults && result.getData().size() < searchResult.getTotalHitsCount()
+                    && result.getData().size() < COLLAPSE_OVERRIDE_TRESHOLD
+                    && searchResult.getTotalHitsCount() < HIT_LIMIT )
                 {
-                    int countRequested = count == null ? HIT_LIMIT : count;
-                    
-                    searchResult =
-                        searchByTerms( terms, getRepositoryId( request ), from, countRequested, exact,
-                            expandVersion, expandPackaging, expandClassifier, collapseResults );
-
-                    result.setTooManyResults( searchResult.getTotalHitsCount() > countRequested );
-
-                    result.setTotalCount( searchResult.getTotalHitsCount() );
-
-                    result.setFrom( from == null ? -1 : from.intValue() );
-
-                    result.setCount( count == null ? -1 : count );
-
-                    result.setData( new ArrayList<NexusArtifact>( ai2NaColl( request, searchResult.getResults() ) ) );
-
-                    // if we had collapseResults ON, and the totalHits are larger than actual (filtered) results,
-                    // and
-                    // the actual result count is below COLLAPSE_OVERRIDE_TRESHOLD,
-                    // and full result set is smaller than HIT_LIMIT
-                    // then repeat without collapse
-                    if ( collapseResults && result.getData().size() < searchResult.getTotalHitsCount()
-                        && result.getData().size() < COLLAPSE_OVERRIDE_TRESHOLD
-                        && searchResult.getTotalHitsCount() < HIT_LIMIT )
-                    {
-                        collapseResults = false;
-
-                        continue;
-                    }
-
-                    // we came here, so we break the while-loop, we got what we need
-                    break;
-                }
-                catch ( NoSuchRepositoryException e )
-                {
-                    throw new ResourceException( Status.CLIENT_ERROR_BAD_REQUEST, "Repository with ID='"
-                        + getRepositoryId( request ) + "' does not exists!", e );
-                }
-                catch ( AlreadyClosedException e )
-                {
-                    getLogger().info(
-                        "*** NexusIndexer bug, we got AlreadyClosedException that should never happen with ReadOnly IndexReaders! Please put Nexus into DEBUG log mode and report this issue together with the stack trace!" );
-
-                    if ( getLogger().isDebugEnabled() )
-                    {
-                        // just keep it silent (DEBUG)
-                        getLogger().debug( "Got AlreadyClosedException exception!", e );
-                    }
-
-                    result.setData( null );
-                }
-                finally
-                {
-                    if ( searchResult != null )
-                    {
-                        try
-                        {
-                            searchResult.close();
-                        }
-                        catch ( IOException e )
-                        {
-                            throw new ResourceException( Status.SERVER_ERROR_INTERNAL, e.getMessage(), e );
-                        }
-                    }
+                    collapseResults = false;
                 }
             }
-            catch ( IOException e )
+            catch ( NoSuchRepositoryException e )
             {
-                throw new ResourceException( Status.SERVER_ERROR_INTERNAL, e.getMessage(), e );
+                throw new ResourceException( Status.CLIENT_ERROR_BAD_REQUEST, "Repository with ID='"
+                    + getRepositoryId( request ) + "' does not exists!", e );
             }
+            catch ( AlreadyClosedException e )
+            {
+                getLogger().info(
+                    "*** NexusIndexer bug, we got AlreadyClosedException that should never happen with ReadOnly IndexReaders! Please put Nexus into DEBUG log mode and report this issue together with the stack trace!" );
 
-            runCount++;
+                if ( getLogger().isDebugEnabled() )
+                {
+                    // just keep it silent (DEBUG)
+                    getLogger().debug( "Got AlreadyClosedException exception!", e );
+                }
+
+                result.setData( null );
+            }
+            finally
+            {
+                if ( searchResult != null )
+                {
+                    try
+                    {
+                        searchResult.close();
+                    }
+                    catch ( IOException e )
+                    {
+                        throw new ResourceException( Status.SERVER_ERROR_INTERNAL, e.getMessage(), e );
+                    }
+                }
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new ResourceException( Status.SERVER_ERROR_INTERNAL, e.getMessage(), e );
         }
 
         if ( result.getData() == null )

--- a/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus3578IndexerManagerIT.java
+++ b/nexus/nexus-core-plugins/nexus-indexer-lucene-plugin-parent/nexus-indexer-lucene-plugin/src/test/java/org/sonatype/nexus/index/Nexus3578IndexerManagerIT.java
@@ -55,7 +55,7 @@ public class Nexus3578IndexerManagerIT
         super.setUp();
 
         hackContext( (DefaultIndexingContext) ( (DefaultIndexerManager) indexerManager ).getRepositoryIndexContext(
-            snapshots.getId() ) );
+            snapshots.getId() ).getDelegate() );
 
         this.mimeUtil = lookup( MimeUtil.class );
 


### PR DESCRIPTION
This is an update to latest MI (5.0.0 as of today).

Most notable changes is fixed locking, as deadlocks are now avoided.

The "worst case" where a search operation (search on UI, or even archetype catalog retrieval, that also sources info from index) would become blocked during reindex is somewhat "fixed": context being reindexed will not be searched, and catalog for reindexed repository will be empty.
