### PR TITLE
[NEXUS-5258] Do not save default remote storage provider

### DIFF
--- a/nexus/nexus-configuration/src/test/resources/nexus-NEXUS-2212.xml
+++ b/nexus/nexus-configuration/src/test/resources/nexus-NEXUS-2212.xml
@@ -33,7 +33,6 @@
         <url>file:/Users/demers/dev/source/nexus/trunk/nexus/nexus-webapp/target/foo/nexus-webapp-1.4.0-SNAPSHOT/bin/jsw/macosx-universal-32/../../../../sonatype-work/nexus/storage/central</url>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
         <mirrors>
           <mirror>
@@ -69,7 +68,6 @@
         <url>file:/Users/demers/dev/source/nexus/trunk/nexus/nexus-webapp/target/foo/nexus-webapp-1.4.0-SNAPSHOT/bin/jsw/macosx-universal-32/../../../../sonatype-work/nexus/storage/apache-snapshots</url>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -99,7 +97,6 @@
         <url>file:/Users/demers/dev/source/nexus/trunk/nexus/nexus-webapp/target/foo/nexus-webapp-1.4.0-SNAPSHOT/bin/jsw/macosx-universal-32/../../../../sonatype-work/nexus/storage/codehaus-snapshots</url>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -281,7 +278,6 @@
         <url>file:/Users/demers/dev/source/nexus/trunk/nexus/nexus-webapp/target/foo/nexus-webapp-1.4.0-SNAPSHOT/bin/jsw/macosx-universal-32/../../../../sonatype-work/nexus/storage/test</url>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/content/groups/Snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -308,7 +304,6 @@
         <url>file:/Users/demers/dev/source/nexus/trunk/nexus/nexus-webapp/target/foo/nexus-webapp-1.4.0-SNAPSHOT/bin/jsw/macosx-universal-32/../../../../sonatype-work/nexus/storage/javanet</url>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>https://maven-repository.dev.java.net/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/nexus-103.xml
@@ -60,7 +60,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -81,7 +80,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -100,7 +98,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/nexus-103.xml
@@ -60,7 +60,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -81,7 +80,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -100,7 +98,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-101.xml
@@ -43,7 +43,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://svn.sonatype.com/mvnrepos/releases</url>
 			</remoteStorage>
 		</repository>
@@ -62,7 +61,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://svn.sonatype.com/mvnrepos/snapshots</url>
 			</remoteStorage>
 		</repository>
@@ -81,7 +79,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://svn.sonatype.com/mvnrepos/customer</url>
 			</remoteStorage>
 		</repository>
@@ -101,7 +98,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -120,7 +116,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>
@@ -139,7 +134,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://download.java.net/maven/2/</url>
 			</remoteStorage>
 		</repository>
@@ -158,7 +152,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://maven.restlet.org/</url>
 			</remoteStorage>
 		</repository>
@@ -177,7 +170,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://gwt-maven.googlecode.com/svn/trunk/mavenrepo/</url>
 			</remoteStorage>
 		</repository>
