### PR TITLE
NXCM-4814 avoid system-wide indexer lockups

### DIFF
--- a/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
+++ b/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/index/DefaultIndexerManager.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -60,7 +61,6 @@ import org.apache.maven.index.ArtifactInfoPostprocessor;
 import org.apache.maven.index.Field;
 import org.apache.maven.index.FlatSearchRequest;
 import org.apache.maven.index.FlatSearchResponse;
-import org.apache.maven.index.IndexerEngine;
 import org.apache.maven.index.IteratorResultSet;
 import org.apache.maven.index.IteratorSearchRequest;
 import org.apache.maven.index.IteratorSearchResponse;
@@ -70,7 +70,6 @@ import org.apache.maven.index.MatchHighlightRequest;
 import org.apache.maven.index.NexusIndexer;
 import org.apache.maven.index.Scanner;
 import org.apache.maven.index.ScanningRequest;
-import org.apache.maven.index.ScanningResult;
 import org.apache.maven.index.SearchType;
 import org.apache.maven.index.artifact.VersionUtils;
 import org.apache.maven.index.context.DefaultIndexingContext;
@@ -186,6 +185,8 @@ import com.google.common.annotations.VisibleForTesting;
 public class DefaultIndexerManager
     implements IndexerManager
 {
+    private static final String ARTIFICIAL_EXCEPTION = "This is an artificial exception that provides caller backtrace.";
+
     /** The key used in working directory. */
     public static final String INDEXER_WORKING_DIRECTORY_KEY = "indexer";
 
@@ -290,6 +291,14 @@ public class DefaultIndexerManager
     @Nullable
     @Named( "${lucene.fsdirectory.type}" )
     private String luceneFSDirectoryType;
+
+    /**
+     * Timeout, in seconds, acquiring index locks. This is a safety net meant to prevent complete system lockup in case
+     * of index lock leaks.
+     */
+    @Inject
+    @Named( "${nexus.indexer.locktimeout:-60}" )
+    private int lockTimeoutSeconds;
 
     /**
      * Locks that protect access to repository index. Item-level add/remove and search operations must acquire read
@@ -2285,21 +2294,23 @@ public class DefaultIndexerManager
         }
         else
         {
-            lock = getRepositoryLock( repository ).readLock();
-            lock.lock();
-            IndexingContext context = getRepositoryIndexContext( repository );
-            if ( context != null )
+            lock = getRepositoryLock( repository, false /* shared */);
+            if ( lock != null )
             {
-                lockedContext = new LockingIndexingContext( context, lock );
-            }
-            else
-            {
-                lock.unlock();
-                lock = null;
+                IndexingContext context = getRepositoryIndexContext( repository );
+                if ( context != null )
+                {
+                    lockedContext = new LockingIndexingContext( context, lock );
+                }
+                else
+                {
+                    lock.unlock();
+                    lock = null;
+                }
             }
         }
 
-        if ( lockedContext != null )
+        if ( lockedContext != null && lock != null )
         {
             try
             {
@@ -2313,7 +2324,7 @@ public class DefaultIndexerManager
         else
         {
             logger.warn( "Could not perform index operation on repository {}", repository.getId(),
-                         new Exception( "This is an artificial exception that provides caller backtrace." ) );
+                         new Exception( ARTIFICIAL_EXCEPTION ) );
         }
     }
 
@@ -2324,24 +2335,26 @@ public class DefaultIndexerManager
     private void sharedSingle( Repository repository, Runnable runnable )
         throws IOException
     {
-        Lock lock = getRepositoryLock( repository ).readLock();
-        lock.lock();
-        try
+        Lock lock = getRepositoryLock( repository, false /* shared */);
+        if ( lock != null )
         {
-            IndexingContext ctx = getRepositoryIndexContext( repository );
-            if ( ctx != null )
+            try
             {
-                runnable.run( ctx );
+                IndexingContext ctx = getRepositoryIndexContext( repository );
+                if ( ctx != null )
+                {
+                    runnable.run( ctx );
+                }
+                else
+                {
+                    logger.warn( "Could not perform index operation on repository {}", repository.getId(),
+                                 new Exception( ARTIFICIAL_EXCEPTION ) );
+                }
             }
-            else
+            finally
             {
-                logger.warn( "Could not perform index operation on repository {}", repository.getId(),
-                             new Exception( "This is an artificial exception that provides caller backtrace." ) );
+                lock.unlock();
             }
-        }
-        finally
-        {
-            lock.unlock();
         }
     }
 
