### PR TITLE
Implement Events / Scheduler clients

### DIFF
--- a/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/events/api/EventsWaitForPlexusResource.java
+++ b/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/events/api/EventsWaitForPlexusResource.java
@@ -1,0 +1,120 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.events.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.atomic.AtomicLong;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.restlet.Context;
+import org.restlet.data.Form;
+import org.restlet.data.Request;
+import org.restlet.data.Response;
+import org.restlet.data.Status;
+import org.restlet.resource.ResourceException;
+import org.restlet.resource.Variant;
+import org.sonatype.nexus.events.EventInspectorHost;
+import org.sonatype.plexus.rest.resource.AbstractPlexusResource;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+
+@Named
+@Singleton
+public class EventsWaitForPlexusResource
+    extends AbstractPlexusResource
+{
+
+    private static final String RESOURCE_URI = "/events/waitFor";
+
+    private final EventInspectorHost eventInspectorHost;
+
+    private final EventBus eventBus;
+
+    @Inject
+    public EventsWaitForPlexusResource( final EventInspectorHost eventInspectorHost,
+                                        final EventBus eventBus )
+    {
+        this.eventInspectorHost = checkNotNull( eventInspectorHost );
+        this.eventBus = checkNotNull( eventBus );
+    }
+
+    @Override
+    public String getResourceUri()
+    {
+        return RESOURCE_URI;
+    }
+
+    @Override
+    public PathProtectionDescriptor getResourceProtection()
+    {
+        return new PathProtectionDescriptor( getResourceUri(), "anon" );
+    }
+
+    @Override
+    public Object getPayloadInstance()
+    {
+        return null;
+    }
+
+    public Object get( Context context, Request request, Response response, Variant variant )
+        throws ResourceException
+    {
+        Form form = request.getResourceRef().getQueryAsForm();
+        final long window = Long.parseLong( form.getFirstValue( "window", "10000" ) );
+        final long timeout = Long.parseLong( form.getFirstValue( "timeout", "60000" ) );
+
+        final AtomicLong lastEventTime = new AtomicLong( System.currentTimeMillis() );
+
+        final Object recorder = new Object()
+        {
+
+            public void on( final Object event )
+            {
+                lastEventTime.set( System.currentTimeMillis() );
+            }
+
+        };
+
+        eventBus.register( recorder );
+
+        try
+        {
+            final long startTime = System.currentTimeMillis();
+            while ( System.currentTimeMillis() - startTime <= timeout )
+            {
+                if ( eventInspectorHost.isCalmPeriod()
+                    && System.currentTimeMillis() - lastEventTime.get() >= window )
+                {
+                    response.setStatus( Status.SUCCESS_OK );
+                    return "Ok";
+                }
+                Thread.sleep( 500 );
+            }
+        }
+        catch ( final InterruptedException ignore )
+        {
+            // ignore
+        }
+        finally
+        {
+            eventBus.unregister( recorder );
+        }
+
+        response.setStatus( Status.SUCCESS_ACCEPTED );
+        return "Still munching on them...";
+    }
+
+}

--- a/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/TaskHelperPlexusResource.java
+++ b/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/TaskHelperPlexusResource.java
@@ -12,10 +12,9 @@
  */
 package org.sonatype.nexus.plugins.tasks.api;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static org.sonatype.nexus.plugins.tasks.api.TasksWaitForPlexusResource.getTaskByName;
+import static org.sonatype.nexus.plugins.tasks.api.TasksWaitForPlexusResource.isTaskCompleted;
+import static org.sonatype.nexus.plugins.tasks.api.TasksWaitForPlexusResource.sleep;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
@@ -31,14 +30,12 @@ import org.sonatype.plexus.rest.resource.AbstractPlexusResource;
 import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
 import org.sonatype.plexus.rest.resource.PlexusResource;
 import org.sonatype.scheduling.ScheduledTask;
-import org.sonatype.scheduling.TaskState;
-import org.sonatype.scheduling.schedules.ManualRunSchedule;
-import org.sonatype.scheduling.schedules.RunNowSchedule;
 
 @Component( role = PlexusResource.class, hint = "TaskHelperResource" )
 public class TaskHelperPlexusResource
     extends AbstractPlexusResource
 {
+
     @Requirement
     private NexusScheduler nexusScheduler;
 
@@ -82,58 +79,23 @@ public class TaskHelperPlexusResource
             }
         }
 
