### PR TITLE
Subordinate locking and improvement for NEXUS-5418

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/AbstractRepositoryItemUidFactory.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/AbstractRepositoryItemUidFactory.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.proxy.item;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
 
@@ -49,7 +51,7 @@ public abstract class AbstractRepositoryItemUidFactory
             path = RepositoryItemUid.PATH_ROOT;
         }
 
-        return new DefaultRepositoryItemUid( this, repository, path );
+        return new DefaultRepositoryItemUid( repository, path );
     }
 
     @Override
@@ -67,6 +69,7 @@ public abstract class AbstractRepositoryItemUidFactory
         new WeakHashMap<DefaultRepositoryItemUidLock, WeakReference<DefaultRepositoryItemUidLock>>();
 
     @Override
+    @Deprecated
     public DefaultRepositoryItemUidLock createUidLock( final RepositoryItemUid uid )
     {
         final String key = new String( uid.getKey() );
@@ -75,11 +78,24 @@ public abstract class AbstractRepositoryItemUidFactory
     }
 
     @Override
+    @Deprecated
     public DefaultRepositoryItemUidLock createUidAttributeLock( final RepositoryItemUid uid )
     {
         final String key = new String( "attribute:" + uid.getKey() );
 
         return doCreateUidLockForKey( key );
+    }
+
+    @Override
+    public DefaultRepositoryItemUidLock createUidLock( final String key )
+    {
+        return doCreateUidLockForKey( checkNotNull( key ) );
+    }
+
+    @Override
+    public DefaultRepositoryItemUidLock createUidAttributeLock( final String key )
+    {
+        return doCreateUidLockForKey( "attribute:" + checkNotNull( key ) );
     }
 
     // ==

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUid.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUid.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.proxy.item;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.sonatype.nexus.proxy.item.uid.Attribute;
 import org.sonatype.nexus.proxy.repository.Repository;
 
