### PR TITLE
NXCM-4947 - add support for JMXConfiguration to Nexus bundles

### DIFF
--- a/nexus-launcher/pom.xml
+++ b/nexus-launcher/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-bundle-launcher</artifactId>
-      <version>1.5</version>
+      <version>1.5.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
+++ b/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
@@ -26,9 +26,11 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 
 import org.apache.tools.ant.taskdefs.condition.Os;
 import org.sonatype.nexus.bundle.launcher.NexusBundleConfiguration;
+import org.sonatype.sisu.bl.jmx.JMXConfiguration;
 import org.sonatype.sisu.bl.support.DefaultWebBundleConfiguration;
 import org.sonatype.sisu.bl.support.resolver.BundleResolver;
 import org.sonatype.sisu.bl.support.resolver.TargetDirectoryResolver;
@@ -92,14 +94,11 @@ public class DefaultNexusBundleConfiguration
      */
     private String logPattern;
 
-    /**
-     * Constructor.
-     *
-     * @since 2.2
-     */
     @Inject
-    public DefaultNexusBundleConfiguration( final FileTaskBuilder fileTaskBuilder )
+    public DefaultNexusBundleConfiguration( final FileTaskBuilder fileTaskBuilder,
+        final Provider<JMXConfiguration> jmxConfigurationProvider )
     {
+        super( jmxConfigurationProvider );
         this.fileTaskBuilder = checkNotNull( fileTaskBuilder );
         this.plugins = Lists.newArrayList();
         this.logLevelsPerLoggerName = Maps.newHashMap();


### PR DESCRIPTION
if configured, set the appropriate system properties via JSWConfig to enable an RMI registry/JMX server agent to be launched at Nexus bundle start using standard JDK 6+ system properties.

This allows monitoring a Nexus bundle remotely via JMX using RMI during test execution.

Depends on sonatype/sisu-bundle-launcher/pull/6
