### PR TITLE
NXCM-4861: Fixing the ArtifactStoreHelper.storeItemWithChecksums method

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
@@ -30,13 +30,13 @@ public class RequestContext
     /** Context URL of the original resource requested on the incoming connector. */
     public static final String CTX_REQUEST_URL = "request.url";
 
-    /** Context flag to mark a request local only. */
+    /** Context flag to mark a request local only (proxy: do not attempt remote access at all, else: no effect). */
     public static final String CTX_LOCAL_ONLY_FLAG = "request.localOnly";
 
-    /** Context flag to mark a request local only. */
+    /** Context flag to mark a request local only (proxy: force remote access -- might still serve local if up2date, else: no effect). */
     public static final String CTX_REMOTE_ONLY_FLAG = "request.remoteOnly";
 
-    /** Context flag to mark a request local only. */
+    /** Context flag to mark a request local only (group: do not "dive" into members, else: no effect). */
     public static final String CTX_GROUP_LOCAL_ONLY_FLAG = "request.groupLocalOnly";
 
     /** Context key for condition "if-modified-since" */
@@ -55,15 +55,11 @@ public class RequestContext
 
     public RequestContext()
     {
-        super();
-
-        this.parent = null;
+        setParentContext( null );
     }
 
     public RequestContext( RequestContext parent )
     {
-        this();
-
         setParentContext( parent );
     }
 
