### PR TITLE
Add support for defining an icon with a number of variants

### DIFF
--- a/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
+++ b/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
@@ -17,7 +17,7 @@
  *
  * The container automatically creates CSS styles for icons and installs them into the browser when loading.
  *
- * A simple example of an icon container with a since icon, and how to reference the icon.
+ * A simple example of an icon container with a single icon, and how to reference the icon.
  *
  *      @example
  *      var myIcons = NX.create('Nexus.util.IconContainer', {

--- a/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
+++ b/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
@@ -216,7 +216,7 @@ NX.define('Nexus.util.IconContainer', {
             }
             else {
                 // if no default configuration, then the default icon an alias to the last variant defined
-                self.defineIcon(name, '@' + lastIconName);
+                self.defineIcon(name, '@' + lastIcon.name);
             }
         }
     },

--- a/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
+++ b/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
@@ -164,6 +164,18 @@ NX.define('Nexus.util.IconContainer', {
     },
 
     /**
+     * Returns the icon name of a variant.
+     *
+     * @private
+     *
+     * @return {String}
+     */
+    variantName: function(name, variant) {
+        // TODO: Do we want this or maybe name + '_' + variant ?
+        return name + variant;
+    },
+
+    /**
      * Load icons from configuration.
      *
      * @private
@@ -187,7 +199,7 @@ NX.define('Nexus.util.IconContainer', {
             // define icons for each variant, remember last icon name we created for default
             var lastIcon;
             Ext.iterate(config, function(key, value) {
-                lastIcon = self.defineIcon(name + key, value, name);
+                lastIcon = self.defineIcon(self.variantName(name, key), value, name);
             });
 
             // complain if there were no variants configured
@@ -195,14 +207,15 @@ NX.define('Nexus.util.IconContainer', {
 
             // handle default icon
             if (defaultIconFileName !== undefined) {
-                // if the fileName starts with '^' then its a back reference to a variant
+                // if the fileName starts with '^' then its an alias back reference to a variant
                 if (defaultIconFileName.startsWith('^')) {
-                    defaultIconFileName = '@' + name + defaultIconFileName.substring(1);
+                    defaultIconFileName = '@' + self.variantName(name, defaultIconFileName.substring(1));
                 }
+                // otherwise could be a filePath or alias too
                 self.defineIcon(name, defaultIconFileName);
             }
             else {
-                // if no default configuration, then the default icon is the last icon defined
+                // if no default configuration, then the default icon an alias to the last variant defined
                 self.defineIcon(name, '@' + lastIconName);
             }
         }

--- a/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
+++ b/nexus-webapp/src/main/webapp/js/Nexus/util/IconContainer.js
@@ -13,7 +13,73 @@
 /*global NX, Ext, Nexus*/
 
 /**
- * Support for icon containers.
+ * Support for icon containers.  An icon container is a helper to manage image/icon resources used by an application.
+ *
+ * The container automatically creates CSS styles for icons and installs them into the browser when loading.
+ *
+ * A simple example of an icon container with a since icon, and how to reference the icon.
+ *
+ *      @example
+ *      var myIcons = NX.create('Nexus.util.IconContainer', {
+ *          icons: {
+ *              hello:  'hello.png'
+ *          }
+ *      });
+ *
+ *      // returns an icon object
+ *      var icon = myIcons.get('hello);
+ *
+ *      // the name of the CSS class of the icon
+ *      var cssClass = icon.cls;
+ *
+ *      // renders a <img> html snippet for the icon
+ *      var imgHtml = icon.img;
+ *
+ * Icons can reference other icons, this helps avoid loading duplicate assents into the browser, and still allows
+ * for flexible icon naming.  This allows applications to define meaningful names, and then manage which asset
+ * belongs to that name inside of the icon container:
+ *
+ *      @example
+ *      var myIcons = NX.create('Nexus.util.IconContainer', {
+ *          icons: {
+ *              rulePassed:         'tick.png',
+ *              event_rulesPassed:  '@rulePassed',
+ *              event_rulePassed:   '@rulePassed'
+ *             }
+ *      });
+ *
+ * Here 'event_rulesPassed' and 'event_rulePassed' are aliases to the 'rulePassed' icon.  Only 1 img/css asset for 'rulePassed'
+ * is installed into the browser.
+ *
+ * For icons which might have many different sizes, and icon definition can be configured to know about different variants:
+ *
+ *      @example
+ *      var myIcons = NX.create('Nexus.util.IconContainer', {
+ *          icons: {
+ *              rulePassed: {
+ *                  x16:    'tick.png',
+ *                  x32:    'tick-32x32.png',
+ *                  _:      '^x16'
+ *              },
+ *              event_rulesPassed:   '@rulePassed',
+ *              event_rulePassed:    '@rulePassed'
+ *             }
+ *      });
+ *
+ * This defines 5 icons, and 2 img+css (the assets loaded into the browser).
+ *
+ * The first bits for rulePassed define 2 icons 'rulePassedx16' and 'rulePassedx32' pointing at tick.png and tick-32x32.png respectively.
+ * The special _ key is the default which will be used to set the 'rulePassed' icon.
+ * The special syntax here with '^x16' means that he default icon is really the 'x16' variant and
+ * ATM this only works for the default '_' variant.
+ *
+ * Icon objects have a variant() method which can be used to access a variant:
+ *
+ *      @example
+ *      var icon = MyIcons.get('rulePassed');
+ *      var bigger = icon.variant('x32');
+ *
+ * If the variant does not exist then it returns the same icon.
  *
  * @since 2.4
  */
@@ -36,8 +102,11 @@ NX.define('Nexus.util.IconContainer', {
     /**
      * Base-path for images.
      *
+     * This defaults to the base resource path of Nexus + '/static/icons'.
+     *
      * @public
      * @property
+     * @type {String}
      */
     basePath: undefined,
 


### PR DESCRIPTION
This allows you to define something like this:

```
icons: {
    rulePassed: {
        x16:    'tick.png',
        x32:    'tick-32x32.png',
        _:      '^x16'
    },
    event_rulesPassed:   '@rulePassed',
    event_rulePassed:    '@rulePassed'
}
```

This defines 5 icons, and 2 img+css (the assets loaded into the browser).

The first bits for rulePassed define 2 icons 'rulePassedx16' and 'rulePassedx32' pointing at tick.png and tick-32x32.png respectively.  The special _ key is the default which will be used to set the 'rulePassed' icon.  The special syntax here with '^x16' means that he default icon is really the 'x16' variant & ATM this only works for the default '_' variant.

Icon objects also now have a variant() method on them, so you can:

```
var icon = MyIcons.get('rulePassed');
```

Which gets you the icon object, and then you can get a variant by:

```
var bigger = icon.variant('x32');
```

If the variant does not exist then it returns the same icon.

Oh and those other icons which are using '@' syntax are simply aliases to other defined icons, '^' is only for back referencing into an icons variants.  I suppose I could have just used this too:

```
_: '@rulePassedx16'
```

But I'm hiding the details of how the variant is used to construct the target icon name, so that should be avoided I think.

---

This was the best I could come up with for a simple way to define icons of various sizes and expose them to the UI in a simple/sane way.