@@ -197,7 +189,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -216,7 +207,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>
@@ -235,7 +225,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://maven.restlet.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-142.xml
@@ -37,7 +37,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -68,7 +67,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -99,7 +97,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -128,7 +125,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -157,7 +153,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -188,7 +183,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus-143.xml
@@ -38,7 +38,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -70,7 +69,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -102,7 +100,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -131,7 +128,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -160,7 +156,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -191,7 +186,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/validator/nexus-bad1.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/validator/nexus-bad1.xml
@@ -53,7 +53,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -74,7 +73,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -92,7 +90,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/validator/nexus-bad2.xml
+++ b/nexus/nexus-configuration/src/test/resources/org/sonatype/nexus/configuration/validator/nexus-bad2.xml
@@ -63,7 +63,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>badPolicy</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -84,7 +83,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -103,7 +101,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfigurator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfigurator.java
@@ -147,6 +147,13 @@ public abstract class AbstractProxyRepositoryConfigurator
             {
                 RemoteStorageContext rsc = prepository.getRemoteStorageContext();
 
+                // NEXUS-5258 Do not persist storage provider hint if it's the default one
+                if ( remoteProviderHintFactory.getDefaultHttpRoleHint().equals(
+                        prepository.getRemoteStorage().getProviderId() ) )
+                {
+                    repoConfig.getRemoteStorage().setProvider( null );
+                }
+
                 if ( rsc.hasRemoteAuthenticationSettings() )
                 {
                     repoConfig.getRemoteStorage().setAuthentication(

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfigurator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfigurator.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.proxy.repository;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.sonatype.configuration.ConfigurationException;
@@ -45,6 +46,25 @@ public abstract class AbstractProxyRepositoryConfigurator
 
     @Requirement
     private RemoteProviderHintFactory remoteProviderHintFactory;
+
+    /**
+     * For plexus injection.
+     */
+    protected AbstractProxyRepositoryConfigurator()
+    {
+    }
+
+    @VisibleForTesting
+    AbstractProxyRepositoryConfigurator( final AuthenticationInfoConverter authenticationInfoConverter,
+                                                   final GlobalHttpProxySettings globalHttpProxySettings,
+                                                   final GlobalRemoteConnectionSettings globalRemoteConnectionSettings,
+                                                   final RemoteProviderHintFactory remoteProviderHintFactory )
+    {
+        this.authenticationInfoConverter = authenticationInfoConverter;
+        this.globalHttpProxySettings = globalHttpProxySettings;
+        this.globalRemoteConnectionSettings = globalRemoteConnectionSettings;
+        this.remoteProviderHintFactory = remoteProviderHintFactory;
+    }
 
     @Override
     public void doApplyConfiguration( Repository repository, ApplicationConfiguration configuration,

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/RepoConversionTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/RepoConversionTest.java
@@ -87,9 +87,8 @@ public class RepoConversionTest
         assertEquals( "This should match, since they should be the same!", remoteRepositoryStorage.getProviderId(),
                       afterTreatment.getRemoteStorage().getProviderId() );
 
-        assertEquals( "Config should state the same as object is", afterTreatment.getRemoteStorage().getProviderId(),
-                      ( ( (CRepositoryCoreConfiguration) afterTreatment.getCurrentCoreConfiguration() )
-                          .getConfiguration( false ) ).getRemoteStorage().getProvider() );
+        // before NEXUS-5258, this test used to check that the provider was set. Nexus does not set the provider anymore
+        // if it is the default provider, to let repos pick up the system default.
 
         assertEquals( "Config should state the same as object is", afterTreatment.getRemoteUrl(),
                       ( ( (CRepositoryCoreConfiguration) afterTreatment.getCurrentCoreConfiguration() )

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfiguratorTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepositoryConfiguratorTest.java
@@ -1,0 +1,113 @@
+/**
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.repository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.configuration.application.AuthenticationInfoConverter;
+import org.sonatype.nexus.configuration.application.GlobalHttpProxySettings;
+import org.sonatype.nexus.configuration.application.GlobalRemoteConnectionSettings;
+import org.sonatype.nexus.configuration.model.CRemoteStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.CRepositoryCoreConfiguration;
+import org.sonatype.nexus.proxy.storage.remote.RemoteProviderHintFactory;
+import org.sonatype.nexus.proxy.storage.remote.RemoteRepositoryStorage;
+import org.sonatype.nexus.proxy.storage.remote.RemoteStorageContext;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+import org.sonatype.sisu.litmus.testsupport.mock.MockitoRule;
+
+/**
+ *
+ */
+public class AbstractProxyRepositoryConfiguratorTest
+    extends TestSupport
+{
+
+    private AbstractProxyRepositoryConfigurator underTest;
+
+    @Mock
+    private RemoteProviderHintFactory providerHints;
+
+    @Mock
+    private GlobalRemoteConnectionSettings connSettings;
+
+    @Mock
+    private GlobalHttpProxySettings proxySettings;
+
+    @Mock
+    private AuthenticationInfoConverter authInfoConverter;
+
+    @Mock
+    private CRepositoryCoreConfiguration coreConfiguration;
+
+    @Mock
+    private ProxyRepository repository;
+
+    @Mock
+    private ApplicationConfiguration configuration;
+
+    @Mock
+    private CRepository repoConfiguration;
+
+    @Mock
+    private CRemoteStorage storageConfiguration;
+
+    @Mock
+    private RemoteRepositoryStorage storage;
+
+    @Mock
+    private RemoteStorageContext storageContext;
+
+    @Before
+    public void setup()
+    {
+        underTest =
+            new AbstractProxyRepositoryConfigurator( authInfoConverter, proxySettings, connSettings, providerHints ) {};
+
+        when( providerHints.getDefaultHttpRoleHint() ).thenReturn( "defaultHint" );
+        when( coreConfiguration.getConfiguration( true ) ).thenReturn( repoConfiguration );
+        when( repoConfiguration.getRemoteStorage() ).thenReturn( storageConfiguration );
+        when( repository.getRemoteStorage() ).thenReturn( storage );
+        when( repository.getRemoteStorageContext() ).thenReturn( storageContext );
+    }
+
+    @Test
+    public void doNotSaveDefaultProvider()
+    {
+        when( storage.getProviderId() ).thenReturn( "defaultHint" );
+
+        underTest.doPrepareForSave( repository, configuration, coreConfiguration );
+
+        verify( storageConfiguration ).setProvider( null );
+    }
+
+    @Test
+    public void retainNonDefaultProvider()
+    {
+        when( storage.getProviderId() ).thenReturn( "differentHint" );
+
+        underTest.doPrepareForSave( repository, configuration, coreConfiguration );
+
+        verify( storageConfiguration, Mockito.never() ).setProvider( anyString() );
+    }
+
+}

--- a/nexus/nexus-test/nexus-it-helper-plugin/src/test/resources/nexus.xml
+++ b/nexus/nexus-test/nexus-it-helper-plugin/src/test/resources/nexus.xml
@@ -67,7 +67,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>release</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://repo1.maven.org/maven2/</url>
 			</remoteStorage>
 		</repository>
@@ -88,7 +87,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://people.apache.org/repo/m2-snapshot-repository</url>
 			</remoteStorage>
 		</repository>
@@ -107,7 +105,6 @@
 			<maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
 			<repositoryPolicy>snapshot</repositoryPolicy>
 			<remoteStorage>
-				<provider>apacheHttpClient3x</provider>
 				<url>http://snapshots.repository.codehaus.org/</url>
 			</remoteStorage>
 		</repository>

--- a/nexus/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/nexus.xml
@@ -52,7 +52,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1089/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1089/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1101/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1101/test-config/nexus.xml
@@ -40,7 +40,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1113/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1113/test-config/nexus.xml
@@ -50,7 +50,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1116/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1116/test-config/nexus.xml
@@ -44,7 +44,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1146/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1146/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1155/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1155/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1560/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1560/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1563/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1563/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus1581/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus1581/test-config/nexus.xml
@@ -33,7 +33,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus2120/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus2120/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus2351/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus2351/test-config/nexus.xml
@@ -330,7 +330,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:60944/remote/release-proxy-repo-1</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus2379/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus2379/test-config/nexus.xml
@@ -168,7 +168,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:60944/remote/release-proxy-repo-1</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus2692/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus2692/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -65,7 +64,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -96,7 +94,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus2996/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus2996/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -65,7 +64,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -96,7 +94,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus3011/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus3011/test-config/nexus.xml
@@ -31,7 +31,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -59,7 +58,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -87,7 +85,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus3045/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus3045/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -65,7 +64,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots</url>
       </remoteStorage>
       <externalConfiguration>
@@ -96,7 +94,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://snapshots.repository.codehaus.org/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus3082/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus3082/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus3832/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus3832/test-config/nexus.xml
@@ -38,7 +38,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4123/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4123/test-config/nexus.xml
@@ -36,7 +36,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test/nexus/content/groups/public/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -68,7 +67,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test/nexus/content/groups/thirdparty/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -99,7 +97,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test/nexus/content/groups/enterprise/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -158,7 +155,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test/nexus/content/groups/enterprise-snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -189,7 +185,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test/nexus/content/groups/internal/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -220,7 +215,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://test:8200/nexus/content/repositories/test/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus421/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus421/test-config/nexus.xml
@@ -31,7 +31,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -59,7 +58,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -87,7 +85,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -116,7 +113,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -142,7 +138,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -170,7 +165,6 @@
       <indexable>true</indexable>
       <searchable>true</searchable>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4218/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4218/test-config/nexus.xml
@@ -38,7 +38,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4268/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4268/test-config/nexus.xml
@@ -36,7 +36,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repo1.maven.org/maven2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -67,7 +66,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -98,7 +96,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/2/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -127,7 +124,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://download.java.net/maven/1/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -156,7 +152,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://repository.apache.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>
@@ -187,7 +182,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://nexus.codehaus.org/snapshots/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4341/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4341/test-config/nexus.xml
@@ -34,7 +34,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4539/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4539/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4593/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4593/test-config/nexus.xml
@@ -38,7 +38,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>${proxy-repo-base-url}release-proxy-repo-1</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus4594/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus4594/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository/</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus602/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus602/test-config/nexus.xml
@@ -38,7 +38,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus635/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus635/test-config/nexus.xml
@@ -44,7 +44,6 @@
             <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
             <repositoryPolicy>release</repositoryPolicy>
             <remoteStorage>
-                <provider>apacheHttpClient3x</provider>
                 <url>http://repo1.maven.org/maven2/</url>
             </remoteStorage>
         </repository>
@@ -65,7 +64,6 @@
             <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
             <repositoryPolicy>snapshot</repositoryPolicy>
             <remoteStorage>
-                <provider>apacheHttpClient3x</provider>
                 <url>http://people.apache.org/repo/m2-snapshot-repository</url>
             </remoteStorage>
         </repository>
@@ -84,7 +82,6 @@
             <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
             <repositoryPolicy>snapshot</repositoryPolicy>
             <remoteStorage>
-                <provider>apacheHttpClient3x</provider>
                 <url>http://snapshots.repository.codehaus.org/</url>
             </remoteStorage>
         </repository>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus874/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus874/test-config/nexus.xml
@@ -42,7 +42,6 @@
             <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
             <repositoryPolicy>release</repositoryPolicy>
             <remoteStorage>
-                <provider>apacheHttpClient3x</provider>
                 <url>http://repo1.maven.org/maven2/</url>
             </remoteStorage>
         </repository> -->

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus970/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus970/test-config/nexus.xml
@@ -44,7 +44,6 @@
             <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata>
             <repositoryPolicy>release</repositoryPolicy>
             <remoteStorage>
-                <provider>apacheHttpClient3x</provider>
                 <url>http://repo1.maven.org/maven2/</url>
             </remoteStorage>
         </repository> -->

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus977browse/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus977browse/test-config/nexus.xml
@@ -38,7 +38,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus977download/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus977download/test-config/nexus.xml
@@ -38,7 +38,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nexus977tasks/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nexus977tasks/test-config/nexus.xml
@@ -116,7 +116,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>${proxy-repo-base-url}nexus977tasks/1</url>
       </remoteStorage>
       <externalConfiguration>
@@ -147,7 +146,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>${proxy-repo-base-url}nexus977tasks/2</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/nexus-test/nexus-test-harness-its/resources/nxcm1928/test-config/nexus.xml
+++ b/nexus/nexus-test/nexus-test-harness-its/resources/nxcm1928/test-config/nexus.xml
@@ -34,7 +34,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository</url>
       </remoteStorage>
       <externalConfiguration>

--- a/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm2974/test-config/nexus.xml
+++ b/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm2974/test-config/nexus.xml
@@ -48,7 +48,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm335/test-config/nexus.xml
+++ b/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm335/test-config/nexus.xml
@@ -48,7 +48,7 @@
     <!--
       <repository> <id>central</id> <name>Maven Central</name> <localStatus>inService</localStatus> <proxyMode>allow</proxyMode> <allowWrite>false</allowWrite> <browseable>true</browseable> <indexable>true</indexable>
       <notFoundCacheTTL>1440</notFoundCacheTTL> <artifactMaxAge>-1</artifactMaxAge> <metadataMaxAge>1440</metadataMaxAge> <maintainProxiedRepositoryMetadata>false</maintainProxiedRepositoryMetadata> <repositoryPolicy>release</repositoryPolicy>
-      <remoteStorage> <provider>apacheHttpClient3x</provider> <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
+      <remoteStorage>  <url>http://repo1.maven.org/maven2/</url> </remoteStorage> </repository>
     -->
 
 

--- a/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm4591/test-config/nexus.xml
+++ b/nexus/plugins/ldap/nexus-ldap-plugin-it/resources/nxcm4591/test-config/nexus.xml
@@ -48,7 +48,6 @@
         <provider>file</provider>
       </localStorage>
       <remoteStorage>
-        <provider>apacheHttpClient3x</provider>
         <url>http://localhost:${webproxy-server-port}/repository</url>
       </remoteStorage>
       <externalConfiguration>


### PR DESCRIPTION
This pull request will change the config behavior to not save the system default remote storage provider into the repo configuration. 

Repositories with old 'apachehttpclient3x' will stay that way. Repositories using 'apachehttpclient4x' (the current default) will be saved without a provider hint to grab the system default on load in the future. This value can already be set via a system property. This makes "upgrading" the default storage provider effortless, as all repositories using the default before will instantly use the new default.

In hindsight, I'm not sure if that was the intention of the issue. As it is now, a new repository will have the current system default applied, and will explicitely save that value into the configuration. This behavior actually matches the issue description ("use system default on create").

Comments?
