### PR TITLE
Fix MUtils to handle 'too short' checksums

### DIFF
--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/MUtils.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
@@ -47,61 +48,67 @@ public class MUtils
     {
         try
         {
-            String raw = StringUtils.chomp( IOUtil.toString( inputStream, "UTF-8" ) ).trim();
-
-            if ( StringUtils.isEmpty( raw ) )
-            {
-                return "";
-            }
-
-            String digest;
-            // digest string at end with separator, e.g.:
-            // MD5 (pom.xml) = 68da13206e9dcce2db9ec45a9f7acd52
-            // ant-1.5.jar: DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167
-            if ( raw.contains( "=" ) || raw.contains( ":" ) )
-            {
-                digest = raw.split( "[=:]", 2 )[1].trim();
-            }
-            else
-            {
-                // digest string at start, e.g. '68da13206e9dcce2db9ec45a9f7acd52 pom.xml'
-                digest = raw.split( " ", 2 )[0];
-            }
-
-            if ( !isDigest( digest ) )
-            {
-                // maybe it's "uncompressed", e.g. 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167'
-                digest = compress( digest );
-            }
-
-            if ( !isDigest( digest ) )
-            {
-                // check if the raw string is an uncompressed checksum, e.g.
-                // 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167'
-                digest = compress( raw );
-            }
-
-            if ( !isDigest( digest ) )
-            {
-                // check if the raw string is an uncompressed checksum with file name suffix, e.g.
-                // 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167 pom.xml'
-                digest = compress( raw.substring( 0, raw.lastIndexOf( " " ) ).trim() );
-            }
-
-            if ( !isDigest( digest ) )
-            {
-                // we have to return some string even if it's not a valid digest, because 'null' is treated as
-                // "checksum does not exist" elsewhere (AbstractChecksumContentValidator)
-                // -> fallback to original behavior
-                digest = raw.split( " ", 2 )[0];
-            }
-
-            return digest;
+            return readDigest( IOUtil.toString( inputStream, "UTF-8" ) );
         }
         finally
         {
             IOUtil.close( inputStream );
         }
+    }
+
+    @VisibleForTesting
+    static String readDigest( final String input )
+    {
+        String raw = StringUtils.chomp( input ).trim();
+
+        if ( StringUtils.isEmpty( raw ) )
+        {
+            return "";
+        }
+
+        String digest;
+        // digest string at end with separator, e.g.:
+        // MD5 (pom.xml) = 68da13206e9dcce2db9ec45a9f7acd52
+        // ant-1.5.jar: DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167
+        if ( raw.contains( "=" ) || raw.contains( ":" ) )
+        {
+            digest = raw.split( "[=:]", 2 )[1].trim();
+        }
+        else
+        {
+            // digest string at start, e.g. '68da13206e9dcce2db9ec45a9f7acd52 pom.xml'
+            digest = raw.split( " ", 2 )[0];
+        }
+
+        if ( !isDigest( digest ) )
+        {
+            // maybe it's "uncompressed", e.g. 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167'
+            digest = compress( digest );
+        }
+
+        if ( !isDigest( digest ) )
+        {
+            // check if the raw string is an uncompressed checksum, e.g.
+            // 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167'
+            digest = compress( raw );
+        }
+
+        if ( !isDigest( digest ) && digest.contains( " " ) )
+        {
+            // check if the raw string is an uncompressed checksum with file name suffix, e.g.
+            // 'DCAB 88FC 2A04 3C24 79A6 DE67 6A2F 8179 E9EA 2167 pom.xml'
+            digest = compress( raw.substring( 0, raw.lastIndexOf( " " ) ).trim() );
+        }
+
+        if ( !isDigest( digest ) )
+        {
+            // we have to return some string even if it's not a valid digest, because 'null' is treated as
+            // "checksum does not exist" elsewhere (AbstractChecksumContentValidator)
+            // -> fallback to original behavior
+            digest = raw.split( " ", 2 )[0];
+        }
+
+        return digest;
     }
 
     private static String compress( String digest )

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/MUtilsTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/MUtilsTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.sonatype.nexus.proxy.maven.MUtils.readDigest;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -81,6 +82,19 @@ public class MUtilsTest
         final File sha1 = util.resolveFile( "target/test-classes/nexus-4984/zero-bytes-length.sha1" );
         final String digest = MUtils.readDigestFromStream( new FileInputStream( sha1 ) );
         assertThat( "Zero bites checksum file", digest, is( equalTo( "" ) ) );
+    }
+
+    /**
+     * Invalid digest, so MUtil should return it as is.
+     */
+    @Test
+    public void invalidShortDigest()
+    {
+        assertThat( readDigest( "123456" ), is( "123456" ) );
+        assertThat( readDigest( "" ), is( "" ) );
+
+        // special case, because space is a delimiter that will be munched
+        assertThat( readDigest( " " ), is( "" ) );
     }
 
 }


### PR DESCRIPTION
Unguarded index of(" ") was triggering an exception and resulted in
relaying HTTP 500 status for staging close with checksum rule check.
