### PR TITLE
Use timestamp as path prefix for aggregated js file

### DIFF
--- a/nexus/nexus-webapp/pom.xml
+++ b/nexus/nexus-webapp/pom.xml
@@ -261,7 +261,7 @@
               <aggregations>
                 <aggregation>
                   <insertNewLine>true</insertNewLine>
-                  <output>${compressed-dir}/js/sonatype-all.js</output>
+                  <output>${project.build.outputDirectory}/js/sonatype-all.js</output>
                   <inputDir>${project.build.directory}/generated-sources/yuicompressor/js</inputDir>
                   <excludes>
                     <exclude>lib/require*.js</exclude>
@@ -271,7 +271,7 @@
                   </includes> 
                 </aggregation>
                 <aggregation>
-                  <output>${compressed-dir}/style/sonatype-all.css</output>
+                  <output>${project.build.outputDirectory}/style/sonatype-all.css</output>
                   <inputDir>${project.build.directory}/generated-sources/yuicompressor/style</inputDir>
                   <includes>
                     <include>**/*.css</include>
@@ -334,15 +334,6 @@
             js/lib/*,
             style/sonatype-all.css
           </warSourceIncludes>
-          <webResources>
-            <webResource>
-              <directory>${compressed-dir}</directory>
-              <includes>
-                <include>**/sonatype-all.js</include>
-                <include>**/sonatype-all.css</include>
-              </includes>
-            </webResource>
-          </webResources>
         </configuration>
       </plugin>
 

