### PR TITLE
[NXCM-4587] Unescape HTML entities for SMTP valiation resource

### DIFF
--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/AbstractGlobalConfigurationPlexusResource.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/AbstractGlobalConfigurationPlexusResource.java
@@ -43,6 +43,7 @@ import org.sonatype.nexus.rest.model.RemoteConnectionSettings;
 import org.sonatype.nexus.rest.model.RemoteHttpProxySettings;
 import org.sonatype.nexus.rest.model.RestApiSettings;
 import org.sonatype.nexus.rest.model.SmtpSettings;
+import org.sonatype.nexus.rest.model.SmtpSettingsResource;
 import org.sonatype.nexus.rest.model.SystemNotificationSettings;
 
 /**
@@ -428,10 +429,4 @@ public abstract class AbstractGlobalConfigurationPlexusResource
         return result;
     }
 
-    @Override
-    public void configureXStream( final XStream xstream )
-    {
-        xstream.registerLocalConverter( SmtpSettings.class, "username", new HtmlUnescapeStringConverter( true ) );
-        xstream.registerLocalConverter( SmtpSettings.class, "password", new HtmlUnescapeStringConverter( true ) );
-    }
 }

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/GlobalConfigurationPlexusResource.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/GlobalConfigurationPlexusResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
+import com.thoughtworks.xstream.XStream;
 import org.codehaus.enunciate.contract.jaxrs.ResourceMethodSignature;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
@@ -51,6 +52,7 @@ import org.sonatype.nexus.proxy.repository.UsernamePasswordRemoteAuthenticationS
 import org.sonatype.nexus.rest.model.ErrorReportingSettings;
 import org.sonatype.nexus.rest.model.GlobalConfigurationResource;
 import org.sonatype.nexus.rest.model.GlobalConfigurationResourceResponse;
+import org.sonatype.nexus.rest.model.HtmlUnescapeStringConverter;
 import org.sonatype.nexus.rest.model.RemoteConnectionSettings;
 import org.sonatype.nexus.rest.model.RemoteHttpProxySettings;
 import org.sonatype.nexus.rest.model.RestApiSettings;
@@ -582,4 +584,10 @@ public class GlobalConfigurationPlexusResource
         }
     }
 
+    @Override
+    public void configureXStream( final XStream xstream )
+    {
+        xstream.registerLocalConverter( SmtpSettings.class, "username", new HtmlUnescapeStringConverter( true ) );
+        xstream.registerLocalConverter( SmtpSettings.class, "password", new HtmlUnescapeStringConverter( true ) );
+    }
 }

--- a/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/SmtpSettingsValidationPlexusResource.java
+++ b/nexus/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/global/SmtpSettingsValidationPlexusResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
+import com.thoughtworks.xstream.XStream;
 import org.codehaus.enunciate.contract.jaxrs.ResourceMethodSignature;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
@@ -30,6 +31,7 @@ import org.restlet.resource.ResourceException;
 import org.sonatype.nexus.configuration.model.CSmtpConfiguration;
 import org.sonatype.nexus.email.EmailerException;
 import org.sonatype.nexus.email.SmtpSettingsValidator;
+import org.sonatype.nexus.rest.model.HtmlUnescapeStringConverter;
 import org.sonatype.nexus.rest.model.SmtpSettingsResource;
 import org.sonatype.nexus.rest.model.SmtpSettingsResourceRequest;
 import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
@@ -142,4 +144,10 @@ public class SmtpSettingsValidationPlexusResource
         }
     }
 
+    @Override
+    public void configureXStream( final XStream xstream )
+    {
+        xstream.registerLocalConverter( SmtpSettingsResource.class, "username", new HtmlUnescapeStringConverter( true ) );
+        xstream.registerLocalConverter( SmtpSettingsResource.class, "password", new HtmlUnescapeStringConverter( true ) );
+    }
 }


### PR DESCRIPTION
The smtp config validation resource actually uses a different DTO than the actual settings resource... User/Password is unescaped for both now.
