### PR TITLE
Add generation of shard configurations, and configure to run a shard

### DIFF
--- a/nexus/nexus-test/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/pom.xml
@@ -214,10 +214,14 @@
       </activation>
       <build>
         <plugins>
+          <!--
+          NOTE: Using patched version of surefire, which supports includes/excludes from files.
+          https://jira.codehaus.org/browse/SUREFIRE-925
+          -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.13-SNAPSHOT</version>
+            <version>2.13-SONATYPE-SNAPSHOT</version>
             <configuration>
               <includesFile>${settings.localRepository}/org/sonatype/nexus/${project.artifactId}/shards/shard-${testsuite.shardId}.txt</includesFile>
             </configuration>

--- a/nexus/nexus-test/nexus-test-harness-its/pom.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/pom.xml
@@ -29,18 +29,6 @@
     <cargo.version>1.3.0</cargo.version>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
 
     <!-- The IT Launcher -->
@@ -178,7 +166,66 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
+    <profile>
+      <id>testsuite-genshards</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>gmaven-plugin</artifactId>
+            <version>1.5-SNAPSHOT</version>
+            <executions>
+              <execution>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <providerSelection>1.7</providerSelection>
+                  <classpathIncludes>none</classpathIncludes>
+                  <source>file:${project.basedir}/src/test/script/genshards.groovy</source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>testsuite-shard</id>
+      <activation>
+        <property>
+          <name>testsuite.shardId</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.13-SNAPSHOT</version>
+            <configuration>
+              <includesFile>${settings.localRepository}/org/sonatype/nexus/${project.artifactId}/shards/shard-${testsuite.shardId}.txt</includesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>it</id>
       <activation>

--- a/nexus/nexus-test/nexus-test-harness-its/src/test/script/genshards.groovy
+++ b/nexus/nexus-test/nexus-test-harness-its/src/test/script/genshards.groovy
@@ -1,0 +1,59 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+import org.apache.tools.ant.DirectoryScanner
+
+def testDir = new File("${project.build.testSourceDirectory}")
+// NOTE: Stuffing this into the local repository, so that agents will have access to this w/o extra configuration
+def shardDir = new File("${settings.localRepository}/org/sonatype/nexus/${project.artifactId}/shards")
+def shardCount = 10
+def shards = [:]
+
+println "Scanning test-classes in ${testDir}"
+
+def scanner = new DirectoryScanner()
+scanner.basedir = testDir
+scanner.includes = [ '**/*IT.java' ]
+scanner.scan()
+
+println "Found ${scanner.includedFilesCount} test-classes"
+
+def iter = scanner.includedFiles.toList().iterator()
+def running = true
+while (running) {
+    for (i in 0 ..< shardCount) {
+        if (!iter.hasNext()) {
+            running = false
+        }
+        else {
+            def list = shards[i]
+            if (!list) {
+                shards[i] = list = []
+            }
+            list << iter.next()
+        }
+    }
+}
+
+println "Creating shard configurations in ${shardDir}"
+
+shards.each { key, value ->
+    println "Shard [$key] size=${value.size()}"
+    def file = new File(shardDir, "shard-${key}.txt")
+    file.parentFile.mkdirs()
+    file.withPrintWriter { writer ->
+        value.each {
+            writer.println "$it"
+        }
+    }
+}


### PR DESCRIPTION
Pending some bits to get surefire + gmaven updated, but this is basically the short-term plan to handle automatic sharding of nexus-test-harness-its test execution.