@@ -22,9 +24,6 @@ import org.sonatype.nexus.proxy.repository.Repository;
 public class DefaultRepositoryItemUid
     implements RepositoryItemUid
 {
-    /** The factory. */
-    private final RepositoryItemUidFactory factory;
-
     /** The repository. */
     private final Repository repository;
 
@@ -37,25 +36,12 @@ public class DefaultRepositoryItemUid
     /** Lazily created */
     private RepositoryItemUidLock lock;
 
-    protected DefaultRepositoryItemUid( final RepositoryItemUidFactory factory, final Repository repository,
-                                        final String path )
+    protected DefaultRepositoryItemUid( final Repository repository, final String path )
     {
-        super();
-
-        this.factory = factory;
-
-        this.repository = repository;
-
-        this.path = path;
-
+        this.repository = checkNotNull( repository );
+        this.path = checkNotNull( path );
         this.stringRepresentation = getRepository().getId() + ":" + getPath();
-
         this.lock = null;
-    }
-
-    public RepositoryItemUidFactory getRepositoryItemUidFactory()
-    {
-        return factory;
     }
 
     @Override
@@ -81,18 +67,18 @@ public class DefaultRepositoryItemUid
     {
         if ( lock == null )
         {
-            lock = factory.createUidLock( this );
+            lock = repository.createUidLock( this );
         }
 
         return lock;
     }
-    
+
     @Override
     public synchronized RepositoryItemUidLock getAttributeLock()
     {
         if ( lock == null )
         {
-            lock = factory.createUidAttributeLock( this );
+            lock = repository.createUidAttributeLock( this );
         }
 
         return lock;

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactory.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactory.java
@@ -43,6 +43,8 @@ public interface RepositoryItemUidFactory
      * 
      * @param uid
      * @return
+     * @deprecated In case of need use {@link Repository#createUidLock(String)} instead if needed, otherwise
+     *             {@link RepositoryItemUid#getLock()} is preferred to obtain the lock.
      */
     RepositoryItemUidLock createUidLock( RepositoryItemUid uid );
 
@@ -51,6 +53,26 @@ public interface RepositoryItemUidFactory
      * 
      * @param uid
      * @return
+     * @deprecated In case of need use {@link Repository#createUidAttributeLock(String)} instead if needed, otherwise
+     *             {@link RepositoryItemUid#getAttributeLock()} is preferred to obtain the lock.
      */
     RepositoryItemUidLock createUidAttributeLock( RepositoryItemUid uid );
+
+    /**
+     * Creates a shared UIDLock based on a key.
+     * 
+     * @param key
+     * @return lock instance, never {@code null}.
+     * @since 2.4
+     */
+    RepositoryItemUidLock createUidLock( String key );
+
+    /**
+     * Creates a shared attribute UIDLock based on a key.
+     * 
+     * @param key
+     * @return lock instance, never {@code null}.
+     * @since 2.4
+     */
+    RepositoryItemUidLock createUidAttributeLock( String key );
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -390,7 +390,7 @@ public abstract class AbstractMavenRepository
         {
             fixedPath = fixedPath.substring( 0, fixedPath.length() - 4 );
         }
-        return super.fixPathForLockKey( path );
+        return super.fixPathForLockKey( fixedPath );
     }
 
     @Override

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -377,6 +377,22 @@ public abstract class AbstractMavenRepository
 
     // =================================================================================
     // DefaultRepository customizations
+
+    @Override
+    protected String fixPathForLockKey( final String path )
+    {
+        String fixedPath = path;
+        if ( fixedPath.endsWith( ".sha1" ) )
+        {
+            fixedPath = fixedPath.substring( 0, fixedPath.length() - 5 );
+        }
+        else if ( fixedPath.endsWith( ".md5" ) )
+        {
+            fixedPath = fixedPath.substring( 0, fixedPath.length() - 4 );
+        }
+        return super.fixPathForLockKey( path );
+    }
+
     @Override
     protected StorageItem doRetrieveItem( ResourceStoreRequest request )
         throws IllegalOperationException, ItemNotFoundException, StorageException

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1198,6 +1198,15 @@ public abstract class AbstractRepository
      * override it here. Default is "same as input", meaning an UID presented as {@code repoId:/foo/bar} would use Lock
      * instance keyed with {@code repoId:/foo/bar}. But to override this, and for example have UID
      * {@code repoId:/foo/bar.ext} use lock keyed with {@code repoId:/foo/bar.baz} you can override this here.
+     * <p>
+     * Note: all the input paths are expected to be "normalized ones": being absolute, using generic "/" character as
+     * path separator (since these are NOT File paths, but just hierarchical paths of strings). For example:
+     * {@link RepositoryItemUid#getPath()} returns paths like these. Hence, you HAVE TO return paths conforming
+     * the requirements above too.
+     * <p>
+     * Note: an extreme example of override for this method would be an implementation that always returns same
+     * string! That would mean, that all READ operations would be concurrent (since they use shared locks), but
+     * any WRITE operation would make repository LOCKED.
      * 
      * @param path
      * @return

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/Repository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/Repository.java
@@ -29,6 +29,7 @@ import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.attributes.AttributesHandler;
 import org.sonatype.nexus.proxy.cache.PathCache;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.item.RepositoryItemUidLock;
 import org.sonatype.nexus.proxy.item.StorageCollectionItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.item.uid.RepositoryItemUidAttributeManager;
@@ -149,9 +150,34 @@ public interface Repository
     boolean hasAnyTargetsForRequest( ResourceStoreRequest request );
 
     /**
-     * Creates an UID within this Repository.
+     * Creates an UID within this Repository for given path.
+     * 
+     * @param path the path.
+     * @return the {@link RepositoryItemUid} instance, never {@code null}.
      */
     RepositoryItemUid createUid( String path );
+
+    /**
+     * Creates an UID lock within this Repository for given path.
+     * 
+     * @param uid the UID to create lock for, must not be {@code null}.
+     * @return the {@link RepositoryItemUidLock} instance, never {@code null}.
+     * @throws IllegalArgumentException if passed in UID does not belong to this repository.
+     * @since 2.4
+     */
+    RepositoryItemUidLock createUidLock( RepositoryItemUid uid )
+        throws IllegalArgumentException;
+
+    /**
+     * Creates an attribute UID lock within this Repository for given path.
+     * 
+     * @param uid the UID to create lock for, must not be {@code null}.
+     * @return the {@link RepositoryItemUidLock} instance, never {@code null}.
+     * @throws IllegalArgumentException if passed in UID does not belong to this repository.
+     * @since 2.4
+     */
+    RepositoryItemUidLock createUidAttributeLock( RepositoryItemUid uid )
+        throws IllegalArgumentException;
 
     /**
      * Returns the repository ItemUidAttributeManager.

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.java
@@ -82,6 +82,55 @@ public class RepositoryItemUidFactoryTest
     }
 
     @Test
+    public void testPathPeculiaritesInM2Repo()
+        throws Exception
+    {
+        // In Mave repositories, the artifact and their sha1/md5 counterpart locks are
+        // "squashed" all onto the artifact keyed lock (subordinate locking)
+        // see org.sonatype.nexus.proxy.maven.AbstractMavenRepository.fixPathForLockKey(String)
+        final RepositoryItemUid uid1 = repository.createUid( "/some/blammo/poth.jar" );
+        final RepositoryItemUid uid2 = repository.createUid( "/some/blammo/poth.jar.sha1" );
+        final RepositoryItemUid uid3 = repository.createUid( "/some/blammo/poth.jar.md5" );
+        final RepositoryItemUid uid4 = repository.createUid( "/some/blammo/poth.pom" );
+        final RepositoryItemUid uid5 = repository.createUid( "/some/blammo/poth.pom.sha1" );
+        final RepositoryItemUid uid6 = repository.createUid( "/some/blammo/poth.pom.md5" );
+
+        final DefaultRepositoryItemUidLock uidLock1 = (DefaultRepositoryItemUidLock) uid1.getLock();
+        final DefaultRepositoryItemUidLock uidLock2 = (DefaultRepositoryItemUidLock) uid2.getLock();
+        final DefaultRepositoryItemUidLock uidLock3 = (DefaultRepositoryItemUidLock) uid3.getLock();
+        final DefaultRepositoryItemUidLock uidLock4 = (DefaultRepositoryItemUidLock) uid4.getLock();
+        final DefaultRepositoryItemUidLock uidLock5 = (DefaultRepositoryItemUidLock) uid5.getLock();
+        final DefaultRepositoryItemUidLock uidLock6 = (DefaultRepositoryItemUidLock) uid6.getLock();
+
+        // They share SAME lock, but wrapping instances of DefaultRepositoryItemUidLock are not same!
+        Assert.assertNotSame( "UIDLock instances should be same", uidLock1.hashCode(), uidLock2.hashCode() );
+        Assert.assertTrue( "UIDLock instances should be same", uidLock1.equals( uidLock2 ) );
+        Assert.assertSame( "UIDLock lock instances should be same", uidLock1.getContentLock(),
+            uidLock2.getContentLock() );
+        // They share SAME lock, but wrapping instances of DefaultRepositoryItemUidLock are not same!
+        Assert.assertNotSame( "UIDLock instances should be same", uidLock1.hashCode(), uidLock3.hashCode() );
+        Assert.assertTrue( "UIDLock instances should be same", uidLock1.equals( uidLock3 ) );
+        Assert.assertSame( "UIDLock lock instances should be same", uidLock1.getContentLock(),
+            uidLock3.getContentLock() );
+        // They share SAME lock, but wrapping instances of DefaultRepositoryItemUidLock are not same!
+        Assert.assertNotSame( "UIDLock instances should be same", uidLock4.hashCode(), uidLock5.hashCode() );
+        Assert.assertTrue( "UIDLock instances should be same", uidLock4.equals( uidLock5 ) );
+        Assert.assertSame( "UIDLock lock instances should be same", uidLock4.getContentLock(),
+            uidLock5.getContentLock() );
+        // They share SAME lock, but wrapping instances of DefaultRepositoryItemUidLock are not same!
+        Assert.assertNotSame( "UIDLock instances should be same", uidLock4.hashCode(), uidLock6.hashCode() );
+        Assert.assertTrue( "UIDLock instances should be same", uidLock4.equals( uidLock6 ) );
+        Assert.assertSame( "UIDLock lock instances should be same", uidLock4.getContentLock(),
+            uidLock6.getContentLock() );
+
+        // but, uid1 (artifact) and uid4 (pom) are DIFFERENT
+        Assert.assertNotSame( "UIDLock instances should be different", uidLock1.hashCode(), uidLock4.hashCode() );
+        Assert.assertTrue( "UIDLock instances should be different", !uidLock1.equals( uidLock4 ) );
+        Assert.assertNotSame( "UIDLock lock instances should be different", uidLock1.getContentLock(),
+            uidLock4.getContentLock() );
+    }
+
+    @Test
     public void testRelease()
         throws Exception
     {

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/item/RepositoryItemUidFactoryTest.java
@@ -12,32 +12,30 @@
  */
 package org.sonatype.nexus.proxy.item;
 
-import static org.mockito.Mockito.doReturn;
-
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
 import org.sonatype.nexus.proxy.AbstractNexusTestEnvironment;
 import org.sonatype.nexus.proxy.access.Action;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
 import org.sonatype.nexus.proxy.repository.Repository;
+
 public class RepositoryItemUidFactoryTest
     extends AbstractNexusTestEnvironment
 {
-    @Mock
     protected RepositoryItemUidFactory factory;
 
-    @Mock
     protected Repository repository;
 
     public void setUp()
         throws Exception
     {
         super.setUp();
-
-        MockitoAnnotations.initMocks( this );
-        doReturn("repo1").when( repository ).getId();
-
+        repository = lookup( Repository.class, M2Repository.ID );
+        final CRepository config = new DefaultCRepository();
+        config.setId( "repo1" );
+        repository.configure( config );
         factory = lookup( RepositoryItemUidFactory.class );
     }
 


### PR DESCRIPTION
This change introduces a possibility left to Repository implementors to interfere (and probably modify) the UID key to UIDLock key mapping. Before this change, UID Key was used for UIDLock key as is, meaning, no different UID was using same UIDLock instance.

In this change, Maven repositories would lock artefacts and their checksums "as one", irrespective do you operate with artefact or checksum UID's (or requests or items). Simply put, this change makes Maven repositories always use the artefact lock for both, for artefacts and for their checksums.

Since this change reduces the involved locks (in case of Maven repositories) from 2 to 1, this also avoids possible deadlocks for concurrent requests tampering with same artefact and it's checksum.

Note: sorry for reformat in AbstractRepository.
