### PR TITLE
Safer handling of mbean registration

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
@@ -76,7 +76,11 @@ public class DebugEventInspector
         {
             try
             {
-                ManagementFactory.getPlatformMBeanServer().unregisterMBean( jmxName );
+                final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+                if ( server.isRegistered( jmxName ) )
+                {
+                    server.unregisterMBean( jmxName );
+                }
             }
             catch ( final Exception e )
             {

--- a/nexus-core/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/events/DebugEventInspector.java
@@ -55,6 +55,11 @@ public class DebugEventInspector
         {
             jmxName = ObjectName.getInstance( JMX_DOMAIN, "name", DebugEventInspector.class.getSimpleName() );
             final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            if ( server.isRegistered( jmxName ) )
+            {
+                getLogger().warn( "MBean already registered; replacing: {}", jmxName );
+                server.unregisterMBean( jmxName );
+            }
             server.registerMBean( new DefaultDebugEventInspectorMBean( this ), jmxName );
         }
         catch ( Exception e )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -87,6 +87,11 @@ public class DefaultAttributeUpgrader
         {
             jmxName = ObjectName.getInstance( JMX_DOMAIN, "name", AttributeUpgrader.class.getSimpleName() );
             final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            if ( server.isRegistered( jmxName ) )
+            {
+                getLogger().warn( "MBean already registered; replacing: {}", jmxName );
+                server.unregisterMBean( jmxName );
+            }
             server.registerMBean( new DefaultAttributeUpgraderMBean( this ), jmxName );
         }
         catch ( Exception e )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/attributes/upgrade/DefaultAttributeUpgrader.java
@@ -122,7 +122,11 @@ public class DefaultAttributeUpgrader
         {
             try
             {
-                ManagementFactory.getPlatformMBeanServer().unregisterMBean( jmxName );
+                final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+                if ( server.isRegistered( jmxName ) )
+                {
+                    server.unregisterMBean( jmxName );
+                }
             }
             catch ( final Exception e )
             {


### PR DESCRIPTION
In test env, this fails often in tests (with loud logs).

Simple change to unregister before registration if already exists.

Though opened pull here to see if anyone else has issues with the components in the test-env are only getting lifecycle operations (dispose in this case) once per-test-class... which is the root cause of this problem.

ie. this could be a symptom of a larger problem.
