### PR TITLE
Warn when magic annotations (@ExtensionPoint @Managed) kick in

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
+++ b/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
@@ -139,11 +139,11 @@ public final class NexusTypeVisitor
             // TODO: Flip this to WARN when aggressively killing legacy component annotations
             // Complain if we see legacy annotations
             if (EXTENSION_POINT_DESC.equals(desc)) {
-                log.debug("Detected legacy @ExtensionPoint annotation: {}", clazz);
+                log.debug("Found legacy @ExtensionPoint annotation: {}", clazz);
                 log.debug("Source: {}", source);
             }
             else if (MANAGED_DESC.equals(desc)) {
-                log.debug("Detected legacy @Managed annotation: {}", clazz);
+                log.debug("Found legacy @Managed annotation: {}", clazz);
                 log.debug("Source: {}", source);
             }
         }

--- a/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
+++ b/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
@@ -54,6 +54,10 @@ public final class NexusTypeVisitor
 
     static final String SINGLETON_DESC = Type.getDescriptor( Singleton.class );
 
+    static final String EXTENSION_POINT_DESC = Type.getDescriptor( ExtensionPoint.class );
+
+    static final String MANAGED_DESC = Type.getDescriptor( Managed.class );
+
     // ----------------------------------------------------------------------
     // Implementation fields
     // ----------------------------------------------------------------------
@@ -129,6 +133,20 @@ public final class NexusTypeVisitor
         sawComponent = sawComponent || COMPONENT_DESC.equals(desc);
         sawNamed = sawNamed || NAMED_DESC.equals(desc);
         sawSingleton = sawSingleton || SINGLETON_DESC.equals(desc);
+
+        // If we detected a class, then ...
+        if (clazz != null) {
+            // TODO: Flip this to WARN when aggressively killing legacy component annotations
+            // Complain if we see legacy annotations
+            if (EXTENSION_POINT_DESC.equals(desc)) {
+                log.debug("Detected legacy @ExtensionPoint annotation: {}", clazz);
+                log.debug("Source: {}", source);
+            }
+            else if (MANAGED_DESC.equals(desc)) {
+                log.debug("Detected legacy @Managed annotation: {}", clazz);
+                log.debug("Source: {}", source);
+            }
+        }
 
         final AnnotationVisitor annotationVisitor = plexusTypeVisitor.visitAnnotation( desc, visible );
         return nexusType.isComponent() && NAMED_DESC.equals( desc ) ? namedHintVisitor : annotationVisitor;

--- a/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
+++ b/nexus-core/src/main/java/org/sonatype/guice/nexus/scanners/NexusTypeVisitor.java
@@ -126,9 +126,9 @@ public final class NexusTypeVisitor
     public AnnotationVisitor visitAnnotation( final String desc, final boolean visible )
     {
         // Remember if we saw @Component, @Named or @Singleton for legacy warning detection
-        sawComponent = COMPONENT_DESC.equals(desc);
-        sawNamed = NAMED_DESC.equals(desc);
-        sawSingleton = SINGLETON_DESC.equals(desc);
+        sawComponent = sawComponent || COMPONENT_DESC.equals(desc);
+        sawNamed = sawNamed || NAMED_DESC.equals(desc);
+        sawSingleton = sawSingleton || SINGLETON_DESC.equals(desc);
 
         final AnnotationVisitor annotationVisitor = plexusTypeVisitor.visitAnnotation( desc, visible );
         return nexusType.isComponent() && NAMED_DESC.equals( desc ) ? namedHintVisitor : annotationVisitor;

--- a/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/plugin/lucene/ui/IndexerLuceneNexusIndexHtmlCustomizer.java
+++ b/plugins/indexer/nexus-indexer-lucene-plugin/src/main/java/org/sonatype/nexus/plugin/lucene/ui/IndexerLuceneNexusIndexHtmlCustomizer.java
@@ -15,11 +15,13 @@ package org.sonatype.nexus.plugin.lucene.ui;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.sonatype.nexus.plugins.rest.AbstractNexusIndexHtmlCustomizer;
 import org.sonatype.nexus.plugins.rest.NexusIndexHtmlCustomizer;
 
 @Named( "IndexerLuceneNexusIndexHtmlCustomizer" )
+@Singleton
 public class IndexerLuceneNexusIndexHtmlCustomizer
     extends AbstractNexusIndexHtmlCustomizer
     implements NexusIndexHtmlCustomizer

--- a/plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/ArchetypeContentGenerator.java
+++ b/plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/ArchetypeContentGenerator.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.plugins.mac;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.ArtifactInfoFilter;
@@ -35,6 +36,7 @@ import org.sonatype.nexus.rest.RepositoryURLBuilder;
  * @author cstamas
  */
 @Named( ArchetypeContentGenerator.ID )
+@Singleton
 public class ArchetypeContentGenerator
     implements ContentGenerator
 {

--- a/plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/MacPluginEventInspector.java
+++ b/plugins/nexus-archetype-plugin/src/main/java/org/sonatype/nexus/plugins/mac/MacPluginEventInspector.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.plugins.mac;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.RepositoryNotAvailableException;
@@ -38,6 +39,8 @@ import org.sonatype.plexus.appevents.Event;
  * 
  * @author cstamas
  */
+@Named
+@Singleton
 public class MacPluginEventInspector
     extends AbstractLoggingComponent
     implements EventInspector

--- a/plugins/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/RrbIndexHtmlCustomizer.java
+++ b/plugins/nexus-rrb-plugin/src/main/java/org/sonatype/nexus/plugins/rrb/RrbIndexHtmlCustomizer.java
@@ -17,6 +17,11 @@ import java.util.Map;
 import org.sonatype.nexus.plugins.rest.AbstractNexusIndexHtmlCustomizer;
 import org.sonatype.nexus.plugins.rest.NexusIndexHtmlCustomizer;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Named
+@Singleton
 public class RrbIndexHtmlCustomizer
     extends AbstractNexusIndexHtmlCustomizer
     implements NexusIndexHtmlCustomizer


### PR DESCRIPTION
Logs warnings when components are reliant on the ExtensionPoint and Managed "magic" instead of properly using Named and Singleton.

Logs detected Plexus components as DEBUG too, once we are close to killing Plexus completely we can flip this to WARN.
