### PR TITLE
Implementing size() method.

### DIFF
--- a/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/rest/jersey/JerseyNexusClientFactory.java
+++ b/nexus/nexus-client-core/src/main/java/org/sonatype/nexus/client/rest/jersey/JerseyNexusClientFactory.java
@@ -24,7 +24,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.params.ConnRoutePNames;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.CoreProtocolPNames;
 import org.sonatype.nexus.client.core.Condition;
 import org.sonatype.nexus.client.core.spi.SubsystemFactory;


### PR DESCRIPTION
Default implementation was returning -1 constant for
getSize(), that made Jersey to stick with Chunked
transfer encoding (did not know exact size of http message body).

Some HTTP Servers does not like it, like nginx.

This is applied to _all_ client subsystems.

Fixes:
https://github.com/yegor256/jcabi/issues/47