--- a/nexus/nexus-webapp/src/main/webapp/js/ext/ux/browsebutton.js
+++ b/nexus/nexus-webapp/src/main/webapp/js/ext/ux/browsebutton.js
@@ -7,11 +7,6 @@ define('ext/ux/browsebutton',['extjs'], function(Ext){
 /*global Ext*/
 Ext.namespace('Ext.ux.form');
 
-// @author 4Him
-if(typeof Ext.isIE8 !== 'boolean') { // Ext 2.x (at least 2.1) doesn't know IE8. Let's tell him about it...
-    Ext.isIE8 = Ext.isIE && navigator.userAgent.toLowerCase().indexOf("msie 8")>-1;
-}
-
 /**
  * @class Ext.ux.form.BrowseButton
  * @extends Ext.Button

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/pom.xml
@@ -29,6 +29,9 @@
   <properties>
     <nexus.plugin.name>Nexus Restlet 1.x Plugin</nexus.plugin.name>
     <nexus.plugin.description>Provides Restlet 1.x REST API.</nexus.plugin.description>
+
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+    <build.timestamp>${maven.build.timestamp}</build.timestamp>
   </properties>
 
   <dependencies>
@@ -147,6 +150,15 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/filtered-resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/filtered-resources/org/sonatype/nexus/plugins/restlet1x/version.properties
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/filtered-resources/org/sonatype/nexus/plugins/restlet1x/version.properties
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2011-2012 Sonatype, Inc. All rights reserved.
+# Includes the third-party code listed at http://links.sonatype.com/products/rhc/oss/attributions.
+# "Sonatype" is a trademark of Sonatype, Inc.
+#
+
+version = ${build.timestamp}

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/BuildNumberService.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/BuildNumberService.java
@@ -1,0 +1,61 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.restlet1x;
+
+import java.io.InputStream;
+import java.util.Properties;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+@Singleton
+public class BuildNumberService
+{
+
+    private static final Logger logger = LoggerFactory.getLogger( BuildNumberService.class );
+
+    private final String buildNumber;
+
+    @Inject
+    BuildNumberService()
+    {
+        Properties props = new Properties();
+
+        InputStream is = getClass().getResourceAsStream( "version.properties" );
+        try
+        {
+            props.load( is );
+        }
+        catch ( Exception e )
+        {
+            logger.warn( "Could not determine build qualifier", e );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( is );
+        }
+
+        buildNumber = props.getProperty( "version", "unknown-version" );
+    }
+
+    public String getBuildNumber()
+    {
+        return buildNumber;
+    }
+
+}

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/NexusWebappResourceBundle.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/NexusWebappResourceBundle.java
@@ -1,0 +1,58 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.restlet1x;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.plugins.rest.AbstractNexusResourceBundle;
+import org.sonatype.nexus.plugins.rest.DefaultStaticResource;
+import org.sonatype.nexus.plugins.rest.ExternalStaticResource;
+import org.sonatype.nexus.plugins.rest.StaticResource;
+
+@Named
+public class NexusWebappResourceBundle
+    extends AbstractNexusResourceBundle
+{
+
+    private final BuildNumberService buildNumberService;
+
+    @Inject
+    public NexusWebappResourceBundle( final BuildNumberService buildNumberService )
+    {
+        this.buildNumberService = buildNumberService;
+    }
+
+    @Override
+    public List<StaticResource> getContributedResouces()
+    {
+        String prefix = buildNumberService.getBuildNumber();
+
+        List<StaticResource> result = new ArrayList<StaticResource>();
+
+        result.add( new ExternalStaticResource( new File( "nexus/js/sonatype-all.js" ),
+                                               "js/" + prefix + "/sonatype-all.js", "text/javascript" ) );
+        result.add( new ExternalStaticResource( new File( "nexus/style/sonatype-all.css" ),
+                                               "style/" + prefix + "/sonatype-all.css", "text/css" ) );
+
+        return result;
+    }
+}

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/NexusWebappResourceBundle.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/plugins/restlet1x/NexusWebappResourceBundle.java
@@ -48,9 +48,9 @@ public class NexusWebappResourceBundle
 
         List<StaticResource> result = new ArrayList<StaticResource>();
 
-        result.add( new ExternalStaticResource( new File( "nexus/js/sonatype-all.js" ),
+        result.add( new DefaultStaticResource( this.getClass().getResource( "/js/sonatype-all.js" ),
                                                "js/" + prefix + "/sonatype-all.js", "text/javascript" ) );
-        result.add( new ExternalStaticResource( new File( "nexus/style/sonatype-all.css" ),
+        result.add( new DefaultStaticResource( this.getClass().getResource( "nexus/style/sonatype-all.css" ),
                                                "style/" + prefix + "/sonatype-all.css", "text/css" ) );
 
         return result;

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/IndexTemplatePlexusResource.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/IndexTemplatePlexusResource.java
@@ -18,6 +18,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.velocity.VelocityContext;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Configuration;
@@ -39,33 +43,45 @@ import org.restlet.resource.ResourceException;
 import org.restlet.resource.Variant;
 import org.sonatype.nexus.Nexus;
 import org.sonatype.nexus.plugins.rest.NexusIndexHtmlCustomizer;
+import org.sonatype.nexus.plugins.restlet1x.BuildNumberService;
 import org.sonatype.plexus.rest.representation.VelocityRepresentation;
 import org.sonatype.plexus.rest.resource.AbstractPlexusResource;
 import org.sonatype.plexus.rest.resource.ManagedPlexusResource;
 import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
 import org.sonatype.sisu.velocity.Velocity;
 
-@Component( role = ManagedPlexusResource.class, hint = "indexTemplate" )
+@Named("indexTemplate")
+@Singleton
 public class IndexTemplatePlexusResource
     extends AbstractPlexusResource
-    implements ManagedPlexusResource, Initializable
+    implements ManagedPlexusResource
 {
-    @Requirement
     private Nexus nexus;
 
-    @Requirement( role = NexusIndexHtmlCustomizer.class )
     private Map<String, NexusIndexHtmlCustomizer> bundles;
     
-    @Requirement
     private Velocity velocity;
 
-    @Configuration( value = "${index.template.file}" )
+    private BuildNumberService buildNumberService;
+
     String templateFilename;
+
+    @Inject
+    public IndexTemplatePlexusResource( final Map<String, NexusIndexHtmlCustomizer> bundles, final Nexus nexus,
+                                        final @Named("${index.template.file:-templates/index.vm}") String templateFilename,
+                                        final Velocity velocity, final BuildNumberService buildNumberService )
+    {
+        this();
+
+        this.bundles = bundles;
+        this.nexus = nexus;
+        this.templateFilename = templateFilename;
+        this.velocity = velocity;
+        this.buildNumberService = buildNumberService;
+    }
 
     public IndexTemplatePlexusResource()
     {
-        super();
-
         setReadable( true );
 
         setModifiable( false );
@@ -200,6 +216,8 @@ public class IndexTemplatePlexusResource
         }
         templatingContext.put( "debug", debug );
 
+        templatingContext.put( "buildQualifier", buildNumberService.getBuildNumber() );
+
         return new VelocityRepresentation( context, templateFilename, getClass().getClassLoader(), templatingContext, MediaType.TEXT_HTML );
     }
 
@@ -230,16 +248,6 @@ public class IndexTemplatePlexusResource
                     "Got Exception exception during Velocity invocation!",
                     e );
             }
-        }
-    }
-
-    public void initialize()
-        throws InitializationException
-    {
-        // Hasn't been interpolated
-        if ( "${index.template.file}".equals( templateFilename ) )
-        {
-            templateFilename = "templates/index.vm";
         }
     }
 }

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/resources/templates/index.vm
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/resources/templates/index.vm
@@ -32,7 +32,7 @@
 
   <link rel="stylesheet" href="ext-3.4.0/resources/css/ext-all.css" type="text/css" media="screen" charset="utf-8">
   <link rel="stylesheet" href="ext-3.4.0/resources/css/xtheme-gray.css" type="text/css" media="screen" charset="utf-8">
-  <link rel="stylesheet" href="style/sonatype-all.css?$nexusVersion" type="text/css" media="screen" title="no title" charset="utf-8">
+  <link rel="stylesheet" href="style/$buildQualifier/sonatype-all.css" type="text/css" media="screen" title="no title" charset="utf-8">
 
 ##  <script src="js/sonatype-all.js?$nexusVersion" type="text/javascript" charset="utf-8"></script>
     <script src="ext-3.4.0/adapter/ext/ext-base$!{debug}.js" type="text/javascript" charset="utf-8"></script>
@@ -49,7 +49,7 @@
 
   #if ($!debug != "-debug")
       ## load aggregated module definitions
-      <script src="js/sonatype-all.js?$nexusVersion" type="text/javascript" charset="utf-8"></script>
+      <script src="js/$buildQualifier/sonatype-all.js" type="text/javascript" charset="utf-8"></script>
   #end
 
     <script type="text/javascript" charset="utf-8">


### PR DESCRIPTION
This is WIP and not working correctly right now, more a reminder for future work and RFC whether someone spots what's wrong here. The reason for this is better cache busting in browsers.

For some reason the ExternalStaticResources is not attached to restlet correctly. It's processed in [NexusApplication](https://github.com/sonatype/nexus/blob/timestamped-resource-url/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/NexusApplication.java#L210), but still gives 404 for the timestamped URLs.

This is a hack anyway because it uses an ExternalStaticResource for sonatype-all.js. It should rather use classpath lookup, but that seems to not work at all for the location of the js files here (they are included in the WAR root directory). This will get better when we can wrap the UI stuff into a plugin.
