### PR TITLE
More RemoteIPFinder fixes

### DIFF
--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/RemoteIPFinder.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/RemoteIPFinder.java
@@ -16,7 +16,6 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,7 +26,7 @@ import org.restlet.data.Request;
 
 public class RemoteIPFinder
 {
-    protected static final String FORWARD_HEADER = "X-Forwarded-For";
+    static final String FORWARD_HEADER = "X-Forwarded-For";
 
     public static String findIP( HttpServletRequest request )
     {
@@ -38,14 +37,7 @@ public class RemoteIPFinder
             return forwardedIP;
         }
 
-        String remoteIP = request.getRemoteAddr();
-
-        if ( remoteIP != null )
-        {
-            return remoteIP;
-        }
-
-        return null;
+        return request.getRemoteAddr();
     }
 
     public static String findIP( Request request )
@@ -59,67 +51,65 @@ public class RemoteIPFinder
             return forwardedIP;
         }
 
-        List<String> ipAddresses = request.getClientInfo().getAddresses();
+        List<String> clientAddresses = request.getClientInfo().getAddresses();
 
-        return resolveIp( ipAddresses );
+        if ( clientAddresses.size() > 1 )
+        {
+            // restlet1x ClientInfo.getAddresses has *reverse* order to XFF
+            // (this has been fixed in restlet2x, along with a clearer API)
+
+            String[] ipAddresses = new String[clientAddresses.size()];
+            for ( int i = 0, j = ipAddresses.length - 1; j >= 0; i++, j-- )
+            {
+                ipAddresses[i] = clientAddresses.get( j );
+            }
+
+            forwardedIP = resolveIp( ipAddresses );
+
+            if ( forwardedIP != null )
+            {
+                return forwardedIP;
+            }
+        }
+
+        return request.getClientInfo().getAddress();
     }
 
-    protected static String getFirstForwardedIp( String forwardedFor )
+    /**
+     * Returns the *left-most* resolvable IP from the given XFF string; otherwise null.
+     */
+    private static String getFirstForwardedIp( String forwardedFor )
     {
         if ( !StringUtils.isEmpty( forwardedFor ) )
         {
-            String[] forwardedIps = forwardedFor.split( "," );
-
-            return resolveIp( Arrays.asList( forwardedIps ) );
+            return resolveIp( forwardedFor.split( "\\s*,\\s*" ) );
         }
 
         return null;
     }
 
-    private static String resolveIp( List<String> ipAddresses )
+    /**
+     * Returns the *left-most* resolvable IP from the given sequence.
+     */
+    private static String resolveIp( String[] ipAddresses )
     {
-        String ip0 = null;
-        String ip4 = null;
-        String ip6 = null;
-
-        if ( ipAddresses.size() > 0 )
+        for ( String ip : ipAddresses )
         {
-            ip0 = ipAddresses.get( 0 );
-
-            for ( String ip : ipAddresses )
+            InetAddress ipAdd;
+            try
             {
-
-                InetAddress ipAdd;
-                try
-                {
-                    ipAdd = InetAddress.getByName( ip );
-                }
-                catch ( UnknownHostException e )
-                {
-                    continue;
-                }
-                if ( ipAdd instanceof Inet4Address )
-                {
-                    ip4 = ip;
-                    continue;
-                }
-                if ( ipAdd instanceof Inet6Address )
-                {
-                    ip6 = ip;
-                    continue;
-                }
+                ipAdd = InetAddress.getByName( ip );
+            }
+            catch ( UnknownHostException e )
+            {
+                continue;
+            }
+            if ( ipAdd instanceof Inet4Address || ipAdd instanceof Inet6Address )
+            {
+                return ip;
             }
         }
 
-        if ( ip4 != null )
-        {
-            return ip4;
-        }
-        if ( ip6 != null )
-        {
-            return ip6;
-        }
-
-        return ip0;
+        return null;
     }
 }

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
@@ -56,6 +56,8 @@ public class RemoteIPFinderTest
         Mockito.doReturn( "127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
         Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( http ) );
 
