### PR TITLE
Retry handlers fix

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImpl.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImpl.java
@@ -319,13 +319,7 @@ public class Hc4ProviderImpl
     @Override
     public DefaultHttpClient createHttpClient( final RemoteStorageContext context )
     {
-        final DefaultHttpClient httpClient = createHttpClient( context, sharedConnectionManager );
-        // obey the given retries count and apply it to client.
-        final int retries =
-            context.getRemoteConnectionSettings() != null ? context.getRemoteConnectionSettings().getRetrievalRetryCount()
-                : 0;
-        httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( retries, false ) );
-        return httpClient;
+        return createHttpClient( context, sharedConnectionManager );
     }
 
     // ==
@@ -357,6 +351,11 @@ public class Hc4ProviderImpl
             new DefaultHttpClientImpl( clientConnectionManager, createHttpParams( context ) );
         configureAuthentication( httpClient, context.getRemoteAuthenticationSettings(), null );
         configureProxy( httpClient, context.getRemoteProxySettings() );
+        // obey the given retries count and apply it to client.
+        final int retries =
+            context.getRemoteConnectionSettings() != null ? context.getRemoteConnectionSettings().getRetrievalRetryCount()
+                : 0;
+        httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( retries, false ) );
         return httpClient;
     }
 

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImpl.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImpl.java
@@ -42,6 +42,7 @@ import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
@@ -162,6 +163,7 @@ public class Hc4ProviderImpl
      * @param applicationConfiguration the Nexus {@link ApplicationConfiguration}.
      * @param userAgentBuilder UA builder component.
      * @param multicaster the event multicaster
+     * @param jmxInstaller installer to expose pool information over JMX.
      */
     @Inject
     public Hc4ProviderImpl( final ApplicationConfiguration applicationConfiguration,
@@ -178,14 +180,14 @@ public class Hc4ProviderImpl
         this.applicationEventMulticaster.addEventListener( this );
         this.jmxInstaller.register( sharedConnectionManager );
         getLogger().info( "{} started up (keep-alive {} millis), listening for shutdown.", getClass().getSimpleName(),
-                          getConnectionPoolKeepalive() );
+            getConnectionPoolKeepalive() );
     }
 
     // configuration
 
     /**
      * Returns the pool max size.
-     *
+     * 
      * @return pool max size
      */
     protected int getConnectionPoolMaxSize()
@@ -195,7 +197,7 @@ public class Hc4ProviderImpl
 
     /**
      * Returns the pool size per route.
-     *
+     * 
      * @return pool per route size
      */
     protected int getConnectionPoolSize()
@@ -205,7 +207,7 @@ public class Hc4ProviderImpl
 
     /**
      * Returns the keep alive (idle open) time in milliseconds.
-     *
+     * 
      * @return keep alive in milliseconds.
      */
     protected long getConnectionPoolKeepalive()
@@ -215,7 +217,7 @@ public class Hc4ProviderImpl
 
     /**
      * Returns the pool timeout in milliseconds.
-     *
+     * 
      * @return pool timeout in milliseconds.
      */
     protected long getConnectionPoolTimeout()
@@ -317,7 +319,13 @@ public class Hc4ProviderImpl
     @Override
     public DefaultHttpClient createHttpClient( final RemoteStorageContext context )
     {
-        return createHttpClient( context, sharedConnectionManager );
+        final DefaultHttpClient httpClient = createHttpClient( context, sharedConnectionManager );
+        // obey the given retries count and apply it to client.
+        final int retries =
+            context.getRemoteConnectionSettings() != null ? context.getRemoteConnectionSettings().getRetrievalRetryCount()
+                : 0;
+        httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( retries, false ) );
+        return httpClient;
     }
 
     // ==
