### PR TITLE
Catch-All fix

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/NexusApplicationHandlePlexusResourceSecurityTest.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/NexusApplicationHandlePlexusResourceSecurityTest.java
@@ -1,0 +1,62 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.rest;
+
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+import org.sonatype.plexus.rest.resource.PlexusResource;
+import org.sonatype.security.web.ProtectedPathManager;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+public class NexusApplicationHandlePlexusResourceSecurityTest
+    extends TestSupport
+{
+    @Mock
+    private PlexusResource mockResource;
+
+    @Mock( name = "protectedPathManager" )
+    private ProtectedPathManager mockProtectedPathManager;
+
+    @InjectMocks
+    private NexusApplication nexusApplication = new NexusApplication();
+
+    @Test( expected = IllegalStateException.class )
+    public void handlePlexusResourceSecurityWithMismatch()
+    {
+        final PathProtectionDescriptor descriptor = new PathProtectionDescriptor( "/foo/bar/*", "" );
+        Mockito.when( mockResource.getResourceProtection() ).thenReturn( descriptor );
+        Mockito.when( mockResource.getResourceUri() ).thenReturn( "/foo/baz" );
+        nexusApplication.handlePlexusResourceSecurity( mockResource );
+    }
+
+    @Test
+    public void handlePlexusResourceSecurityWithoutMismatch()
+    {
+        final PathProtectionDescriptor descriptor = new PathProtectionDescriptor( "/foo/bar/*", "" );
+        Mockito.when( mockResource.getResourceProtection() ).thenReturn( descriptor );
+        Mockito.when( mockResource.getResourceUri() ).thenReturn( "/foo/bar/{pattern}" );
+        nexusApplication.handlePlexusResourceSecurity( mockResource );
+    }
+
+    @Test
+    public void handlePlexusResourceSecurityWithoutMismatchWithRestletPatterns()
+    {
+        final PathProtectionDescriptor descriptor = new PathProtectionDescriptor( "/repositories/*", "" );
+        Mockito.when( mockResource.getResourceProtection() ).thenReturn( descriptor );
+        Mockito.when( mockResource.getResourceUri() ).thenReturn( "/repositories/{repoId}" );
+        nexusApplication.handlePlexusResourceSecurity( mockResource );
+    }
+}


### PR DESCRIPTION
Removal of "special catch-all" permission, and doing checks instead of PlexusResources on the fly.