+        // Note that if you use a DNS provider, such as OpenDNS, or internet cafe which buckets non-resolvable IPs
+        // to a landing page host, these tests will fail when the name 'missing' actually resolves to an IP
         Mockito.doReturn( "missing, 127.0.0.2, unknown, 127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
         Assert.assertEquals( "127.0.0.2", RemoteIPFinder.findIP( http ) );
 

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
@@ -12,23 +12,100 @@
  */
 package org.sonatype.nexus.rest;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.restlet.data.ClientInfo;
+import org.restlet.data.Form;
+import org.restlet.data.Request;
 
+@SuppressWarnings( "unchecked" )
 public class RemoteIPFinderTest
 {
     @Test
     public void testResolveIP()
     {
+        HttpServletRequest http = Mockito.mock( HttpServletRequest.class );
+
+        Request restlet = Mockito.mock( Request.class );
+        Map<String, Object> attributes = Mockito.mock( Map.class );
+        Form form = Mockito.mock( Form.class );
+        ClientInfo clientInfo = new ClientInfo();
+
+        Mockito.doReturn( attributes ).when( restlet ).getAttributes();
+        Mockito.doReturn( form ).when( attributes ).get( "org.restlet.http.headers" );
+        Mockito.doReturn( clientInfo ).when( restlet ).getClientInfo();
+
         /*
-         * Broken resolveIP method always returned first element, check it now skips non-resolvable IPs:
+         * Verify that we respect the X-Forwarded-For spec and return the left-most resolvable IP:
          */
-        HttpServletRequest request = Mockito.mock( HttpServletRequest.class );
-        Mockito.doReturn( "[missing],127.0.0.1,{unknown}" ).when( request ).getHeader( "X-Forwarded-For" );
-        Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( request ) );
+
+        // HTTP
+
+        Mockito.doReturn( "" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( null ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "missing, 127.0.0.2, unknown, 127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.2", RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "127.0.0.3, 127.0.0.2, 127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.3", RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "localhost" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "localhost", RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "client, proxy1, proxy2" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Mockito.doReturn( null ).when( http ).getRemoteAddr();
+        Assert.assertEquals( null, RemoteIPFinder.findIP( http ) );
+
+        Mockito.doReturn( "client, proxy1, proxy2" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
+        Mockito.doReturn( "upstream" ).when( http ).getRemoteAddr();
+        Assert.assertEquals( "upstream", RemoteIPFinder.findIP( http ) );
+
+        // RESTLET
+
+        Mockito.doReturn( "" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( restlet ) );
+
+        Mockito.doReturn( null ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( restlet ) );
+
+        Mockito.doReturn( "127.0.0.1" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( restlet ) );
+
+        Mockito.doReturn( "missing, 127.0.0.2, unknown, 127.0.0.1" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.2", RemoteIPFinder.findIP( restlet ) );
+
+        Mockito.doReturn( "127.0.0.3, 127.0.0.2, 127.0.0.1" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "127.0.0.3", RemoteIPFinder.findIP( restlet ) );
+
+        Mockito.doReturn( "localhost" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "localhost", RemoteIPFinder.findIP( restlet ) );
+
+        clientInfo.setAddresses( null );
+        Mockito.doReturn( "client, proxy1, proxy2" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( restlet ) );
+
+        clientInfo.setAddresses( Collections.<String> emptyList() );
+        Mockito.doReturn( "client, proxy1, proxy2" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( null, RemoteIPFinder.findIP( restlet ) );
+
+        // restlet1x clientInfo addresses are the last known upstream address + reverse of XFF
+        clientInfo.setAddresses( Arrays.asList( "upstream", "proxy2", "proxy1", "client" ) );
+        Mockito.doReturn( "client, proxy1, proxy2" ).when( form ).getFirstValue( RemoteIPFinder.FORWARD_HEADER );
+        Assert.assertEquals( "upstream", RemoteIPFinder.findIP( restlet ) );
     }
 }

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
@@ -15,11 +15,9 @@ package org.sonatype.nexus.rest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.restlet.data.ClientInfo;

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/RemoteIPFinderTest.java
@@ -56,7 +56,7 @@ public class RemoteIPFinderTest
         Mockito.doReturn( "127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
         Assert.assertEquals( "127.0.0.1", RemoteIPFinder.findIP( http ) );
 
-        // Note that if you use a DNS provider, such as OpenDNS, or internet cafe which buckets non-resolvable IPs
+        // Note that if you use a DNS provider, such as OpenDNS, or internet cafe which buckets non-resolvable host names
         // to a landing page host, these tests will fail when the name 'missing' actually resolves to an IP
         Mockito.doReturn( "missing, 127.0.0.2, unknown, 127.0.0.1" ).when( http ).getHeader( RemoteIPFinder.FORWARD_HEADER );
         Assert.assertEquals( "127.0.0.2", RemoteIPFinder.findIP( http ) );


### PR DESCRIPTION
Respect XFF spec and return left-most resolvable IP, which should be the client's according to http://en.wikipedia.org/wiki/X-Forwarded-For

Note that Restlet 1x for some reason reverses the XFF list when storing it in ClientInfo.getAddresses

   https://github.com/sonatype/restlet1x/blob/master/restlet-1.1.6-5346-sonatype/modules/com.noelios.restlet/src/com/noelios/restlet/http/HttpRequest.java#L209

So we now reverse the list of addresses returned by ClientInfo.getAddresses to get it back into XFF order.

Interestingly Restlet 2x doesn't reverse the list when storing the XFF details inside ClientInfo:

   https://github.com/restlet/restlet-framework-java/blob/master/modules/org.restlet/src/org/restlet/engine/adapter/HttpRequest.java#L309