@@ -345,7 +353,8 @@ public class Hc4ProviderImpl
     protected DefaultHttpClient createHttpClient( final RemoteStorageContext context,
                                                   final ClientConnectionManager clientConnectionManager )
     {
-        final DefaultHttpClient httpClient = new DefaultHttpClientImpl( clientConnectionManager, createHttpParams( context ) );
+        final DefaultHttpClient httpClient =
+            new DefaultHttpClientImpl( clientConnectionManager, createHttpParams( context ) );
         configureAuthentication( httpClient, context.getRemoteAuthenticationSettings(), null );
         configureProxy( httpClient, context.getRemoteProxySettings() );
         return httpClient;

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/PoolingClientConnectionManagerMBeanInstaller.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/apachehttpclient/PoolingClientConnectionManagerMBeanInstaller.java
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory;
 /**
  * An wrapper {@link Hc4Provider} that automatically registers / unregisters JMX MBeans for each created
  * {@link HttpClient}s and {@link PoolingClientConnectionManager}.
- *
+ * 
  * @since 2.2
  */
-@Named()
+@Named
 @Singleton
 public class PoolingClientConnectionManagerMBeanInstaller
 {
@@ -40,25 +40,27 @@ public class PoolingClientConnectionManagerMBeanInstaller
 
     private ObjectName jmxName;
 
+    /**
+     * Registers the connection manager to JMX.
+     * 
+     * @param connectionManager
+     */
     public synchronized void register( final PoolingClientConnectionManager connectionManager )
     {
         if ( jmxName == null )
         {
             try
             {
-                jmxName = ObjectName.getInstance(
-                    JMX_DOMAIN, "name", PoolingClientConnectionManager.class.getSimpleName()
-                );
+                jmxName =
+                    ObjectName.getInstance( JMX_DOMAIN, "name", PoolingClientConnectionManager.class.getSimpleName() );
 
                 final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
                 server.registerMBean( new PoolingClientConnectionManagerMBeanImpl( connectionManager ), jmxName );
             }
             catch ( final Exception e )
             {
-                LOGGER.warn(
-                    "Failed to register mbean {} due to {}:{}",
-                    new Object[]{ jmxName, e.getClass(), e.getMessage() }
-                );
+                LOGGER.warn( "Failed to register mbean {} due to {}:{}",
+                    new Object[] { jmxName, e.getClass(), e.getMessage() } );
                 jmxName = null;
             }
         }
@@ -68,6 +70,9 @@ public class PoolingClientConnectionManagerMBeanInstaller
         }
     }
 
+    /**
+     * Unregisters the connection manager from JMX.
+     */
     public synchronized void unregister()
     {
         if ( jmxName != null )
@@ -79,10 +84,8 @@ public class PoolingClientConnectionManagerMBeanInstaller
             }
             catch ( final Exception e )
             {
-                LOGGER.warn(
-                    "Failed to unregister mbean {} due to {}:{}",
-                    new Object[]{ jmxName, e.getClass(), e.getMessage() }
-                );
+                LOGGER.warn( "Failed to unregister mbean {} due to {}:{}",
+                    new Object[] { jmxName, e.getClass(), e.getMessage() } );
             }
             finally
             {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
@@ -70,7 +70,7 @@ public class HttpClientManagerImpl
         Preconditions.checkNotNull( ctx );
         final DefaultHttpClient httpClient = (DefaultHttpClient) hc4Provider.createHttpClient( ctx );
         // RRS/Proxy repositories handle retries manually, so kill the retry handler set by Hc4Provider
-        httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( 0, false ) );
+        // httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( 0, false ) );
         configure( proxyRepository, ctx, httpClient );
         return httpClient;
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerImpl.java
@@ -23,6 +23,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.RedirectStrategy;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.params.HttpProtocolParams;
 import org.apache.http.protocol.HttpContext;
 import org.sonatype.nexus.apachehttpclient.Hc4Provider;
@@ -68,6 +69,8 @@ public class HttpClientManagerImpl
         Preconditions.checkNotNull( proxyRepository );
         Preconditions.checkNotNull( ctx );
         final DefaultHttpClient httpClient = (DefaultHttpClient) hc4Provider.createHttpClient( ctx );
+        // RRS/Proxy repositories handle retries manually, so kill the retry handler set by Hc4Provider
+        httpClient.setHttpRequestRetryHandler( new StandardHttpRequestRetryHandler( 0, false ) );
         configure( proxyRepository, ctx, httpClient );
         return httpClient;
     }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImplTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/apachehttpclient/Hc4ProviderImplTest.java