-        ScheduledTask<?> namedTask = null;
+        final ScheduledTask<?> namedTask = getTaskByName( nexusScheduler, name );
 
-        if ( name != null )
+        if ( name != null && namedTask == null )
         {
-            namedTask = getTaskByName( name );
-
-            if ( namedTask == null )
-            {
-                // task wasn't found, so bounce on outta here
-                response.setStatus( Status.SUCCESS_OK );
-                return "OK";
-            }
+            // task wasn't found, so bounce on outta here
+            response.setStatus( Status.SUCCESS_OK );
+            return "OK";
         }
 
         for ( int i = 0; i < attempts; i++ )
         {
-            try
-            {
-                Thread.sleep( 500 );
-            }
-            catch ( InterruptedException e )
-            {
-            }
+            sleep();
 
-            if ( namedTask != null )
+            if ( isTaskCompleted( nexusScheduler, taskType, namedTask ) )
             {
-                if ( isTaskCompleted( namedTask ) )
-                {
-                    response.setStatus( Status.SUCCESS_OK );
-                    return "OK";
-                }
-            }
-            else
-            {
-                Set<ScheduledTask<?>> tasks = getTasks( taskType );
-
-                boolean running = false;
-
-                for ( ScheduledTask<?> task : tasks )
-                {
-                    if ( !isTaskCompleted( task ) )
-                    {
-                        running = true;
-                        break;
-                    }
-                }
-
-                if ( !running )
-                {
-                    response.setStatus( Status.SUCCESS_OK );
-                    return "OK";
-                }
+                response.setStatus( Status.SUCCESS_OK );
+                return "OK";
             }
         }
 
@@ -141,72 +103,4 @@ public class TaskHelperPlexusResource
         return "Tasks Not Finished";
     }
 
