### PR TITLE
Fix for NPE during version range resolution.

### DIFF
--- a/plugins/nexus-maven-bridge-plugin/src/main/java/org/sonatype/nexus/plugins/mavenbridge/workspace/NexusWorkspaceReader.java
+++ b/plugins/nexus-maven-bridge-plugin/src/main/java/org/sonatype/nexus/plugins/mavenbridge/workspace/NexusWorkspaceReader.java
@@ -122,7 +122,7 @@ public class NexusWorkspaceReader
             }
         }
 
-        return null;
+        return Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
The NexusWorkspaceReader returned null on findVersions() instead of
an empty collection. This is in violation with the javadoc and
resulted in NPE's during version range resolutions.
