### PR TITLE
NEXUS-5488: Adding log4j-over-slf4j to core

### DIFF
--- a/nexus-webapp/pom.xml
+++ b/nexus-webapp/pom.xml
@@ -41,6 +41,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-slf4j-logging</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,11 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>


### PR DESCRIPTION
Also, made nexus-webapp explicitly reference
the three SLF4j libs (api, jcl-over and log4j-over)
to be clear they are being includded into resulting WAR