@@ -180,7 +176,7 @@ public class RequestContext
     /**
      * Sets the request remote only.
      * 
-     * @param requestremoteOnly the new request remote only
+     * @param requestRemoteOnly the new request remote only
      */
     public void setRequestRemoteOnly( boolean requestRemoteOnly )
     {
@@ -207,7 +203,7 @@ public class RequestContext
     /**
      * Sets the request group local only.
      * 
-     * @param requestremoteOnly the new request group local only
+     * @param requestGroupLocal the new request group local only
      */
     public void setRequestGroupLocalOnly( boolean requestGroupLocal )
     {
@@ -347,26 +343,30 @@ public class RequestContext
      */
     public Map<String, Object> flatten()
     {
-        HashMap<String, Object> result = new HashMap<String, Object>();
-
+        final HashMap<String, Object> result = new HashMap<String, Object>();
         RequestContext ctx = this;
-
-        Stack<RequestContext> stack = new Stack<RequestContext>();
-
+        final Stack<RequestContext> stack = new Stack<RequestContext>();
         while ( ctx != null )
         {
             stack.push( ctx );
-
             ctx = ctx.getParentContext();
         }
-
         while ( !stack.isEmpty() )
         {
             ctx = stack.pop();
-
             result.putAll( ctx );
         }
-
         return result;
+    }
+
+    // ==
+
+    @Override
+    public String toString()
+    {
+        return "RequestContext{" +
+            "this=" + super.toString() +
+            ", parent=" + parent +
+            '}';
     }
 }

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/RequestContext.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Stack;
 
 import org.codehaus.plexus.util.StringUtils;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.ProxyRepository;
 
 public class RequestContext
     extends HashMap<String, Object>
@@ -30,13 +32,13 @@ public class RequestContext
     /** Context URL of the original resource requested on the incoming connector. */
     public static final String CTX_REQUEST_URL = "request.url";
 
-    /** Context flag to mark a request local only (proxy: do not attempt remote access at all, else: no effect). */
+    /** Context flag to mark a request local only. For {@link ProxyRepository} instances: do not attempt remote access at all, else: no effect. */
     public static final String CTX_LOCAL_ONLY_FLAG = "request.localOnly";
 
-    /** Context flag to mark a request local only (proxy: force remote access -- might still serve local if up2date, else: no effect). */
+    /** Context flag to mark a request local only. For {@link ProxyRepository} instances: force remote access -- might still serve local if cache is fresh, else: no effect. */
     public static final String CTX_REMOTE_ONLY_FLAG = "request.remoteOnly";
 
-    /** Context flag to mark a request local only (group: do not "dive" into members, else: no effect). */
+    /** Context flag to mark a request local only. For {@link GroupRepository} instances: do not "dive" into members, else: no effect. */
     public static final String CTX_GROUP_LOCAL_ONLY_FLAG = "request.groupLocalOnly";
 
     /** Context key for condition "if-modified-since" */

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -48,9 +48,9 @@ public class ResourceStoreRequest
     /**
      * Constructor.
      *
-     * @param requestPath
-     * @param localOnly
-     * @param remoteOnly
+     * @param requestPath the request path.
+     * @param localOnly See {@link RequestContext#CTX_LOCAL_ONLY_FLAG}.
+     * @param remoteOnly See {@link RequestContext#CTX_REMOTE_ONLY_FLAG}.
      */
     public ResourceStoreRequest( String requestPath, boolean localOnly, boolean remoteOnly )
     {

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/ResourceStoreRequest.java
@@ -34,20 +34,26 @@ public class ResourceStoreRequest
     private String requestPath;
 
     /** Extra data associated with this request. */
-    private RequestContext requestContext;
+    private final RequestContext requestContext;
 
     /** Used internally by Routers. */
-    private Stack<String> pathStack;
+    private final Stack<String> pathStack;
 
     /** Used internally to track reposes where this request was */
-    private List<String> processedRepositories;
+    private final List<String> processedRepositories;
 
     /** Used internally to track applied mappins */
-    private Map<String, List<String>> appliedMappings;
+    private final Map<String, List<String>> appliedMappings;
 
+    /**
+     * Constructor.
+     *
+     * @param requestPath
+     * @param localOnly
+     * @param remoteOnly
+     */
     public ResourceStoreRequest( String requestPath, boolean localOnly, boolean remoteOnly )
     {
-        super();
         this.requestPath = requestPath;
         this.pathStack = new Stack<String>();
         this.processedRepositories = new ArrayList<String>();
@@ -57,11 +63,23 @@ public class ResourceStoreRequest
         this.requestContext.setRequestRemoteOnly( remoteOnly );
     }
 
+    /**
+     * Shortcut constructor.
+     *
+     * @param requestPath
+     * @param localOnly
+     * @deprecated use {@link #ResourceStoreRequest(String, boolean, boolean)} instead.
+     */
     public ResourceStoreRequest( String requestPath, boolean localOnly )
     {
         this( requestPath, localOnly, false );
     }
 
+    /**
+     * Shortcut constructor.
+     *
+     * @param requestPath
+     */
     public ResourceStoreRequest( String requestPath )
     {
         this( requestPath, false, false );
@@ -71,7 +89,7 @@ public class ResourceStoreRequest
      * Creates a request aimed at given path denoted by RepositoryItemUid.
      * 
      * @param uid the uid
-     * @deprecated use ResourceStoreRequest(String path)
+     * @deprecated use {@link #ResourceStoreRequest(String, boolean, boolean)} instead.
      */
     public ResourceStoreRequest( RepositoryItemUid uid, boolean localOnly )
     {
@@ -79,28 +97,28 @@ public class ResourceStoreRequest
     }
 
     /**
-     * Creates a request for a given item.
+     * Creates a request for a given item that is expected to be already present (locally).
      * 
      * @param item
      */
-    public ResourceStoreRequest( StorageItem item )
+    public ResourceStoreRequest( final StorageItem item )
     {
         this( item.getRepositoryItemUid().getPath(), true, false );
-
-        this.requestContext = item.getItemContext();
+        getRequestContext().setParentContext( item.getItemContext() );
     }
 
     /**
-     * Creates a new request off from a given one.
+     * Creates a new request off from a given one, item is expected to be already present (locally).
      * 
-     * @param item
+     * @param request
      */
-    public ResourceStoreRequest( ResourceStoreRequest request )
+    public ResourceStoreRequest( final ResourceStoreRequest request )
     {
         this( request.getRequestPath(), true, false );
-
         getRequestContext().setParentContext( request.getRequestContext() );
     }
+
+    // ==
 
     /**
      * Gets the request context.
@@ -127,9 +145,10 @@ public class ResourceStoreRequest
      * 
      * @param requestPath the new request path
      */
-    public void setRequestPath( String requestPath )
+    public ResourceStoreRequest setRequestPath( String requestPath )
     {
         this.requestPath = requestPath;
+        return this;
     }
 
     /**
@@ -171,9 +190,10 @@ public class ResourceStoreRequest
      * 
      * @param requestLocalOnly the new request local only
      */
-    public void setRequestLocalOnly( boolean requestLocalOnly )
+    public ResourceStoreRequest setRequestLocalOnly( boolean requestLocalOnly )
     {
         getRequestContext().setRequestLocalOnly( requestLocalOnly );
+        return this;
     }
 
     /**
@@ -189,11 +209,12 @@ public class ResourceStoreRequest
     /**
      * Sets the request remote only.
      * 
-     * @param requestremoteOnly the new request remote only
+     * @param requestRemoteOnly the new request remote only
      */
-    public void setRequestRemoteOnly( boolean requestRemoteOnly )
+    public ResourceStoreRequest setRequestRemoteOnly( boolean requestRemoteOnly )
     {
         getRequestContext().setRequestRemoteOnly( requestRemoteOnly );
+        return this;
     }
 
     /**
@@ -209,11 +230,12 @@ public class ResourceStoreRequest
     /**
      * Sets the request group local only.
      * 
-     * @param requestremoteOnly the new request group local only
+     * @param requestGroupLocal the new request group local only
      */
-    public void setRequestGroupLocalOnly( boolean requestGroupLocal )
+    public ResourceStoreRequest setRequestGroupLocalOnly( boolean requestGroupLocal )
     {
         getRequestContext().setRequestGroupLocalOnly( requestGroupLocal );
+        return this;
     }
 
     /**
@@ -261,9 +283,10 @@ public class ResourceStoreRequest
      * 
      * @param ifModifiedSince
      */
-    public void setIfModifiedSince( long ifModifiedSince )
+    public ResourceStoreRequest setIfModifiedSince( long ifModifiedSince )
     {
         getRequestContext().setIfModifiedSince( ifModifiedSince );
+        return this;
     }
 
     /**
@@ -281,9 +304,10 @@ public class ResourceStoreRequest
      * 
      * @param tag
      */
-    public void setIfNoneMatch( String tag )
+    public ResourceStoreRequest setIfNoneMatch( String tag )
     {
         getRequestContext().setIfNoneMatch( tag );
+        return this;
     }
 
     /**
@@ -301,9 +325,10 @@ public class ResourceStoreRequest
      * 
      * @param url
      */
-    public void setRequestUrl( String url )
+    public ResourceStoreRequest setRequestUrl( String url )
     {
         getRequestContext().setRequestUrl( url );
+        return this;
     }
 
     /**
@@ -321,9 +346,10 @@ public class ResourceStoreRequest
      * 
      * @param url
      */
-    public void setRequestAppRootUrl( String url )
+    public ResourceStoreRequest setRequestAppRootUrl( String url )
     {
         getRequestContext().setRequestAppRootUrl( url );
+        return this;
     }
 
     /**
@@ -349,10 +375,12 @@ public class ResourceStoreRequest
     @Override
     public String toString()
     {
-        StringBuilder sb = new StringBuilder( getClass().getSimpleName() );
-        sb.append( "(requestPath=\"" );
-        sb.append( getRequestPath() );
-        sb.append( "\")" );
-        return sb.toString();
+        return "ResourceStoreRequest{" +
+            "requestPath='" + requestPath + '\'' +
+            ", requestContext=" + requestContext +
+            ", pathStack=" + pathStack +
+            ", processedRepositories=" + processedRepositories +
+            ", appliedMappings=" + appliedMappings +
+            '}';
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreHelper.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ArtifactStoreHelper.java
@@ -80,7 +80,9 @@ public class ArtifactStoreHelper
                     RepositoryStringUtils.getHumanizedNameString( getMavenRepository() ), request ), e );
             }
 
-            StorageFileItem storedFile = (StorageFileItem) getMavenRepository().retrieveItem( false, request );
+            // NXCM-4861: Doing "local only" lookup, same code should be used as in org.sonatype.nexus.proxy.repository.AbstractProxyRepository#doCacheItem
+            // Note: ResourceStoreRequest( ResourceStoreRequest ) creates a "subordinate" request from passed with same path but localOnly=true
+            StorageFileItem storedFile = (StorageFileItem) getMavenRepository().retrieveItem( false, new ResourceStoreRequest( request ) );
 
             String sha1Hash = storedFile.getRepositoryItemAttributes().get( DigestCalculatingInspector.DIGEST_SHA1_KEY );
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/Nxcm4861ArtifactStoreHelper_storeItemWithChecksumsTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/Nxcm4861ArtifactStoreHelper_storeItemWithChecksumsTest.java
@@ -46,11 +46,19 @@ import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.storage.local.LocalRepositoryStorage;
 import org.sonatype.sisu.litmus.testsupport.mock.MockitoRule;
 
-public class Nxcm4861Test
+/**
+ * UT for NXCM-4861: {@link ArtifactStoreHelper#storeItemWithChecksums(boolean, org.sonatype.nexus.proxy.item.AbstractStorageItem)}
+ * was in some cases causing proxying to kick in (after store item was retrieved from remote -- only in case of procurement reposes
+ * but still wrong). 
+ * 
+ * Despite extending {@link AbstractProxyTestEnvironment} it actually uses
+ * a hosted repo only, and using spy determines actually happened invocations. 
+ */
+public class Nxcm4861ArtifactStoreHelper_storeItemWithChecksumsTest
     extends AbstractProxyTestEnvironment
 {
 
-    private Logger log = LoggerFactory.getLogger( Nxcm4861Test.class );
+    private Logger log = LoggerFactory.getLogger( Nxcm4861ArtifactStoreHelper_storeItemWithChecksumsTest.class );
 
     private static final String REPO_ID = "inhouse";
 

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/Nxcm4861Test.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/maven/Nxcm4861Test.java
@@ -1,0 +1,136 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.configuration.model.CLocalStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
+import org.sonatype.nexus.proxy.AbstractProxyTestEnvironment;
+import org.sonatype.nexus.proxy.EnvironmentBuilder;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.storage.local.LocalRepositoryStorage;
+import org.sonatype.sisu.litmus.testsupport.mock.MockitoRule;
+
+public class Nxcm4861Test
+    extends AbstractProxyTestEnvironment
+{
+
+    private Logger log = LoggerFactory.getLogger( Nxcm4861Test.class );
+
+    private static final String REPO_ID = "inhouse";
+
+    @Override
+    protected EnvironmentBuilder getEnvironmentBuilder()
+        throws Exception
+    {
+        // we need one hosted repo only, so build it
+        return new EnvironmentBuilder()
+        {
+            @Override
+            public void startService()
+            {
+            }
+
+            @Override
+            public void stopService()
+            {
+            }
+
+            @Override
+            public void buildEnvironment( AbstractProxyTestEnvironment env )
+                throws ConfigurationException,
+                IOException,
+                ComponentLookupException
+            {
+                final PlexusContainer container = env.getPlexusContainer();
+                // ading one hosted only
+                final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                CRepository repoConf = new DefaultCRepository();
+                repoConf.setProviderRole( Repository.class.getName() );
+                repoConf.setProviderHint( "maven2" );
+                repoConf.setId( REPO_ID );
+                repoConf.setLocalStorage( new CLocalStorage() );
+                repoConf.getLocalStorage().setProvider( "file" );
+                repoConf.getLocalStorage().setUrl(
+                    env.getApplicationConfiguration().getWorkingDirectory(
+                        "proxy/store/inhouse" ).toURI().toURL().toString() );
+                Xpp3Dom exRepo = new Xpp3Dom( "externalConfiguration" );
+                repoConf.setExternalConfiguration( exRepo );
+                M2RepositoryConfiguration exRepoConf = new M2RepositoryConfiguration( exRepo );
+                exRepoConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                repo.configure( repoConf );
+                env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                env.getRepositoryRegistry().addRepository( repo );
+            }
+        };
+    }
+
+    @Test
+    public void retrieveAfterStoreShouldBeLocalOnly()
+        throws Exception
+    {
+        final MavenRepository realMavenRepository =
+            getRepositoryRegistry().getRepositoryWithFacet( REPO_ID, MavenRepository.class );
+        final MavenRepository mavenRepository = Mockito.spy( realMavenRepository );
+
+        // invoke storeWithChecksums
+        final String PATH = "/group/artifact/1.0/artifact-1.0.jar";
+        final ResourceStoreRequest request = new ResourceStoreRequest( PATH );
+        mavenRepository.storeItemWithChecksums( request, new ByteArrayInputStream( "some fluke content".getBytes() ),
+                                                null );
+
+        // verify side effects (storage changes)
+        assertThat( "Artifact should be stored",
+                    mavenRepository.getLocalStorage().containsItem( mavenRepository, new ResourceStoreRequest( PATH ) ),
+                    is( true ) );
+        assertThat( "Artifact checksum should be stored",
+                    mavenRepository.getLocalStorage().containsItem( mavenRepository,
+                                                                    new ResourceStoreRequest( PATH + ".sha1" ) ),
+                    is( true ) );
+
+        // verify params
+        final ArgumentCaptor<ResourceStoreRequest> ac = ArgumentCaptor.forClass( ResourceStoreRequest.class );
+        verify( mavenRepository ).retrieveItem( anyBoolean(), ac.capture() );
+
+        // we need to have exactly one retrieve invocation
+        assertThat( "We must have one retrieve happened!", ac.getAllValues().size(), equalTo( 1 ) );
+        // and that one must be localOnly
+        assertThat( "Request " + ac.getValue() + " should be localOnly!", ac.getValue().isRequestLocalOnly(),
+                    is( true ) );
+    }
+}


### PR DESCRIPTION
In some cases, current imple can result in remote item download
for some proxy configuration, like itemAgingActive=false used by
procurement.

Fixing it, to enforce "localOnly" flag. Basically, same code
is now executed as in case of cache (where also store+retrieve)
happens, see:
org.sonatype.nexus.proxy.repository.AbstractProxyRepository#doCacheItem

Other minor cleanup (mostly javadoc) done.

Added UT that verifies that maven repo now receives a retrieve
with localOnly=true flag.