@@ -2444,35 +2457,52 @@ public class DefaultIndexerManager
     private void exclusiveSingle( Repository repository, Runnable runnable )
         throws IOException
     {
-        Lock lock = getRepositoryLock( repository ).writeLock();
-        lock.lock();
-        try
+        Lock lock = getRepositoryLock( repository, true /* exclusive */);
+        if ( lock != null )
         {
-            IndexingContext ctx = getRepositoryIndexContext( repository );
-            runnable.run( ctx );
-        }
-        finally
-        {
-            lock.unlock();
+            try
+            {
+                IndexingContext ctx = getRepositoryIndexContext( repository );
+                runnable.run( ctx );
+            }
+            finally
+            {
+                lock.unlock();
+            }
         }
     }
 
     /**
-     * Returns "repository" read-write lock that corresponds to the repository. The lock is used to protect access to
-     * the repository Lucene index.
+     * Acquires either shared or exclusive "repository" lock. The lock is used to protect access to the repository
+     * Lucene index. Returns null if requested lock cannot be acquired due to timeout or ingterruption.
      */
-    private ReadWriteLock getRepositoryLock( Repository repository )
+    private Lock getRepositoryLock( Repository repository, boolean exclusive )
     {
+        ReadWriteLock rwlock;
         synchronized ( repositoryLocks )
         {
-            ReadWriteLock lock = repositoryLocks.get( repository.getId() );
-            if ( lock == null )
+            rwlock = repositoryLocks.get( repository.getId() );
+            if ( rwlock == null )
             {
-                lock = NamedReadWriteLock.decorate( new ReentrantReadWriteLock(), repository.getId() );
-                repositoryLocks.put( repository.getId(), lock );
+                rwlock = NamedReadWriteLock.decorate( new ReentrantReadWriteLock(), repository.getId() );
+                repositoryLocks.put( repository.getId(), rwlock );
             }
-            return lock;
         }
+        try
+        {
+            Lock lock = exclusive ? rwlock.writeLock() : rwlock.readLock();
+            if ( lock.tryLock( lockTimeoutSeconds, TimeUnit.SECONDS ) )
+            {
+                return lock;
+            }
+        }
+        catch ( InterruptedException e )
+        {
+            // TODO consider throwing IOException instead
+        }
+        logger.error( "Could not acquire {} lock on repository {}", exclusive ? "exclusive" : "shared",
+                      repository.getId(), new Exception( ARTIFICIAL_EXCEPTION ) );
+        return null;
     }
 
     /**
@@ -2558,19 +2588,21 @@ public class DefaultIndexerManager
         Map<String, IndexingContext> contexts = new LinkedHashMap<String, IndexingContext>();
         for ( Repository repository : sorted )
         {
-            Lock lock = getRepositoryLock( repository ).readLock();
-
-            lock.lock(); // at this point repository index cannot be added or removed, we can safely use it
-            IndexingContext context = getRepositoryIndexContext( repository );
-
-            if ( !repository.getId().equals( force ) && context == null )
+            Lock lock = getRepositoryLock( repository, false /* shared */);
+            if ( lock != null )
             {
-                lock.unlock();
-                continue;
-            }
+                // at this point repository index cannot be added or removed, we can safely use it
+                IndexingContext context = getRepositoryIndexContext( repository );
 
-            locks.add( lock );
-            contexts.put( repository.getId(), new LockingIndexingContext( context, lock ) );
+                if ( !repository.getId().equals( force ) && context == null )
+                {
+                    lock.unlock();
+                    continue;
+                }
+
+                locks.add( lock );
+                contexts.put( repository.getId(), new LockingIndexingContext( context, lock ) );
+            }
         }
 
         if ( contexts.isEmpty() )


### PR DESCRIPTION
All indexer locks are acquired with a time out (default 60 seconds).
Lock timeouts are logged as errors but otherwise ignored. This can
result in individual index corruption and index-related exceptions,
particularly on windows, but should prevent system-wide lockups due
to infinite wait for lock acquisition.

Signed-off-by: Igor Fedorenko igor@ifedorenko.com
