### PR TITLE
NEXUS-5422 use String to determine if two versions are equal

### DIFF
--- a/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/GAHolder.java
+++ b/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/GAHolder.java
@@ -17,27 +17,26 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.maven.index.artifact.VersionUtils;
-import org.sonatype.aether.version.Version;
 import org.sonatype.nexus.rest.model.NexusNGArtifact;
 
 class GAHolder
 {
-    private final SortedMap<Version, NexusNGArtifact> versionHits = new TreeMap<Version, NexusNGArtifact>();
+    private final SortedMap<StringVersion, NexusNGArtifact> versionHits = new TreeMap<StringVersion, NexusNGArtifact>();
 
     private NexusNGArtifact latestSnapshot = null;
 
-    private Version latestSnapshotVersion = null;
+    private StringVersion latestSnapshotVersion = null;
 
     private NexusNGArtifact latestRelease = null;
 
-    private Version latestReleaseVersion = null;
+    private StringVersion latestReleaseVersion = null;
 
-    public NexusNGArtifact getVersionHit( Version version )
+    public NexusNGArtifact getVersionHit( StringVersion version )
     {
         return versionHits.get( version );
     }
 
-    public void putVersionHit( Version version, NexusNGArtifact versionHit )
+    public void putVersionHit( StringVersion version, NexusNGArtifact versionHit )
     {
         versionHits.put( version, versionHit );
 

--- a/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/SearchNGIndexPlexusResource.java
+++ b/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/SearchNGIndexPlexusResource.java
@@ -40,7 +40,6 @@ import org.restlet.resource.ResourceException;
 import org.restlet.resource.Variant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonatype.aether.version.Version;
 import org.sonatype.nexus.index.Searcher;
 import org.sonatype.nexus.proxy.NoSuchRepositoryException;
 import org.sonatype.nexus.proxy.maven.MavenRepository;
@@ -419,7 +418,7 @@ public class SearchNGIndexPlexusResource
 
             }
 
-            Version version = ai.getArtifactVersion();
+            StringVersion version = new StringVersion( ai.version, ai.getArtifactVersion() );
 
             NexusNGArtifact versionHit = gaholder.getVersionHit( version );
             if ( versionHit == null )

--- a/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/StringVersion.java
+++ b/nexus/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/rest/indexng/StringVersion.java
@@ -1,0 +1,68 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.rest.indexng;
+
+import org.sonatype.aether.version.Version;
+
+/**
+ * Special version wrapper that uses original (string) version representation to determine version equality but aether
+ * Version to determine if one version is greater than another. In other words, it provides proper version order
+ * (according to Maven versioning rules), but treats "2" and "2.0" as two distinct versions.
+ */
+class StringVersion
+    implements Comparable<StringVersion>
+{
+    private final String string;
+
+    private final Version version;
+
+    public StringVersion( String string, Version version )
+    {
+        this.string = string;
+        this.version = version;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return string.hashCode();
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+
+        if ( !( obj instanceof StringVersion ) )
+        {
+            return false;
+        }
+
+        return string.equals( ( (StringVersion) obj ).string );
+    }
+
+    @Override
+    public int compareTo( StringVersion other )
+    {
+        int c = version.compareTo( other.version );
+        if ( c != 0 )
+        {
+            return c;
+        }
+        return string.compareTo( other.string );
+    }
+
+}


### PR DESCRIPTION
Aether uses Maven version comparison rules to determine if two
versions are equal, and considers 2 and 2.0 to be the same version,
which is not appropriate for index searches.

Changed the code to use aether logic to order versions, but fall
back to string comparison to determine if versions are equal or not.

Signed-off-by: Igor Fedorenko igor@ifedorenko.com