@@ -19,6 +19,7 @@ import org.apache.http.client.params.ClientPNames;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.params.HttpConnectionParams;
 import org.junit.Assert;
@@ -43,7 +44,7 @@ public class Hc4ProviderImplTest
 
     @Mock
     private UserAgentBuilder userAgentBuilder;
-    
+
     @Mock
     private ApplicationEventMulticaster multicaster;
 
@@ -79,7 +80,17 @@ public class Hc4ProviderImplTest
             // shared client does not reuse connections (no pool)
             Assert.assertTrue( ( (DefaultHttpClient) client ).getConnectionReuseStrategy() instanceof NoConnectionReuseStrategy );
             Assert.assertTrue( ( (DefaultHttpClient) client ).getConnectionManager() instanceof PoolingClientConnectionManager );
-            // check is all set as needed
+
+            // check is all set as needed: retries
+            Assert.assertTrue( ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() instanceof StandardHttpRequestRetryHandler );
+            Assert.assertEquals(
+                globalRemoteStorageContext.getRemoteConnectionSettings().getRetrievalRetryCount(),
+                ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).getRetryCount() );
+            Assert.assertEquals(
+                false,
+                ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).isRequestSentRetryEnabled() );
+
+            // check is all set as needed: everything else
             Assert.assertEquals( 1234L, client.getParams().getLongParameter( ClientPNames.CONN_MANAGER_TIMEOUT, 0 ) );
             Assert.assertEquals( 1234, client.getParams().getIntParameter( HttpConnectionParams.CONNECTION_TIMEOUT, 0 ) );
             Assert.assertEquals( 1234, client.getParams().getIntParameter( HttpConnectionParams.SO_TIMEOUT, 0 ) );
@@ -111,7 +122,17 @@ public class Hc4ProviderImplTest
             // shared client does reuse connections (does pool)
             Assert.assertTrue( ( (DefaultHttpClient) client ).getConnectionReuseStrategy() instanceof DefaultConnectionReuseStrategy );
             Assert.assertTrue( ( (DefaultHttpClient) client ).getConnectionManager() instanceof PoolingClientConnectionManager );
-            // check is all set as needed
+
+            // check is all set as needed: retries
+            Assert.assertTrue( ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() instanceof StandardHttpRequestRetryHandler );
+            Assert.assertEquals(
+                globalRemoteStorageContext.getRemoteConnectionSettings().getRetrievalRetryCount(),
+                ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).getRetryCount() );
+            Assert.assertEquals(
+                false,
+                ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).isRequestSentRetryEnabled() );
+
+            // check is all set as needed: everything else
             Assert.assertEquals( 1234L, client.getParams().getLongParameter( ClientPNames.CONN_MANAGER_TIMEOUT, 0 ) );
             Assert.assertEquals( 1234, client.getParams().getIntParameter( HttpConnectionParams.CONNECTION_TIMEOUT, 0 ) );
             Assert.assertEquals( 1234, client.getParams().getIntParameter( HttpConnectionParams.SO_TIMEOUT, 0 ) );

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/storage/remote/httpclient/HttpClientManagerTest.java
@@ -23,15 +23,24 @@ import org.apache.http.ProtocolException;
 import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
 import org.apache.http.client.RedirectStrategy;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.sonatype.nexus.apachehttpclient.Hc4Provider;
+import org.sonatype.nexus.apachehttpclient.Hc4ProviderImpl;
+import org.sonatype.nexus.apachehttpclient.PoolingClientConnectionManagerMBeanInstaller;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.proxy.repository.DefaultRemoteConnectionSettings;
+import org.sonatype.nexus.proxy.repository.DefaultRemoteProxySettings;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
 import org.sonatype.nexus.proxy.utils.UserAgentBuilder;
