### PR TITLE
Get rid of Timeline runtime repair

### DIFF
--- a/nexus/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
+++ b/nexus/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
@@ -116,17 +116,12 @@ public class DefaultTimeline
                             "Timeline index is succesfully repaired, the last "
                                 + configuration.getRepairDaysCountRestored() + " days were restored." );
                     }
-                    catch ( IOException ex )
-                    {
-                        markIndexerDead( ex );
-                        throw ex;
-                    }
                     catch ( Exception ex )
                     {
+                        // do not propagate the exception for indexer
+                        // we have persistor started, and that's enough
                         markIndexerDead( ex );
-                        throw new IOException( "Failed to repair indexer!", ex );
                     }
-
                 }
                 DefaultTimeline.this.started = true;
                 getLogger().info( "Started Timeline..." );

--- a/nexus/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
+++ b/nexus/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
@@ -309,7 +309,9 @@ public class DefaultTimeline
                     }
                     catch ( final IOException ee )
                     {
-                        getLogger().warn( "Unable to operate against Timeline indexer after repair!", e );
+                        // it is only the Work declaring IOEx, it will be not thrown
+                        // in markIndexerDead method!
+                        getLogger().warn( "Unable to cleanly disable Timeline indexer.", e );
                     }
                 }
                 finally
@@ -340,14 +342,20 @@ public class DefaultTimeline
     private volatile boolean indexerIsDead = false;
 
     protected void markIndexerDead( final Exception e )
-        throws IOException
     {
         if ( !indexerIsDead )
         {
             getLogger().warn( "Timeline index got corrupted and is disabled. Repair will be tried on next boot.", e );
             // we need to stop it and signal to not try any other thread
             indexerIsDead = true;
-            indexer.stop();
+            try
+            {
+                indexer.stop();
+            }
+            catch ( IOException ex )
+            {
+                getLogger().warn( "Timeline index can't be stopped cleanly after it's corruption.", ex );
+            }
         }
     }
 }


### PR DESCRIPTION
Repair should be tried only on "boot". During runtime, if corruption is detected, the Indexer should be simply shot down, marked as "broken" and no further operation tried against it.

On next boot, it will be repaired (or tried at least), but no data loss occurs, as the persistor will still write the records.
