### PR TITLE
Stabilize IT: Add 'cancellable' parameter to SleepRepositoryTask

### DIFF
--- a/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/SleepRepositoryTask.java
+++ b/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/SleepRepositoryTask.java
@@ -22,10 +22,14 @@ public class SleepRepositoryTask
     extends AbstractNexusRepositoriesTask<Object>
 {
 
+    private boolean cancellable;
+
     @Override
     protected Object doRun()
         throws Exception
     {
+        cancellable = Boolean.parseBoolean( getParameter( "cancellable" ) );
+
         getLogger().debug( getMessage() );
 
         final int time = getTime();
@@ -41,7 +45,9 @@ public class SleepRepositoryTask
         for ( int i = 0; i < time; i++ )
         {
             Thread.sleep( 1000 / 2 );
-            checkInterruption();
+            if ( cancellable ) {
+                checkInterruption();
+            }
         }
     }
 
@@ -68,7 +74,7 @@ public class SleepRepositoryTask
     @Override
     protected String getMessage()
     {
-        return "Sleeping for " + getTime() + " seconds!";
+        return "Sleeping for " + getTime() + " seconds (cancellable: "+ cancellable + ")!";
     }
 
 }

--- a/nexus/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
+++ b/nexus/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4066/Nexus4066TaskMutualExclusionIT.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.integrationtests.nexus4066;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.sonatype.nexus.test.utils.TaskScheduleUtil.newProperty;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -130,8 +131,10 @@ public class Nexus4066TaskMutualExclusionIT
     {
         final String taskName = "SleepRepositoryTask_" + repo + "_" + System.nanoTime();
         TaskScheduleUtil.runTask( taskName, "SleepRepositoryTask", 0,
-            TaskScheduleUtil.newProperty( "repositoryId", repo ),
-            TaskScheduleUtil.newProperty( "time", String.valueOf( 50 ) ) );
+            newProperty( "repositoryId", repo ),
+            newProperty( "time", String.valueOf( 50 ) ),
+            newProperty( "cancellable", Boolean.toString( true ) )
+        );
 
         Thread.sleep( 2000 );
 

--- a/nexus/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4341/Nexus4341RunningTaskNotEditableIT.java
+++ b/nexus/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus4341/Nexus4341RunningTaskNotEditableIT.java
@@ -72,6 +72,7 @@ public class Nexus4341RunningTaskNotEditableIT
         ScheduledServiceListResource running = createTask();
 
         waitForState( running, "RUNNING" );
+        verifyNoUpdate( running );
 
         ScheduledServiceListResource sleeping = createTask();
 
@@ -80,12 +81,9 @@ public class Nexus4341RunningTaskNotEditableIT
         verifyNoUpdate( sleeping );
         TaskScheduleUtil.cancel( sleeping.getId() );
 
-        verifyNoUpdate( running );
         TaskScheduleUtil.cancel( running.getId() );
-
-        ScheduledServiceListResource cancelled = TaskScheduleUtil.getTask( running.getName() );
-        assertThat( cancelled.getStatus(), is( "CANCELLING" ) );
-        verifyNoUpdate( cancelled );
+        waitForState( running, "CANCELLING" );
+        verifyNoUpdate( running );
     }
 
     private void waitForState( ScheduledServiceListResource task, String state )


### PR DESCRIPTION
dba2d76ad065a741cd4f664e92d00232ba0405b1 changed the basic assumption for the test (SleepRepositoryTask is not cancellable). When the task checks for interruptions, the 'CANCELLING' state may be over too fast for the IT to pick it up.
