### PR TITLE
Smaller fixes

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/events/RepositoryGroupMembersChangedEvent.java
@@ -23,16 +23,17 @@ import org.sonatype.nexus.proxy.repository.GroupRepository;
 
 /**
  * Fired when a group repository members changed and change is commited to configuration (is not rolled back).
- * 
+ *
  * @author cstamas
  */
 public class RepositoryGroupMembersChangedEvent
     extends RepositoryEvent
 {
+
     /**
      * Enum describing the changes that might happen against a group members list. Every enum describes one of the
      * possible type of the change, but they might happen all together too.
-     * 
+     *
      * @author cstamas
      * @since 2.0
      */
@@ -83,7 +84,7 @@ public class RepositoryGroupMembersChangedEvent
     private final Set<MemberChange> memberChangeSet;
 
     public RepositoryGroupMembersChangedEvent( final GroupRepository repository, final List<String> currentMemberIds,
-                                               final List<String> newMemberIds )
+        final List<String> newMemberIds )
     {
         super( repository );
         // we need to copy these to "detach" them for sure from config
@@ -138,7 +139,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the group repository instance being reconfigured.
-     * 
+     *
      * @return
      */
     public GroupRepository getGroupRepository()
@@ -148,7 +149,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the set of enums describing the changes happened against group repository.
-     * 
+     *
      * @return
      * @since 2.0
      */
@@ -159,7 +160,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the list of member repository IDs as it was set before the configuration change.
-     * 
+     *
      * @return
      * @since 2.0
      */
@@ -170,7 +171,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the list of member repository IDs as it was set after the configuration change.
-     * 
+     *
      * @return
      * @since 2.0
      */
@@ -181,7 +182,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the list of repository IDs that were removed from the group by the configuration change.
-     * 
+     *
      * @return
      * @since 2.0
      */
@@ -192,7 +193,7 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the list of repository IDs that were added to the group by the configuration change.
-     * 
+     *
      * @return
      * @since 2.0
      */
@@ -203,12 +204,23 @@ public class RepositoryGroupMembersChangedEvent
 
     /**
      * Returns the list of repository IDs that were reordered within the group by the configuration change.
-     * 
+     *
      * @return
      * @since 2.0
      */
     public List<String> getReorderedRepositoryIds()
     {
         return Collections.unmodifiableList( reorderedRepositoryIds );
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "{" +
+            "repositoryId=" + getRepository().getId() +
+            ", addedMembers=" + getAddedRepositoryIds() +
+            ", removedMembers=" + getRemovedRepositoryIds() +
+            ", reorderedMembers=" + getReorderedRepositoryIds() +
+            '}';
     }
 }

--- a/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
+++ b/nexus/nexus-configuration/src/main/java/org/sonatype/nexus/configuration/AbstractConfigurable.java
@@ -90,7 +90,7 @@ public abstract class AbstractConfigurable
     }
 
     @Subscribe
-    public void onEvent( final ConfigurationPrepareForLoadEvent evt )
+    public final void onEvent( final ConfigurationPrepareForLoadEvent evt )
     {
         try
         {
@@ -105,7 +105,7 @@ public abstract class AbstractConfigurable
     }
 
     @Subscribe
-    public void onEvent( final ConfigurationPrepareForSaveEvent evt )
+    public final void onEvent( final ConfigurationPrepareForSaveEvent evt )
     {
         if ( isDirty() )
         {
@@ -126,7 +126,7 @@ public abstract class AbstractConfigurable
     }
 
     @Subscribe
-    public void onEvent( final ConfigurationValidateEvent evt )
+    public final void onEvent( final ConfigurationValidateEvent evt )
     {
         try
         {
@@ -141,7 +141,7 @@ public abstract class AbstractConfigurable
     }
 
     @Subscribe
-    public void onEvent( final ConfigurationCommitEvent evt )
+    public final void onEvent( final ConfigurationCommitEvent evt )
     {
         try
         {
@@ -155,7 +155,7 @@ public abstract class AbstractConfigurable
     }
 
     @Subscribe
-    public void onEvent( final ConfigurationRollbackEvent evt )
+    public final void onEvent( final ConfigurationRollbackEvent evt )
     {
         rollbackChanges();
     }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
 import org.codehaus.plexus.component.annotations.Requirement;
+import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.nexus.configuration.ConfigurationPrepareForSaveEvent;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
@@ -98,10 +99,12 @@ public abstract class AbstractGroupRepository
         }
     }
 
-    @Subscribe
     @Override
-    public void onEvent( final ConfigurationPrepareForSaveEvent evt )
+    public void prepareForSave()
+        throws ConfigurationException
     {
+        super.prepareForSave();
+
         boolean membersChanged = false;
         List<String> currentMemberIds = Collections.emptyList();
         List<String> newMemberIds = Collections.emptyList();
@@ -127,8 +130,6 @@ public abstract class AbstractGroupRepository
                 newMemberIds = getExternalConfiguration( true ).getMemberRepositoryIds();
             }
         }
-
-        super.onEvent( evt );
 
         if ( membersChanged )
         {

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -100,7 +100,7 @@ public abstract class AbstractGroupRepository
     }
 
     @Override
-    public void prepareForSave()
+    protected void prepareForSave()
         throws ConfigurationException
     {
         super.prepareForSave();


### PR DESCRIPTION
Smaller fixes:
Those are:
- added toString to RepositoryGroupMembersChangedEvent (eases debugging)
- AbstractConfigurable, subscriber methods made final
- AbstractGroupRepository, properly overriding method instead of subscriber method. Original code was not correct,
  as the work done here belongs to prepareToSave actually.

Latter two fixes the "groups are twice called by event bus" issue, that is also
fixed by bumping EventBus to 13.0.1 (done by Alin), but still, this code now is
better and more correct.
