### PR TITLE
Nexus appevents

### DIFF
--- a/nexus/nexus-appevents/pom.xml
+++ b/nexus/nexus-appevents/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Sonatype Nexus (TM) Open Source Version
@@ -22,60 +23,18 @@
     <version>2.3-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nexus-api</artifactId>
-  <name>Nexus : API</name>
+  <artifactId>nexus-appevents</artifactId>
 
   <dependencies>
     <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-guice</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.nexus</groupId>
-      <artifactId>nexus-utils</artifactId>
-    </dependency>
-
-    <!-- Here for "compatibility" reason only! -->
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-plexus</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.nexus</groupId>
-      <artifactId>nexus-appevents</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-task-scheduler</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.configuration</groupId>
-      <artifactId>base-configuration</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-locks</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>eu.medsea.mimeutil</groupId>
-      <artifactId>mime-util</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.plugin</groupId>
-      <artifactId>plugin-host-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.nexus</groupId>
-      <artifactId>nexus-test-common</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractApplicationEventListener.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractApplicationEventListener.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
  *
  * @since 2.3
  *
- * @deprecated Sisu should detect listeners if bound properly.
+ * @deprecated Sisu should detect listeners if bound properly (ie. @Named or explicit module binding to EventListener.class).
  */
 @Deprecated
 public abstract class AbstractApplicationEventListener

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractApplicationEventListener.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractApplicationEventListener.java
@@ -1,0 +1,32 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import javax.inject.Inject;
+
+/**
+ * Support for {@link EventListener} implementations.
+ *
+ * @since 2.3
+ *
+ * @deprecated Sisu should detect listeners if bound properly.
+ */
+@Deprecated
+public abstract class AbstractApplicationEventListener
+    implements EventListener
+{
+    @Inject
+    public AbstractApplicationEventListener(final ApplicationEventMulticaster multicaster) {
+        multicaster.addEventListener(this);
+    }
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractEvent.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractEvent.java
@@ -1,0 +1,79 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The superclass for all events.
+ *
+ * @author cstamas
+ *
+ * @since 2.3
+ */
+public abstract class AbstractEvent<T>
+    implements Event<T>
+{
+    /**
+     * The event date.
+     */
+    private final Date eventDate;
+
+    /**
+     * The event context
+     */
+    private final HashMap<Object, Object> eventContext;
+
+    /**
+     * The sender
+     */
+    private final T eventSender;
+
+    /**
+     * Instantiates a new abstract event.
+     */
+    public AbstractEvent(final T component) {
+        this.eventDate = new Date();
+        this.eventContext = new HashMap<Object, Object>();
+        this.eventSender = component;
+    }
+
+    /**
+     * Gets the event date.
+     *
+     * @return the event date
+     */
+    public Date getEventDate() {
+        return eventDate;
+    }
+
+    /**
+     * Gets the modifiable event context.
+     *
+     * @return the event context
+     */
+    public Map<Object, Object> getEventContext() {
+        return eventContext;
+    }
+
+    /**
+     * Gets the sender
+     *
+     * @return the event sender
+     */
+    public T getEventSender() {
+        return eventSender;
+    }
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractSimpleEventMulticaster.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/AbstractSimpleEventMulticaster.java
@@ -1,0 +1,57 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.plexus.appevents.Event;
+import org.sonatype.plexus.appevents.EventListener;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Support for {@link SimpleEventMulticaster} implementations.
+ *
+ * @author cstamas
+ * @since 2.3
+ */
+public abstract class AbstractSimpleEventMulticaster
+{
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final CopyOnWriteArrayList<EventListener> listeners = new CopyOnWriteArrayList<EventListener>();
+
+    public void addEventListener(final EventListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeEventListener(final EventListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void notifyEventListeners(final Event<?> event) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notifying {} EventListener about event {} fired ({})", listeners.size(), event.getClass().getName(), event);
+        }
+
+        for (EventListener listener : listeners) {
+            if (listener == null) continue;
+            try {
+                listener.onEvent(event);
+            }
+            catch (Exception e) {
+                logger.info("Unexpected exception in listener {}, continuing listener notification.", listener.getClass().getName(), e);
+            }
+        }
+    }
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/ApplicationEventMulticaster.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/ApplicationEventMulticaster.java
@@ -1,0 +1,26 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+/**
+ * Central component serving as event hub for application.
+ *
+ * @author cstamas
+ *
+ * @since 2.3
+ */
+public interface ApplicationEventMulticaster
+    extends EventMulticaster
+{
+    // empty
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/Event.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/Event.java
@@ -1,0 +1,44 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Defines basic exposed event data.
+ *
+ * @param <T> Sender type.
+ *
+ * @since 2.3
+ */
+public interface Event<T>
+{
+    /**
+     * Returns the timestamp of the creation of this event object. It's usage is left for consumer of this event (or
+     * creator).
+     */
+    Date getEventDate();
+
+    /**
+     * Returns the modifiable event context. It may be used for some sort of data or object passing between event
+     * consumer. This interface is not guaranteeing any processing order, so it is left to user of this api to sort this
+     * out.
+     */
+    Map<Object, Object> getEventContext();
+
+    /**
+     * Returns the event sender/initiator.
+     */
+    T getEventSender();
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/EventListener.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/EventListener.java
@@ -1,0 +1,32 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+/**
+ * The listener interface for receiving events. The class that is interested in processing a event implements this
+ * interface, and the object created with that class is registered with a component using the component's
+ * <code>addEventListener<code> method. When
+ * the  event occurs, that object's appropriate
+ * method is invoked.
+ *
+ * @see Event
+ */
+public interface EventListener
+{
+    /**
+     * On event.
+     *
+     * @param event the event.
+     */
+    void onEvent(Event<?> event);
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/EventMulticaster.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/EventMulticaster.java
@@ -1,0 +1,45 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+/**
+ * Event multicaster.
+ *
+ * @since 2.3
+ *
+ * @see Event
+ * @see EventListener
+ */
+public interface EventMulticaster
+{
+    /**
+     * Adds an event listener.
+     *
+     * @param listener the listener
+     */
+    void addEventListener(EventListener listener);
+
+    /**
+     * Removes an event listener.
+     *
+     * @param listener the listener
+     */
+    void removeEventListener(EventListener listener);
+
+    /**
+     * Notify event listeners.
+     *
+     * @param event the evt
+     */
+    void notifyEventListeners(Event<?> event);
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/SimpleApplicationEventMulticaster.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/SimpleApplicationEventMulticaster.java
@@ -1,0 +1,32 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Simple {@link ApplicationEventMulticaster}.
+ *
+ * @author cstamas
+ *
+ * @since 2.3
+ */
+@Named
+@Singleton
+public class SimpleApplicationEventMulticaster
+    extends AbstractSimpleEventMulticaster
+    implements ApplicationEventMulticaster
+{
+    // empty
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/SimpleEventMulticaster.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/SimpleEventMulticaster.java
@@ -1,0 +1,32 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.plexus.appevents;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Simple {@link EventMulticaster}.
+ *
+ * @author cstamas
+ *
+ * @since 2.3
+ */
+@Named
+@Singleton
+public class SimpleEventMulticaster
+    extends AbstractSimpleEventMulticaster
+    implements EventMulticaster
+{
+    // empty
+}

--- a/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/package-info.java
+++ b/nexus/nexus-appevents/src/main/java/org/sonatype/plexus/appevents/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+/**
+ * Retaining the original package {@code org.sonatype.plexus.appevents} for compatibility with other NX components.
+ *
+ * Instead of spending the effort to repackage everything, probably better spent changing to use a
+ * Guava EventBus-style event handling mechanism instead.
+ */
+package org.sonatype.plexus.appevents;

--- a/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
+++ b/nexus/nexus-core-plugins/nexus-ldap-plugin-parent/nexus-ldap-realm-plugin/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.plexus.appevents</groupId>
-      <artifactId>plexus-app-events-api</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-appevents</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/nexus/nexus-plugins/nexus-plugin-api/pom.xml
+++ b/nexus/nexus-plugins/nexus-plugin-api/pom.xml
@@ -105,20 +105,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
-      <groupId>org.sonatype.plexus.appevents</groupId>
-      <artifactId>plexus-app-events-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-appevents</artifactId>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-mailer</artifactId>

--- a/nexus/nexus-proxy/pom.xml
+++ b/nexus/nexus-proxy/pom.xml
@@ -54,14 +54,12 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
+
     <dependency>
-      <groupId>org.sonatype.plexus.appevents</groupId>
-      <artifactId>plexus-app-events-api</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-appevents</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.sonatype.plexus.appevents</groupId>
-      <artifactId>simple-event-multicaster</artifactId>
-    </dependency>
+
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/nexus/nexus-web-utils/pom.xml
+++ b/nexus/nexus-web-utils/pom.xml
@@ -85,8 +85,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.plexus.appevents</groupId>
-      <artifactId>simple-event-multicaster</artifactId>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-appevents</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -329,30 +329,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.plexus.appevents</groupId>
-        <artifactId>plexus-app-events-api</artifactId>
-        <version>1.2</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.sonatype.plexus.appevents</groupId>
-        <artifactId>simple-event-multicaster</artifactId>
-        <version>1.2</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
         <version>2.1.1</version>
@@ -1093,6 +1069,11 @@
 
       <dependency>
         <groupId>org.sonatype.nexus</groupId>
+        <artifactId>nexus-appevents</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.nexus</groupId>
         <artifactId>nexus-bootstrap</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1826,6 +1807,7 @@
   </build>
 
   <modules>
+    <module>nexus-appevents</module>
     <module>nexus-bootstrap</module>
     <module>nexus-plugins</module>
     <module>nexus-mock</module>


### PR DESCRIPTION
Move app-events into nexus, its only used by this project.

Obsoletes: https://github.com/sonatype/sisu-goodies/pull/7

Keeping same package from original plexus-app-events for compatibility.

Added javadocs and some notes.
