### PR TITLE
As noticed by bentmann; the RemoteIPFinder always fails to resolve IPs

### DIFF
--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/RemoteIPFinder.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/RemoteIPFinder.java
@@ -92,7 +92,7 @@ public class RemoteIPFinder
                 InetAddress ipAdd;
                 try
                 {
-                    ipAdd = InetAddress.getByAddress( ip.getBytes() );
+                    ipAdd = InetAddress.getByName( ip );
                 }
                 catch ( UnknownHostException e )
                 {

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
@@ -1,0 +1,34 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.rest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RemoteIPFinderTest
+{
+    @Test
+    public void testResolveIP()
+    {
+        /*
+         * Broken resolveIP method always returned first element, check it now skips non-resolvable IPs:
+         */
+        HttpServletRequest request = Mockito.mock( HttpServletRequest.class );
+        Mockito.doReturn( "[missing],127.0.0.1,{unknown}" ).when( request ).getHeader( "X-Forwarded-For" );
+        Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( request ) );
+    }
+}


### PR DESCRIPTION
Because it incorrectly takes the raw character bytes from the IP string and passes them into InetAddress.getByAddress, which then fails because the byte array is text and does not represent a four-element numeric IP. Instead it should just use InetAddress.getByName to verify the IP string is resolvable.

Kicked off initial CI build: https://builds.sonatype.org/job/nexus-oss-its-feature/522/