-    private boolean isTaskCompleted( ScheduledTask<?> task )
-    {
-        if ( task.getSchedule() instanceof RunNowSchedule )
-        {
-            // runNow scheduled tasks will _dissapear_ when done. So, the fact they are PRESENT simply
-            // means they are not YET complete
-            return false;
-        }
-        else
-        {
-            final TaskState state = task.getTaskState();
-
-            if ( task.getSchedule() instanceof ManualRunSchedule )
-            {
-                // MnuallRunSchedule stuff goes back to SUBMITTED state and sit there for next "kick"
-                // but we _know_ it ran once at least if lastRun date != null AND is in some of the following
-                // states
-                // Note: I _think_ ManualRunScheduled task never go into WAITING state! (unverified claim)
-                return task.getLastRun() != null
-                    && ( TaskState.SUBMITTED.equals( state ) || TaskState.WAITING.equals( state )
-                        || TaskState.FINISHED.equals( state ) || TaskState.BROKEN.equals( state ) || TaskState.CANCELLED.equals( state ) );
-            }
-            else
-            {
-                // the rest of tasks are completed if in any of these statuses
-                return TaskState.WAITING.equals( state ) || TaskState.FINISHED.equals( state )
-                    || TaskState.BROKEN.equals( state ) || TaskState.CANCELLED.equals( state );
-            }
-        }
-    }
-
-    private ScheduledTask<?> getTaskByName( String name )
-    {
-        Map<String, List<ScheduledTask<?>>> taskMap = nexusScheduler.getAllTasks();
-
-        for ( List<ScheduledTask<?>> taskList : taskMap.values() )
-        {
-            for ( ScheduledTask<?> task : taskList )
-            {
-                if ( task.getName().equals( name ) )
-                {
-                    return task;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private Set<ScheduledTask<?>> getTasks( String taskType )
-    {
-        Set<ScheduledTask<?>> tasks = new HashSet<ScheduledTask<?>>();
-
-        Map<String, List<ScheduledTask<?>>> taskMap = nexusScheduler.getAllTasks();
-
-        for ( List<ScheduledTask<?>> taskList : taskMap.values() )
-        {
-            for ( ScheduledTask<?> task : taskList )
-            {
-                if ( taskType == null || task.getType().equals( taskType ) )
-                {
-                    tasks.add( task );
-                }
-            }
-        }
-
-        return tasks;
-    }
 }

--- a/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/TasksWaitForPlexusResource.java
+++ b/nexus/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/tasks/api/TasksWaitForPlexusResource.java
@@ -1,0 +1,216 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.tasks.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.restlet.Context;
+import org.restlet.data.Form;
+import org.restlet.data.Request;
+import org.restlet.data.Response;
+import org.restlet.data.Status;
+import org.restlet.resource.ResourceException;
+import org.restlet.resource.Variant;
+import org.sonatype.nexus.scheduling.NexusScheduler;
+import org.sonatype.plexus.rest.resource.AbstractPlexusResource;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.scheduling.ScheduledTask;
+import org.sonatype.scheduling.TaskState;
+import org.sonatype.scheduling.schedules.ManualRunSchedule;
+import org.sonatype.scheduling.schedules.RunNowSchedule;
+
+@Named
+@Singleton
+public class TasksWaitForPlexusResource
+    extends AbstractPlexusResource
+{
+
+    private static final String RESOURCE_URI = "/tasks/waitFor";
+
+    private final NexusScheduler nexusScheduler;
+
+    @Inject
+    public TasksWaitForPlexusResource( final NexusScheduler nexusScheduler )
+    {
+        this.nexusScheduler = checkNotNull( nexusScheduler );
+    }
+
+    @Override
+    public String getResourceUri()
+    {
+        return RESOURCE_URI;
+    }
+
+    @Override
+    public PathProtectionDescriptor getResourceProtection()
+    {
+        return new PathProtectionDescriptor( getResourceUri(), "anon" );
+    }
+
+    @Override
+    public Object getPayloadInstance()
+    {
+        return null;
+    }
+
+    @Override
+    public Object get( Context context, Request request, Response response, Variant variant )
+        throws ResourceException
+    {
+        final Form form = request.getResourceRef().getQueryAsForm();
+        final String name = form.getFirstValue( "name" );
+        final String taskType = form.getFirstValue( "taskType" );
+        final long timeout = Long.parseLong( form.getFirstValue( "timeout", "60000" ) );
+
+        final ScheduledTask<?> namedTask = getTaskByName( nexusScheduler, name );
+
+        if ( name != null && namedTask == null )
+        {
+            // task wasn't found, so bounce on outta here
+            response.setStatus( Status.SUCCESS_OK );
+            return "OK";
+        }
+
+        final long startTime = System.currentTimeMillis();
+        while ( System.currentTimeMillis() - startTime <= timeout )
+        {
+            sleep();
+
+            if ( isTaskCompleted( nexusScheduler, taskType, namedTask ) )
+            {
+                response.setStatus( Status.SUCCESS_OK );
+                return "OK";
+            }
+        }
+
+        response.setStatus( Status.SUCCESS_ACCEPTED );
+        return "Tasks Not Finished";
+    }
+
+    static boolean isTaskCompleted( final NexusScheduler nexusScheduler,
+                                    final String taskType,
+                                    final ScheduledTask<?> namedTask )
+    {
+        if ( namedTask != null )
+        {
+            return isTaskCompleted( namedTask );
+        }
+        else
+        {
+            for ( final ScheduledTask<?> task : getTasks( nexusScheduler, taskType ) )
+            {
+                if ( !isTaskCompleted( task ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    static ScheduledTask<?> getTaskByName( final NexusScheduler nexusScheduler, final String name )
+    {
+        if ( name == null )
+        {
+            return null;
+        }
+
+        final Map<String, List<ScheduledTask<?>>> taskMap = nexusScheduler.getAllTasks();
+
+        for ( List<ScheduledTask<?>> taskList : taskMap.values() )
+        {
+            for ( ScheduledTask<?> task : taskList )
+            {
+                if ( task.getName().equals( name ) )
+                {
+                    return task;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    static void sleep()
+    {
+        try
+        {
+            Thread.sleep( 500 );
+        }
+        catch ( final InterruptedException e )
+        {
+            // ignore
+        }
+    }
+
+    private static boolean isTaskCompleted( ScheduledTask<?> task )
+    {
+        if ( task.getSchedule() instanceof RunNowSchedule )
+        {
+            // runNow scheduled tasks will _dissapear_ when done. So, the fact they are PRESENT simply
+            // means they are not YET complete
+            return false;
+        }
+        else
+        {
+            final TaskState state = task.getTaskState();
+
+            if ( task.getSchedule() instanceof ManualRunSchedule )
+            {
+                // MnuallRunSchedule stuff goes back to SUBMITTED state and sit there for next "kick"
+                // but we _know_ it ran once at least if lastRun date != null AND is in some of the following
+                // states
+                // Note: I _think_ ManualRunScheduled task never go into WAITING state! (unverified claim)
+                return task.getLastRun() != null
+                    && ( TaskState.SUBMITTED.equals( state ) || TaskState.WAITING.equals( state )
+                    || TaskState.FINISHED.equals( state ) || TaskState.BROKEN.equals( state )
+                    || TaskState.CANCELLED.equals( state ) );
+            }
+            else
+            {
+                // the rest of tasks are completed if in any of these statuses
+                return TaskState.WAITING.equals( state ) || TaskState.FINISHED.equals( state )
+                    || TaskState.BROKEN.equals( state ) || TaskState.CANCELLED.equals( state );
+            }
+        }
+    }
+
+    private static Set<ScheduledTask<?>> getTasks( final NexusScheduler nexusScheduler, final String taskType )
+    {
+        Set<ScheduledTask<?>> tasks = new HashSet<ScheduledTask<?>>();
+
+        Map<String, List<ScheduledTask<?>>> taskMap = nexusScheduler.getAllTasks();
+
+        for ( List<ScheduledTask<?>> taskList : taskMap.values() )
+        {
+            for ( ScheduledTask<?> task : taskList )
+            {
+                if ( taskType == null || task.getType().equals( taskType ) )
+                {
+                    tasks.add( task );
+                }
+            }
+        }
+
+        return tasks;
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/pom.xml
+++ b/nexus/nexus-test/nexus-testsuite-client/pom.xml
@@ -31,6 +31,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.sisu.goodies</groupId>
+      <artifactId>goodies-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <optional>true</optional>

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Events.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Events.java
@@ -1,0 +1,56 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client;
+
+import org.sonatype.nexus.testsuite.client.exception.EventsAreStillBeingHandledException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * Events Nexus Client Subsystem.
+ *
+ * @since 2.3
+ */
+public interface Events
+{
+
+    /**
+     * Wait Nexus to not handle events for a window of 5 seconds (quiet period). Timeouts after 1 minute.
+     *
+     * @throws EventsAreStillBeingHandledException
+     *          If could not find a window of 10 seconds in defined timeout of 1 minute
+     */
+    void waitForCalmPeriod()
+        throws EventsAreStillBeingHandledException;
+
+    /**
+     * Wait Nexus to not handle events for a window of 5 seconds (quiet period). Timeouts after defined time.
+     *
+     * @param timeout timeout
+     * @throws EventsAreStillBeingHandledException
+     *          If could not find a window of 10 seconds in defined timeout
+     */
+    void waitForCalmPeriod( Time timeout )
+        throws EventsAreStillBeingHandledException;
+
+    /**
+     * Wait Nexus to not handle events for a defined window (quiet period). Timeouts after defined time.
+     *
+     * @param timeout timeout
+     * @param window  of time when no events are posted
+     * @throws EventsAreStillBeingHandledException
+     *          If could not find a window in defined timeout
+     */
+    void waitForCalmPeriod( Time timeout, Time window )
+        throws EventsAreStillBeingHandledException;
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Scheduler.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/Scheduler.java
@@ -1,0 +1,33 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client;
+
+import org.sonatype.nexus.testsuite.client.exception.TasksAreStillRunningException;
+import org.sonatype.nexus.testsuite.client.exception.TasksAreStillRunningException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * Scheduler Nexus Client Subsystem.
+ *
+ * @since 2.3
+ */
+public interface Scheduler
+{
+
+    void waitForAllTasksToStop()
+        throws TasksAreStillRunningException;
+
+    void waitForAllTasksToStop( Time timeout )
+        throws TasksAreStillRunningException;
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/EventsAreStillBeingHandledException.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/EventsAreStillBeingHandledException.java
@@ -1,0 +1,34 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.exception;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.sonatype.nexus.client.core.exception.NexusClientException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * Thrown when waiting for Nexus to not handle events but events are still floating in the configured timeout period.
+ *
+ * @since 2.3
+ */
+public class EventsAreStillBeingHandledException
+    extends NexusClientException
+{
+
+    public EventsAreStillBeingHandledException( final Time timeout )
+    {
+        super( "Nexus did not settle down in configured timeout of " + checkNotNull( timeout.toString() ) );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/TasksAreStillRunningException.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/TasksAreStillRunningException.java
@@ -1,0 +1,34 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.exception;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.sonatype.nexus.client.core.exception.NexusClientException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * Thrown when waiting for Nexus to not run tasks but tasks are still running in the configured timeout period.
+ *
+ * @since 2.3
+ */
+public class TasksAreStillRunningException
+    extends NexusClientException
+{
+
+    public TasksAreStillRunningException( final Time timeout )
+    {
+        super( "Nexus was still running tasks configured timeout of " + checkNotNull( timeout.toString() ) );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyEvents.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyEvents.java
@@ -1,0 +1,111 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.internal;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.client.core.spi.SubsystemSupport;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.Events;
+import org.sonatype.nexus.testsuite.client.exception.EventsAreStillBeingHandledException;
+import org.sonatype.sisu.goodies.common.Time;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+/**
+ * Jersey based {@link Events} Nexus Client Subsystem implementation.
+ *
+ * @since 2.3
+ */
+public class JerseyEvents
+    extends SubsystemSupport<JerseyNexusClient>
+    implements Events
+{
+
+    private static final Logger LOG = LoggerFactory.getLogger( Events.class );
+
+    public JerseyEvents( final JerseyNexusClient nexusClient )
+    {
+        super( nexusClient );
+    }
+
+    @Override
+    public void waitForCalmPeriod()
+    {
+        waitForCalmPeriod( null );
+    }
+
+    @Override
+    public void waitForCalmPeriod( @Nullable final Time timeout )
+    {
+        waitForCalmPeriod( null, null );
+    }
+
+    @Override
+    public void waitForCalmPeriod( @Nullable final Time timeout, @Nullable final Time window )
+    {
+        try
+        {
+            Time actualTimeout = timeout;
+            if ( actualTimeout == null )
+            {
+                actualTimeout = Time.minutes( 1 );
+            }
+
+            Time actualWindow = window;
+            if ( actualWindow == null )
+            {
+                actualWindow = Time.seconds( 10 );
+            }
+
+            LOG.info(
+                "Waiting for Nexus to not handle events for {} (timeouts in {})",
+                actualWindow.toString(), actualTimeout.toString()
+            );
+
+            final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+            params.add( "timeout", String.valueOf( actualTimeout.toMillis() ) );
+            params.add( "window", String.valueOf( actualWindow.toMillis() ) );
+
+            final ClientResponse response = getNexusClient()
+                .serviceResource( "events/waitFor", params )
+                .get( ClientResponse.class );
+
+            response.close();
+
+            if ( Response.Status.ACCEPTED.getStatusCode() == response.getStatus() )
+            {
+                throw new EventsAreStillBeingHandledException( actualTimeout );
+            }
+            else if ( !response.getClientResponseStatus().getFamily().equals( Response.Status.Family.SUCCESSFUL ) )
+            {
+                throw getNexusClient().convert( new UniformInterfaceException( response ) );
+            }
+        }
+        catch ( ClientHandlerException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+        catch ( UniformInterfaceException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyScheduler.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyScheduler.java
@@ -1,0 +1,98 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.internal;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.client.core.spi.SubsystemSupport;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.Scheduler;
+import org.sonatype.nexus.testsuite.client.exception.TasksAreStillRunningException;
+import org.sonatype.nexus.testsuite.client.exception.TasksAreStillRunningException;
+import org.sonatype.sisu.goodies.common.Time;
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+/**
+ * Jersey based {@link Scheduler} Nexus Client Subsystem implementation.
+ *
+ * @since 2.3
+ */
+public class JerseyScheduler
+    extends SubsystemSupport<JerseyNexusClient>
+    implements Scheduler
+{
+
+    private static final Logger LOG = LoggerFactory.getLogger( Scheduler.class );
+
+    public JerseyScheduler( final JerseyNexusClient nexusClient )
+    {
+        super( nexusClient );
+    }
+
+    @Override
+    public void waitForAllTasksToStop()
+    {
+        waitForAllTasksToStop( null );
+    }
+
+    @Override
+    public void waitForAllTasksToStop( @Nullable final Time timeout )
+    {
+        try
+        {
+            Time actualTimeout = timeout;
+            if ( actualTimeout == null )
+            {
+                actualTimeout = Time.minutes( 1 );
+            }
+
+            LOG.info(
+                "Waiting for Nexus to not execute any task (timeouts in {})", actualTimeout.toString()
+            );
+
+            final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+            params.add( "timeout", String.valueOf( actualTimeout.toMillis() ) );
+
+            final ClientResponse response = getNexusClient()
+                .serviceResource( "tasks/waitFor", params )
+                .get( ClientResponse.class );
+
+            response.close();
+
+            if ( Response.Status.ACCEPTED.getStatusCode() == response.getStatus() )
+            {
+                throw new TasksAreStillRunningException( actualTimeout );
+            }
+            else if ( !response.getClientResponseStatus().getFamily().equals( Response.Status.Family.SUCCESSFUL ) )
+            {
+                throw getNexusClient().convert( new UniformInterfaceException( response ) );
+            }
+        }
+        catch ( ClientHandlerException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+        catch ( UniformInterfaceException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyEventsSubsystemFactory.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyEventsSubsystemFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.client.core.Condition;
+import org.sonatype.nexus.client.core.condition.NexusStatusConditions;
+import org.sonatype.nexus.client.core.spi.SubsystemFactory;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.Events;
+import org.sonatype.nexus.testsuite.client.internal.JerseyEvents;
+
+/**
+ * Jersey based {@link Events} Nexus Client Subsystem factory.
+ *
+ * @since 2.3
+ */
+@Named
+@Singleton
+public class JerseyEventsSubsystemFactory
+    implements SubsystemFactory<Events, JerseyNexusClient>
+{
+
+    @Override
+    public Condition availableWhen()
+    {
+        return NexusStatusConditions.any20AndLater();
+    }
+
+    @Override
+    public Class<Events> getType()
+    {
+        return Events.class;
+    }
+
+    @Override
+    public Events create( final JerseyNexusClient nexusClient )
+    {
+        return new JerseyEvents( nexusClient );
+    }
+
+}

--- a/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseySchedulerSubsystemFactory.java
+++ b/nexus/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseySchedulerSubsystemFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.client.core.Condition;
+import org.sonatype.nexus.client.core.condition.NexusStatusConditions;
+import org.sonatype.nexus.client.core.spi.SubsystemFactory;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.Scheduler;
+import org.sonatype.nexus.testsuite.client.internal.JerseyScheduler;
+
+/**
+ * Jersey based {@link Scheduler} Nexus Client Subsystem factory.
+ *
+ * @since 2.3
+ */
+@Named
+@Singleton
+public class JerseySchedulerSubsystemFactory
+    implements SubsystemFactory<Scheduler, JerseyNexusClient>
+{
+
+    @Override
+    public Condition availableWhen()
+    {
+        return NexusStatusConditions.any20AndLater();
+    }
+
+    @Override
+    public Class<Scheduler> getType()
+    {
+        return Scheduler.class;
+    }
+
+    @Override
+    public Scheduler create( final JerseyNexusClient nexusClient )
+    {
+        return new JerseyScheduler( nexusClient );
+    }
+
+}


### PR DESCRIPTION
This are the counterparts of EventInspectorsUtil / TaskScheduleUtil (wait for).
Having them will allow us, in most of new plugins to get rid of nexus-test-utils and completely rely only on new Nexus client.

For Scheduler client only the minimum required is parts are done. In the future we could extend it as needed for the "waitFor" parts.
