### PR TITLE
[NXCM-4999] Use in-repo path for matching repo targets

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/router/DefaultRepositoryRouter.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/router/DefaultRepositoryRouter.java
@@ -729,7 +729,7 @@ public class DefaultRepositoryRouter
                 // if this repository is contained in any group, we need to get those targets, and tweak the TargetMatch
                 try
                 {
-                    request.pushRequestPath( route.getOriginalRequestPath() );
+                    request.pushRequestPath( route.getRepositoryPath() );
 
                     matched.addTargetSet( this.itemAuthorizer.getGroupsTargetSet( route.getTargetedRepository(),
                         request ) );

--- a/nexus-core/src/test/resources/org/sonatype/nexus/proxy/router/DefaultRepositoryRouterTest.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/proxy/router/DefaultRepositoryRouterTest.xml
@@ -9,6 +9,10 @@
             <repo1user>nexus:target:*:repo1:*,nexus:view:repository:repo1</repo1user>
             <repo1userNoView>nexus:target:*:repo1:*</repo1userNoView>
             <admin>nexus:target:*:*:*,nexus:view:repository:*</admin>
+            <!-- Have "maven2-all" perm, and that targets all ALL in maven2 reposes -->
+            <nxcm4999user>nexus:view:repository:group1,nexus:target:maven2-all:group1:*</nxcm4999user>
+            <!-- Have "nxcm4999" perm, that targets allow ALL except sources in maven2 reposes -->
+            <nxcm4999userNoSources>nexus:view:repository:group1,nexus:target:nxcm4999:group1:*</nxcm4999userNoSources>
           </userPrivilageMap>
         </configuration>
     </component>


### PR DESCRIPTION
This code path was still using "/repositories/$name/$path" to match
repository target patterns. Repository Browsing worked fine, but archive browser triggered this
bug and lead to not using repo targets the same way:

`(?!/com/.*-sources.jar).*` would deny access to the source jar itself but
would allow access to its contents, while `(?!.*/com/.*-sources.jar).*`
would also deny content access.