+import org.sonatype.plexus.appevents.ApplicationEventMulticaster;
 import org.sonatype.sisu.litmus.testsupport.TestSupport;
 
 /**
@@ -43,16 +52,22 @@ public class HttpClientManagerTest
     @Mock
     private ProxyRepository proxyRepository;
 
-    @Mock
-    private RemoteStorageContext ctx;
-
     // ==
 
     @Mock
-    private Hc4Provider hc4Provider;
+    private ApplicationConfiguration applicationConfiguration;
 
     @Mock
     private UserAgentBuilder userAgentBuilder;
+
+    @Mock
+    private ApplicationEventMulticaster multicaster;
+
+    @Mock
+    private RemoteStorageContext globalRemoteStorageContext;
+
+    @Mock
+    private PoolingClientConnectionManagerMBeanInstaller jmxInstaller;
 
     @Mock
     private HttpRequest request;
@@ -69,21 +84,35 @@ public class HttpClientManagerTest
     @Mock
     private RequestLine requestLine;
 
-    private RedirectStrategy underTest;
+    private Hc4Provider hc4Provider;
+
+    private HttpClientManagerImpl httpClientManager;
 
     @Before
     public void before()
     {
+        final DefaultRemoteConnectionSettings rcs = new DefaultRemoteConnectionSettings();
+        rcs.setConnectionTimeout( 10000 );
+        when( globalRemoteStorageContext.getRemoteConnectionSettings() ).thenReturn( rcs );
+        when( globalRemoteStorageContext.getRemoteProxySettings() ).thenReturn( new DefaultRemoteProxySettings() );
+        when( applicationConfiguration.getGlobalRemoteStorageContext() ).thenReturn( globalRemoteStorageContext );
+
+        hc4Provider = new Hc4ProviderImpl( applicationConfiguration, userAgentBuilder, multicaster, jmxInstaller );
+
         when( proxyRepository.getId() ).thenReturn( "central" );
         when( response.getStatusLine() ).thenReturn( statusLine );
         when( request.getRequestLine() ).thenReturn( requestLine );
-        underTest = new HttpClientManagerImpl( hc4Provider, userAgentBuilder ).getProxyRepositoryRedirectStrategy( proxyRepository, ctx );
+
+        httpClientManager = new HttpClientManagerImpl( hc4Provider, userAgentBuilder );
     }
 
     @Test
     public void doNotFollowRedirectsToDirIndex()
         throws ProtocolException
     {
+        final RedirectStrategy underTest =
+            httpClientManager.getProxyRepositoryRedirectStrategy( proxyRepository, globalRemoteStorageContext );
+
         // no location header
         when( requestLine.getMethod() ).thenReturn( "GET" );
         assertThat( underTest.isRedirected( request, response, httpContext ), is( false ) );
@@ -98,5 +127,22 @@ public class HttpClientManagerTest
         when( statusLine.getStatusCode() ).thenReturn( HttpStatus.SC_MOVED_TEMPORARILY );
         when( response.getFirstHeader( "location" ) ).thenReturn( new BasicHeader( "location", "http://localhost/dir/" ) );
         assertThat( underTest.isRedirected( request, response, httpContext ), is( false ) );
+    }
+
+    @Test
+    public void doNotHandleRetries()
+    {
+        final DefaultHttpClient client =
+            (DefaultHttpClient) new HttpClientManagerImpl( hc4Provider, userAgentBuilder ).create( proxyRepository,
+                globalRemoteStorageContext );
+        // check is all set as needed: retries should be not attempted, as it is manually handled in proxy repo
+        Assert.assertTrue( ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() instanceof StandardHttpRequestRetryHandler );
+        Assert.assertTrue( globalRemoteStorageContext.getRemoteConnectionSettings().getRetrievalRetryCount() != 0 );
+        Assert.assertEquals(
+            0,
+            ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).getRetryCount() );
+        Assert.assertEquals(
+            false,
+            ( (StandardHttpRequestRetryHandler) ( (DefaultHttpClient) client ).getHttpRequestRetryHandler() ).isRequestSentRetryEnabled() );
     }
 }


### PR DESCRIPTION
Seems that Hc4Provider misses to set retry handler (default is 3).

But since AbstractProxy class also handler retries, we actually get 3x3 retries?

(seen in RSO logs)
