### PR TITLE
NEXUS-5472: Cumulative WL fixes

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/WLDiscoveryStatus.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/WLDiscoveryStatus.java
@@ -41,7 +41,12 @@ public class WLDiscoveryStatus
         /**
          * Remote discovery enabled without results yet (is still working).
          */
-        ENABLED,
+        ENABLED_IN_PROGRESS,
+
+        /**
+         * Remote discovery enabled but not possible to perform it (like proxy being blocked).
+         */
+        ENABLED_NOT_POSSIBLE,
 
         /**
          * Remote discovery enabled and was successful.
@@ -66,7 +71,7 @@ public class WLDiscoveryStatus
          */
         public boolean isEnabled()
         {
-            return this.ordinal() >= ENABLED.ordinal();
+            return this.ordinal() >= ENABLED_IN_PROGRESS.ordinal();
         }
     }
 
@@ -85,7 +90,7 @@ public class WLDiscoveryStatus
      */
     public WLDiscoveryStatus( final DStatus status )
     {
-        checkArgument( status.ordinal() < DStatus.SUCCESSFUL.ordinal() );
+        checkArgument( status.ordinal() < DStatus.ENABLED_NOT_POSSIBLE.ordinal() );
         this.status = checkNotNull( status );
         this.lastDiscoveryStrategy = null;
         this.lastDiscoveryMessage = null;
@@ -103,7 +108,7 @@ public class WLDiscoveryStatus
     public WLDiscoveryStatus( final DStatus status, final String lastDiscoveryStrategy,
                               final String lastDiscoveryMessage, final long lastDiscoveryTimestamp )
     {
-        checkArgument( status.ordinal() >= DStatus.SUCCESSFUL.ordinal() );
+        checkArgument( status.ordinal() >= DStatus.ENABLED_NOT_POSSIBLE.ordinal() );
         checkArgument( lastDiscoveryTimestamp > 0 );
         this.status = checkNotNull( status );
         this.lastDiscoveryStrategy = checkNotNull( lastDiscoveryStrategy );

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/WLManager.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/WLManager.java
@@ -67,12 +67,8 @@ public interface WLManager
      * repository during boot up).
      * 
      * @param mavenRepository
-     * @throws IOException
-     * @throws IllegalStateException when the passed in repository is unsupported, or for some reason not in state to be
-     *             updated (out of service, or in case of proxy, it's proxyMode does not allow remote access and such).
      */
-    void initializeWhitelist( MavenRepository mavenRepository )
-        throws IOException, IllegalStateException;
+    void initializeWhitelist( MavenRepository mavenRepository );
 
     /**
      * Executes an update of WL for given repository. In case of {@link MavenProxyRepository} instance, it might not do

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/discovery/DiscoveryResult.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/discovery/DiscoveryResult.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.proxy.maven.wl.discovery;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.sonatype.nexus.proxy.maven.MavenRepository;
@@ -122,6 +123,12 @@ public class DiscoveryResult<R extends MavenRepository>
         {
             return throwable;
         }
+
+        @Override
+        public String toString()
+        {
+            return "Outcome[strategyId=" + strategyId + ", successful=" + successful + ", message=" + message + "]";
+        }
     }
 
     private final R mavenRepository;
@@ -163,13 +170,23 @@ public class DiscoveryResult<R extends MavenRepository>
     }
 
     /**
-     * Returns the succeeded strategy instance.F
+     * Returns the succeeded strategy instance.
      * 
      * @return strategy that succeeded.
      */
     public Outcome getLastResult()
     {
         return getLastOutcome();
+    }
+
+    /**
+     * Returns all the outcomes.
+     * 
+     * @return strategy that succeeded.
+     */
+    public List<Outcome> getAllResults()
+    {
+        return Collections.unmodifiableList( outcomes );
     }
 
     /**

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
@@ -102,7 +102,14 @@ public class EventDispatcher
 
     protected void handleRepositoryModified( final MavenRepository mavenRepository )
     {
-        wlManager.forceUpdateWhitelist( mavenRepository );
+        try
+        {
+            wlManager.forceUpdateWhitelist( mavenRepository );
+        }
+        catch ( IllegalStateException e )
+        {
+            getLogger().info( e.getMessage() );
+        }
     }
 
     protected void handlePrefixFileUpdate( final RepositoryItemEvent evt )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
@@ -22,6 +22,7 @@ import org.sonatype.nexus.configuration.Configurable;
 import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.proxy.RequestContext;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
+import org.sonatype.nexus.proxy.events.RepositoryEventProxyModeChanged;
 import org.sonatype.nexus.proxy.events.RepositoryGroupMembersChangedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCache;
@@ -37,6 +38,7 @@ import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
 import org.sonatype.nexus.proxy.maven.wl.PrefixSource;
 import org.sonatype.nexus.proxy.maven.wl.WLManager;
+import org.sonatype.nexus.proxy.repository.ProxyMode;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.repository.ShadowRepository;
 import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
@@ -180,7 +182,7 @@ public class EventDispatcher
     {
         // we handle repository events after this isActive, is not out of service, and only for non-shadow repository
         // that are Maven2 reposes
-        return isActive() && repository != null && repository.getLocalStatus().shouldServiceRequest()
+        return isActive() && repository != null
             && repository.getRepositoryKind().isFacetAvailable( MavenRepository.class )
             && !repository.getRepositoryKind().isFacetAvailable( ShadowRepository.class )
             && Maven2ContentClass.ID.equals( repository.getRepositoryContentClass().getId() );
@@ -310,9 +312,9 @@ public class EventDispatcher
      */
     @Subscribe
     @AllowConcurrentEvents
-    public void on( final RepositoryConfigurationUpdatedEvent evt )
+    public void onRepositoryConfigurationUpdatedEvent( final RepositoryConfigurationUpdatedEvent evt )
     {
-        if ( isRepositoryHandled( evt.getRepository() ) && evt.isRemoteUrlChanged() )
+        if ( isRepositoryHandled( evt.getRepository() ) )
         {
             final MavenRepository mavenRepository = evt.getRepository().adaptToFacet( MavenRepository.class );
             handleRepositoryModified( mavenRepository );

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteContentDiscovererImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteContentDiscovererImpl.java
@@ -83,8 +83,6 @@ public class RemoteContentDiscovererImpl
             }
             catch ( StrategyFailedException e )
             {
-                getLogger().debug( "Discovery of {} with strategy failed.",
-                    RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), strategy.getId() );
                 discoveryResult.recordFailure( strategy.getId(), e.getMessage() );
             }
             catch ( InvalidInputException e )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -80,6 +80,7 @@ import org.sonatype.nexus.util.task.executor.ConstrainedExecutorImpl;
 import org.sonatype.nexus.util.task.executor.Statistics;
 import org.sonatype.sisu.goodies.eventbus.EventBus;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.eventbus.Subscribe;
@@ -496,7 +497,14 @@ public class WLManagerImpl
         }
     }
 
-    protected boolean isUpdateWhitelistJobRunning()
+    /**
+     * Is visible to expose over the nexus-it-helper-plugin only, and UTs are using this. Should not be used for other
+     * means.
+     * 
+     * @return {@code true} if there are white-list jobs running.
+     */
+    @VisibleForTesting
+    public boolean isUpdateWhitelistJobRunning()
     {
         final Statistics statistics = constrainedExecutor.getStatistics();
         getLogger().debug( "Running update jobs for {}", statistics.getCurrentlyRunningJobKeys() );

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -210,7 +210,10 @@ public class WLManagerImpl
         constrainedExecutor.cancelAllJobs();
         try
         {
-            executor.awaitTermination( 60L, TimeUnit.SECONDS );
+            if ( !executor.awaitTermination( 15L, TimeUnit.SECONDS ) )
+            {
+                executor.shutdownNow();
+            }
         }
         catch ( InterruptedException e )
         {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -467,7 +467,6 @@ public class WLManagerImpl
     protected boolean doUpdateWhitelist( final boolean forced, final MavenRepository mavenRepository )
         throws IllegalStateException
     {
-        checkUpdateConditions( mavenRepository );
         final WLUpdateRepositoryRunnable updateRepositoryJob =
             new WLUpdateRepositoryRunnable( new LoggingProgressListener( getLogger() ), applicationStatusSource, this,
                 mavenRepository );
@@ -508,7 +507,15 @@ public class WLManagerImpl
         }
         else if ( mavenRepository.getRepositoryKind().isFacetAvailable( MavenProxyRepository.class ) )
         {
-            prefixSource = updateProxyWhitelist( mavenRepository.adaptToFacet( MavenProxyRepository.class ), null );
+            final MavenProxyRepository mavenProxyRepository = mavenRepository.adaptToFacet( MavenProxyRepository.class );
+            final ProxyMode proxyMode = mavenProxyRepository.getProxyMode();
+            if ( ProxyMode.ALLOW != proxyMode )
+            {
+                getLogger().info( "Proxy repository {} is in proxyMode={}, not updating it.",
+                    RepositoryStringUtils.getFullHumanizedNameString( mavenRepository ), proxyMode );
+                return;
+            }
+            prefixSource = updateProxyWhitelist( mavenProxyRepository, null );
         }
         else if ( mavenRepository.getRepositoryKind().isFacetAvailable( MavenHostedRepository.class ) )
         {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/scrape/AmazonS3IndexScraper.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/scrape/AmazonS3IndexScraper.java
@@ -147,6 +147,10 @@ public class AmazonS3IndexScraper
                 continue; // skip it
             }
             final String key = keyElements.get( 0 ).text();
+            if ( key.startsWith( "." ) || key.contains( "/." ) )
+            {
+                continue; // skip it, it's a ".dot" file
+            }
             final long size = Long.parseLong( sizeElements.get( 0 ).text() );
             if ( size > 0 )
             {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
@@ -171,9 +171,9 @@ public class DefaultFSLocalRepositoryStorage
             result = new File( repoBase, request.getRequestPath() );
         }
 
-        if ( getLogger().isDebugEnabled() )
+        if ( getLogger().isTraceEnabled() )
         {
-            getLogger().debug( request.getRequestPath() + " --> " + result.getAbsoluteFile() );
+            getLogger().trace( "{} --> {}", request.getRequestPath(), result.getAbsoluteFile() );
         }
 
         // to be foolproof, chrooting it
@@ -258,7 +258,7 @@ public class DefaultFSLocalRepositoryStorage
                     }
                     catch ( NoSuchRepositoryException e )
                     {
-                        getLogger().warn( "Stale link object found on UID: " + uid.toString() + ", deleting it." );
+                        getLogger().warn( "Stale link object found on UID: {}, deleting it.", uid );
 
                         target.delete();
 

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndLocalStatusTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndLocalStatusTest.java
@@ -13,10 +13,8 @@
 package org.sonatype.nexus.proxy.maven.wl.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -239,6 +237,7 @@ public class WLAndLocalStatusTest
             getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
 
         assertThat( proxy1.getLocalStatus(), equalTo( LocalStatus.OUT_OF_SERVICE ) );
+        waitForWLBackgroundUpdates();
 
         // let's check states
 
@@ -247,8 +246,8 @@ public class WLAndLocalStatusTest
             final WLStatus proxy1status = wm.getStatusFor( proxy1 );
             // this repo is Out of Service
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
             // Remark: the combination of those three above simply means "discovery never tried against it"
             // yet.
         }
@@ -279,9 +278,7 @@ public class WLAndLocalStatusTest
                 wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
                     MavenGroupRepository.class ) );
             // not all members have WL, unpublished
-            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            // message should refer to proxy1 as reason of not publishing group WL
-            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
             assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
         }
     }
@@ -296,6 +293,7 @@ public class WLAndLocalStatusTest
             getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
 
         assertThat( proxy1.getLocalStatus(), equalTo( LocalStatus.OUT_OF_SERVICE ) );
+        waitForWLBackgroundUpdates();
 
         // let's check states
         {
@@ -303,8 +301,8 @@ public class WLAndLocalStatusTest
             final WLStatus proxy1status = wm.getStatusFor( proxy1 );
             // this repo is Out of Service
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
             // Remark: the combination of those three above simply means "discovery never tried against it"
             // yet.
         }
@@ -314,9 +312,7 @@ public class WLAndLocalStatusTest
                 wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
                     MavenGroupRepository.class ) );
             // not all members have WL, unpublished
-            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            // message should refer to proxy1 as reason of not publishing group WL
-            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
             assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
         }
 
@@ -367,8 +363,8 @@ public class WLAndLocalStatusTest
                     MavenProxyRepository.class ) );
             // this repo is Out of Service
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
         }
         {
             // group
@@ -376,9 +372,7 @@ public class WLAndLocalStatusTest
                 wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
                     MavenGroupRepository.class ) );
             // not all members have WL, unpublished
-            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            // message should refer to proxy1 as reason of not publishing group WL
-            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
             assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
         }
     }

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndLocalStatusTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndLocalStatusTest.java
@@ -1,0 +1,385 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.wl.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.configuration.model.CLocalStorage;
+import org.sonatype.nexus.configuration.model.CRemoteStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
+import org.sonatype.nexus.proxy.AbstractProxyTestEnvironment;
+import org.sonatype.nexus.proxy.EnvironmentBuilder;
+import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
+import org.sonatype.nexus.proxy.maven.MavenGroupRepository;
+import org.sonatype.nexus.proxy.maven.MavenHostedRepository;
+import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
+import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepository;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.wl.WLDiscoveryStatus.DStatus;
+import org.sonatype.nexus.proxy.maven.wl.WLManager;
+import org.sonatype.nexus.proxy.maven.wl.WLPublishingStatus.PStatus;
+import org.sonatype.nexus.proxy.maven.wl.WLStatus;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.LocalStatus;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.tests.http.server.fluent.Behaviours;
+import org.sonatype.tests.http.server.fluent.Server;
+
+/**
+ * Testing interaction of {@link Repository#getLocalStatus()} and WL.
+ * 
+ * @author cstamas
+ */
+public class WLAndLocalStatusTest
+    extends AbstractWLProxyTest
+{
+    private static final String HOSTED_REPO_ID = "hosted";
+
+    private static final String PROXY1_REPO_ID = "proxy1";
+
+    private static final String PROXY2_REPO_ID = "proxy2";
+
+    private static final String GROUP_REPO_ID = "group";
+
+    private Server server;
+
+    public WLAndLocalStatusTest()
+        throws Exception
+    {
+        // one server serving up stuff for both proxies, it does have prefix file published but nothing else
+        // this only serves the purpose to not have repo autoblock
+        this.server =
+            Server.withPort( 0 ).serve( "/" ).withBehaviours( Behaviours.error( 404, "don't bother yourself" ) ).serve(
+                "/.meta/prefixes.txt" ).withBehaviours( Behaviours.content( prefixFile() ) );
+        server.start();
+    }
+
+    protected String prefixFile()
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter( sw );
+        pw.println( "# This is mighty prefix file!" );
+        pw.println( "/org/apache/maven" );
+        pw.println( "/org/sonatype" );
+        pw.println( " # Added later" );
+        pw.println( "/eu/flatwhite" );
+        return sw.toString();
+    }
+
+    @Override
+    protected EnvironmentBuilder createEnvironmentBuilder()
+        throws Exception
+    {
+        // we need one hosted repo only, so build it
+        return new EnvironmentBuilder()
+        {
+            @Override
+            public void startService()
+            {
+            }
+
+            @Override
+            public void stopService()
+            {
+            }
+
+            @Override
+            public void buildEnvironment( AbstractProxyTestEnvironment env )
+                throws ConfigurationException, IOException, ComponentLookupException
+            {
+                final PlexusContainer container = env.getPlexusContainer();
+                final List<String> reposes = new ArrayList<String>();
+                {
+                    // adding 1st proxy, that is out of service
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY1_REPO_ID );
+                    repoConf.setName( PROXY1_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStatus( LocalStatus.OUT_OF_SERVICE.name() ); // THIS REPO IS OUT OF SERVICE
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY1_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding 2nd proxy
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY2_REPO_ID );
+                    repoConf.setName( PROXY2_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY2_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding one hosted
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( HOSTED_REPO_ID );
+                    repoConf.setName( HOSTED_REPO_ID );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + HOSTED_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom exRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( exRepo );
+                    M2RepositoryConfiguration exRepoConf = new M2RepositoryConfiguration( exRepo );
+                    exRepoConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exRepoConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repo.configure( repoConf );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // add a group
+                    final M2GroupRepository group =
+                        (M2GroupRepository) container.lookup( GroupRepository.class, "maven2" );
+                    CRepository repoGroupConf = new DefaultCRepository();
+                    repoGroupConf.setProviderRole( GroupRepository.class.getName() );
+                    repoGroupConf.setProviderHint( "maven2" );
+                    repoGroupConf.setId( GROUP_REPO_ID );
+                    repoGroupConf.setName( GROUP_REPO_ID );
+                    repoGroupConf.setLocalStorage( new CLocalStorage() );
+                    repoGroupConf.getLocalStorage().setProvider( "file" );
+                    repoGroupConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/test" ).toURI().toURL().toString() );
+                    Xpp3Dom exGroupRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoGroupConf.setExternalConfiguration( exGroupRepo );
+                    M2GroupRepositoryConfiguration exGroupRepoConf = new M2GroupRepositoryConfiguration( exGroupRepo );
+                    exGroupRepoConf.setMemberRepositoryIds( reposes );
+                    exGroupRepoConf.setMergeMetadata( true );
+                    group.configure( repoGroupConf );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoGroupConf );
+                    env.getRepositoryRegistry().addRepository( group );
+                }
+            }
+        };
+    }
+
+    @Override
+    protected boolean enableWLFeature()
+    {
+        return true;
+    }
+
+    @Test
+    public void outOfServiceRepositoryDoesNotAffectWLInitialization()
+        throws Exception
+    {
+        // at this point, NexusStartedEvent was fired, and hence, WL's should be inited
+        final WLManager wm = lookup( WLManager.class );
+        final MavenProxyRepository proxy1 =
+            getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
+
+        assertThat( proxy1.getLocalStatus(), equalTo( LocalStatus.OUT_OF_SERVICE ) );
+
+        // let's check states
+
+        {
+            // proxy1
+            final WLStatus proxy1status = wm.getStatusFor( proxy1 );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            // Remark: the combination of those three above simply means "discovery never tried against it"
+            // yet.
+        }
+
+        {
+            // proxy2
+            final WLStatus proxy2status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY2_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo should be good
+            assertThat( proxy2status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( proxy2status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
+        }
+
+        {
+            // hosted
+            final WLStatus hostedStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( HOSTED_REPO_ID,
+                    MavenHostedRepository.class ) );
+            // this repo should be good
+            assertThat( hostedStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( hostedStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublished
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            // message should refer to proxy1 as reason of not publishing group WL
+            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+    }
+
+    @Test
+    public void flippingLocalStatusUpdatesWL()
+        throws Exception
+    {
+        // at this point, NexusStartedEvent was fired, and hence, WL's should be inited
+        final WLManager wm = lookup( WLManager.class );
+        final MavenProxyRepository proxy1 =
+            getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
+
+        assertThat( proxy1.getLocalStatus(), equalTo( LocalStatus.OUT_OF_SERVICE ) );
+
+        // let's check states
+        {
+            // proxy1
+            final WLStatus proxy1status = wm.getStatusFor( proxy1 );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            // Remark: the combination of those three above simply means "discovery never tried against it"
+            // yet.
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublished
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            // message should refer to proxy1 as reason of not publishing group WL
+            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // let's flip proxy1 now
+            proxy1.setLocalStatus( LocalStatus.IN_SERVICE );
+            getApplicationConfiguration().saveConfiguration();
+            wairForAsyncEventsToCalmDown();
+            waitForWLBackgroundUpdates();
+        }
+
+        // let's check states again, now with enabled proxy1
+
+        {
+            // proxy1
+            final WLStatus proxy1status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( RemotePrefixFileStrategy.ID ) );
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublisged
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // let's flip proxy1 now back
+            proxy1.setLocalStatus( LocalStatus.OUT_OF_SERVICE );
+            getApplicationConfiguration().saveConfiguration();
+            wairForAsyncEventsToCalmDown();
+            waitForWLBackgroundUpdates();
+        }
+
+        // let's check states again, now with enabled proxy1
+
+        {
+            // proxy1
+            final WLStatus proxy1status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublished
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            // message should refer to proxy1 as reason of not publishing group WL
+            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+    }
+}

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndProxyModeTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndProxyModeTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -49,7 +48,6 @@ import org.sonatype.nexus.proxy.maven.wl.WLManager;
 import org.sonatype.nexus.proxy.maven.wl.WLPublishingStatus.PStatus;
 import org.sonatype.nexus.proxy.maven.wl.WLStatus;
 import org.sonatype.nexus.proxy.repository.GroupRepository;
-import org.sonatype.nexus.proxy.repository.LocalStatus;
 import org.sonatype.nexus.proxy.repository.ProxyMode;
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.tests.http.server.fluent.Behaviours;
@@ -240,6 +238,7 @@ public class WLAndProxyModeTest
             getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
 
         assertThat( proxy1.getProxyMode(), equalTo( ProxyMode.BLOCKED_MANUAL ) );
+        waitForWLBackgroundUpdates();
 
         // let's check states
 
@@ -248,8 +247,8 @@ public class WLAndProxyModeTest
             final WLStatus proxy1status = wm.getStatusFor( proxy1 );
             // this repo is Out of Service
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
             // Remark: the combination of those three above simply means "discovery never tried against it"
             // yet.
         }
@@ -297,6 +296,7 @@ public class WLAndProxyModeTest
             getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
 
         assertThat( proxy1.getProxyMode(), equalTo( ProxyMode.BLOCKED_MANUAL ) );
+        waitForWLBackgroundUpdates();
 
         // let's check states
         {
@@ -304,8 +304,8 @@ public class WLAndProxyModeTest
             final WLStatus proxy1status = wm.getStatusFor( proxy1 );
             // this repo is Blocked
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
             // Remark: the combination of those three above simply means "discovery never tried against it"
             // yet.
         }
@@ -369,8 +369,8 @@ public class WLAndProxyModeTest
                     MavenProxyRepository.class ) );
             // this repo is blocked
             assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
-            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
-            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( RemotePrefixFileStrategy.ID ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED_NOT_POSSIBLE ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( "none" ) );
         }
         {
             // group

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndProxyModeTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLAndProxyModeTest.java
@@ -1,0 +1,384 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.wl.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.configuration.model.CLocalStorage;
+import org.sonatype.nexus.configuration.model.CRemoteStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
+import org.sonatype.nexus.proxy.AbstractProxyTestEnvironment;
+import org.sonatype.nexus.proxy.EnvironmentBuilder;
+import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
+import org.sonatype.nexus.proxy.maven.MavenGroupRepository;
+import org.sonatype.nexus.proxy.maven.MavenHostedRepository;
+import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
+import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepository;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.wl.WLDiscoveryStatus.DStatus;
+import org.sonatype.nexus.proxy.maven.wl.WLManager;
+import org.sonatype.nexus.proxy.maven.wl.WLPublishingStatus.PStatus;
+import org.sonatype.nexus.proxy.maven.wl.WLStatus;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.LocalStatus;
+import org.sonatype.nexus.proxy.repository.ProxyMode;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.tests.http.server.fluent.Behaviours;
+import org.sonatype.tests.http.server.fluent.Server;
+
+/**
+ * Testing interaction of {@link Repository#getLocalStatus()} and WL.
+ * 
+ * @author cstamas
+ */
+public class WLAndProxyModeTest
+    extends AbstractWLProxyTest
+{
+    private static final String HOSTED_REPO_ID = "hosted";
+
+    private static final String PROXY1_REPO_ID = "proxy1";
+
+    private static final String PROXY2_REPO_ID = "proxy2";
+
+    private static final String GROUP_REPO_ID = "group";
+
+    private Server server;
+
+    public WLAndProxyModeTest()
+        throws Exception
+    {
+        // one server serving up stuff for both proxies, it does have prefix file published but nothing else
+        // this only serves the purpose to not have repo autoblock
+        this.server =
+            Server.withPort( 0 ).serve( "/" ).withBehaviours( Behaviours.error( 404, "don't bother yourself" ) ).serve(
+                "/.meta/prefixes.txt" ).withBehaviours( Behaviours.content( prefixFile() ) );
+        server.start();
+    }
+
+    protected String prefixFile()
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter( sw );
+        pw.println( "# This is mighty prefix file!" );
+        pw.println( "/org/apache/maven" );
+        pw.println( "/org/sonatype" );
+        pw.println( " # Added later" );
+        pw.println( "/eu/flatwhite" );
+        return sw.toString();
+    }
+
+    @Override
+    protected EnvironmentBuilder createEnvironmentBuilder()
+        throws Exception
+    {
+        // we need one hosted repo only, so build it
+        return new EnvironmentBuilder()
+        {
+            @Override
+            public void startService()
+            {
+            }
+
+            @Override
+            public void stopService()
+            {
+            }
+
+            @Override
+            public void buildEnvironment( AbstractProxyTestEnvironment env )
+                throws ConfigurationException, IOException, ComponentLookupException
+            {
+                final PlexusContainer container = env.getPlexusContainer();
+                final List<String> reposes = new ArrayList<String>();
+                {
+                    // adding 1st proxy, that is blocked
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY1_REPO_ID );
+                    repoConf.setName( PROXY1_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY1_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    exConf.setProxyMode( ProxyMode.BLOCKED_MANUAL );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding 2nd proxy
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY2_REPO_ID );
+                    repoConf.setName( PROXY2_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY2_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding one hosted
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( HOSTED_REPO_ID );
+                    repoConf.setName( HOSTED_REPO_ID );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + HOSTED_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom exRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( exRepo );
+                    M2RepositoryConfiguration exRepoConf = new M2RepositoryConfiguration( exRepo );
+                    exRepoConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exRepoConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repo.configure( repoConf );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // add a group
+                    final M2GroupRepository group =
+                        (M2GroupRepository) container.lookup( GroupRepository.class, "maven2" );
+                    CRepository repoGroupConf = new DefaultCRepository();
+                    repoGroupConf.setProviderRole( GroupRepository.class.getName() );
+                    repoGroupConf.setProviderHint( "maven2" );
+                    repoGroupConf.setId( GROUP_REPO_ID );
+                    repoGroupConf.setName( GROUP_REPO_ID );
+                    repoGroupConf.setLocalStorage( new CLocalStorage() );
+                    repoGroupConf.getLocalStorage().setProvider( "file" );
+                    repoGroupConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/test" ).toURI().toURL().toString() );
+                    Xpp3Dom exGroupRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoGroupConf.setExternalConfiguration( exGroupRepo );
+                    M2GroupRepositoryConfiguration exGroupRepoConf = new M2GroupRepositoryConfiguration( exGroupRepo );
+                    exGroupRepoConf.setMemberRepositoryIds( reposes );
+                    exGroupRepoConf.setMergeMetadata( true );
+                    group.configure( repoGroupConf );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoGroupConf );
+                    env.getRepositoryRegistry().addRepository( group );
+                }
+            }
+        };
+    }
+
+    @Override
+    protected boolean enableWLFeature()
+    {
+        return true;
+    }
+
+    @Test
+    public void manuallyBlockedRepositoryDoesNotAffectWLInitialization()
+        throws Exception
+    {
+        // at this point, NexusStartedEvent was fired, and hence, WL's should be inited
+        final WLManager wm = lookup( WLManager.class );
+        final MavenProxyRepository proxy1 =
+            getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
+
+        assertThat( proxy1.getProxyMode(), equalTo( ProxyMode.BLOCKED_MANUAL ) );
+
+        // let's check states
+
+        {
+            // proxy1
+            final WLStatus proxy1status = wm.getStatusFor( proxy1 );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            // Remark: the combination of those three above simply means "discovery never tried against it"
+            // yet.
+        }
+
+        {
+            // proxy2
+            final WLStatus proxy2status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY2_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo should be good
+            assertThat( proxy2status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( proxy2status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
+        }
+
+        {
+            // hosted
+            final WLStatus hostedStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( HOSTED_REPO_ID,
+                    MavenHostedRepository.class ) );
+            // this repo should be good
+            assertThat( hostedStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( hostedStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublished
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            // message should refer to proxy1 as reason of not publishing group WL
+            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+    }
+
+    @Test
+    public void flippingProxyModeUpdatesWL()
+        throws Exception
+    {
+        // at this point, NexusStartedEvent was fired, and hence, WL's should be inited
+        final WLManager wm = lookup( WLManager.class );
+        final MavenProxyRepository proxy1 =
+            getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID, MavenProxyRepository.class );
+
+        assertThat( proxy1.getProxyMode(), equalTo( ProxyMode.BLOCKED_MANUAL ) );
+
+        // let's check states
+        {
+            // proxy1
+            final WLStatus proxy1status = wm.getStatusFor( proxy1 );
+            // this repo is Blocked
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.ENABLED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( nullValue() ) );
+            // Remark: the combination of those three above simply means "discovery never tried against it"
+            // yet.
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            // not all members have WL, unpublished
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.NOT_PUBLISHED ) );
+            // message should refer to proxy1 as reason of not publishing group WL
+            assertThat( groupStatus.getPublishingStatus().getLastPublishedMessage(), containsString( proxy1.getName() ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // let's flip proxy1 now
+            proxy1.setProxyMode( ProxyMode.ALLOW );
+            getApplicationConfiguration().saveConfiguration();
+            Thread.yield();
+            wairForAsyncEventsToCalmDown();
+            waitForWLBackgroundUpdates();
+        }
+
+        // let's check states again, now with enabled proxy1
+
+        {
+            // proxy1
+            final WLStatus proxy1status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo is Out of Service
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( RemotePrefixFileStrategy.ID ) );
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+
+        {
+            // let's flip proxy1 now back
+            proxy1.setProxyMode( ProxyMode.BLOCKED_MANUAL );
+            getApplicationConfiguration().saveConfiguration();
+            Thread.yield();
+            wairForAsyncEventsToCalmDown();
+            waitForWLBackgroundUpdates();
+        }
+
+        // let's check states again, now with enabled proxy1
+
+        {
+            // proxy1
+            final WLStatus proxy1status =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( PROXY1_REPO_ID,
+                    MavenProxyRepository.class ) );
+            // this repo is blocked
+            assertThat( proxy1status.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( proxy1status.getDiscoveryStatus().getStatus(), equalTo( DStatus.SUCCESSFUL ) );
+            assertThat( proxy1status.getDiscoveryStatus().getLastDiscoveryStrategy(), is( RemotePrefixFileStrategy.ID ) );
+        }
+        {
+            // group
+            final WLStatus groupStatus =
+                wm.getStatusFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID,
+                    MavenGroupRepository.class ) );
+            assertThat( groupStatus.getPublishingStatus().getStatus(), equalTo( PStatus.PUBLISHED ) );
+            assertThat( groupStatus.getDiscoveryStatus().getStatus(), equalTo( DStatus.NOT_A_PROXY ) );
+        }
+    }
+}

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/scrape/AmazonS3IndexScraperTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/scrape/AmazonS3IndexScraperTest.java
@@ -94,6 +94,13 @@ public class AmazonS3IndexScraperTest
             + "<StorageClass>STANDARD</StorageClass>"//
             + "</Contents>"//
             + "<Contents>"//
+            + "<Key>release/.meta/repository-metadata.xml</Key>"//
+            + "<LastModified>2011-08-25T01:38:05.000Z</LastModified>"//
+            + "<ETag>\"8bf32bb10b5a9c818739cc0031c67ac9\"</ETag>"//
+            + "<Size>267</Size>"//
+            + "<StorageClass>STANDARD</StorageClass>"//
+            + "</Contents>"//
+            + "<Contents>"//
             + "<Key>release/foo/baz/1/baz-2.jar</Key>"//
             + "<LastModified>2013-02-02T10:25:26.000Z</LastModified>"//
             + "<ETag>\"9f25f7c8efd60f815626306442d5e71c\"</ETag>"//

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistDisabledSmokeIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistDisabledSmokeIT.java
@@ -66,7 +66,8 @@ public class WhitelistDisabledSmokeIT
     public void waitForDiscoveryOutcome()
         throws Exception
     {
-        waitForWLDiscoveryOutcome( "central" );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( "central" );
     }
 
     @Test

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistEnableDisableDoesNotLoosePeriodIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistEnableDisableDoesNotLoosePeriodIT.java
@@ -42,7 +42,8 @@ public class WhitelistEnableDisableDoesNotLoosePeriodIT
     public void waitForDiscoveryOutcome()
         throws Exception
     {
-        waitForWLDiscoveryOutcome( "central" );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( "central" );
     }
 
     @Test

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistFilteringIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistFilteringIT.java
@@ -179,6 +179,10 @@ public class WhitelistFilteringIT
         final MavenProxyRepository proxyRepository =
             repositories().create( MavenProxyRepository.class, repositoryIdForTest( "someorgProxy1" ) ).asProxyOf(
                 server.getUrl().toExternalForm() ).doNotDownloadRemoteIndexes().save();
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLPublishingOutcomes( proxyRepository.id() );
+        client().getSubsystem( Scheduler.class ).waitForAllTasksToStop();
+
         try
         {
             // clear recorder
@@ -306,6 +310,10 @@ public class WhitelistFilteringIT
         final MavenProxyRepository proxyRepository =
             repositories().create( MavenProxyRepository.class, repositoryIdForTest( "someorgProxy1" ) ).asProxyOf(
                 server.getUrl().toExternalForm() ).doNotDownloadRemoteIndexes().save();
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLPublishingOutcomes( proxyRepository.id() );
+        client().getSubsystem( Scheduler.class ).waitForAllTasksToStop();
+
         try
         {
             // clear recorder

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistITSupport.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistITSupport.java
@@ -26,8 +26,9 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.sonatype.nexus.client.core.exception.NexusClientBadRequestException;
 import org.sonatype.nexus.client.core.subsystem.whitelist.Status;
-import org.sonatype.nexus.client.core.subsystem.whitelist.Whitelist;
 import org.sonatype.nexus.client.core.subsystem.whitelist.Status.Outcome;
+import org.sonatype.nexus.client.core.subsystem.whitelist.Whitelist;
+import org.sonatype.nexus.testsuite.client.WhitelistTest;
 
 import com.google.common.io.Closeables;
 
@@ -58,6 +59,16 @@ public abstract class WhitelistITSupport
     }
 
     /**
+     * Returns {@link WhitelistTest} client subsystem.
+     * 
+     * @return client for whitelist ITs.
+     */
+    public WhitelistTest whitelistTest()
+    {
+        return client().getSubsystem( WhitelistTest.class );
+    }
+
+    /**
      * Waits for a remote discovery outcomes. The passed in repository IDs must correspond to a Maven2 proxy repository,
      * otherwise {@link IllegalArgumentException} is thrown. They all will be waited for, in passed in order.
      * 
@@ -65,12 +76,12 @@ public abstract class WhitelistITSupport
      * @throws IllegalArgumentException if repository ID is not a maven2 proxy.
      * @throws InterruptedException
      */
-    public void waitForWLDiscoveryOutcomes( final String... proxyRepositoryIds )
+    public void _waitForWLDiscoveryOutcomes( final String... proxyRepositoryIds )
         throws IllegalArgumentException, InterruptedException
     {
         for ( String proxyRepositoryId : proxyRepositoryIds )
         {
-            waitForWLDiscoveryOutcome( proxyRepositoryId );
+            _waitForWLDiscoveryOutcome( proxyRepositoryId );
         }
     }
 
@@ -82,7 +93,7 @@ public abstract class WhitelistITSupport
      * @throws IllegalArgumentException if repository ID is not a maven2 proxy.
      * @throws InterruptedException
      */
-    public void waitForWLDiscoveryOutcome( final String proxyRepositoryId )
+    public void _waitForWLDiscoveryOutcome( final String proxyRepositoryId )
         throws IllegalArgumentException, InterruptedException
     {
         // status
@@ -108,12 +119,12 @@ public abstract class WhitelistITSupport
      * @throws IllegalArgumentException if repository ID is not a maven2 repo.
      * @throws InterruptedException
      */
-    public void waitForWLPublishingOutcomes( final String... repositoryIds )
+    public void _waitForWLPublishingOutcomes( final String... repositoryIds )
         throws IllegalArgumentException, InterruptedException
     {
         for ( String repositoryId : repositoryIds )
         {
-            waitForWLPublishingOutcome( repositoryId );
+            _waitForWLPublishingOutcome( repositoryId );
         }
     }
 
@@ -125,7 +136,7 @@ public abstract class WhitelistITSupport
      * @throws NexusClientBadRequestException if repository ID is not a maven2 repo.
      * @throws InterruptedException
      */
-    public void waitForWLPublishingOutcome( final String repositoryId )
+    public void _waitForWLPublishingOutcome( final String repositoryId )
         throws NexusClientBadRequestException, InterruptedException
     {
         // status

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSanityIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSanityIT.java
@@ -75,7 +75,8 @@ public class WhitelistSanityIT
     public void waitForWLDiscoveryOutcome()
         throws Exception
     {
-        waitForWLDiscoveryOutcome( "central" );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        //waitForWLDiscoveryOutcome( "central" );
     }
 
     /**

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSmokeIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSmokeIT.java
@@ -58,7 +58,8 @@ public class WhitelistSmokeIT
     public void waitForDiscoveryOutcome()
         throws Exception
     {
-        waitForWLDiscoveryOutcome( "central" );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( "central" );
     }
 
     @Test
@@ -155,7 +156,8 @@ public class WhitelistSmokeIT
             // block it
             repositories().get( ProxyRepository.class, "central" ).block().save();
             whitelist().updateWhitelist( "central" );
-            waitForWLDiscoveryOutcome( "central" );
+            whitelistTest().waitForAllWhitelistUpdateJobToStop();
+            // waitForWLDiscoveryOutcome( "central" );
 
             // recheck
             final Status statusAfter = whitelist().getWhitelistStatus( "central" );

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSmokeIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistSmokeIT.java
@@ -13,6 +13,7 @@
 package core.whitelist;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -141,13 +142,26 @@ public class WhitelistSmokeIT
         }
     }
 
-    @Test( expected = NexusClientBadRequestException.class )
+    @Test
     public void checkDiscoveryOnBlockedProxyRepository()
+        throws InterruptedException
     {
         try
         {
+            final Status statusBefore = whitelist().getWhitelistStatus( "central" );
+            assertThat( statusBefore.getPublishedStatus(), equalTo( Outcome.SUCCEEDED ) );
+            assertThat( statusBefore.getDiscoveryStatus().getDiscoveryLastStatus(), equalTo( Outcome.SUCCEEDED ) );
+
+            // block it
             repositories().get( ProxyRepository.class, "central" ).block().save();
             whitelist().updateWhitelist( "central" );
+            waitForWLDiscoveryOutcome( "central" );
+
+            // recheck
+            final Status statusAfter = whitelist().getWhitelistStatus( "central" );
+            assertThat( statusAfter.getPublishedStatus(), equalTo( Outcome.SUCCEEDED ) );
+            assertThat( statusAfter.getDiscoveryStatus().getDiscoveryLastStatus(), equalTo( Outcome.FAILED ) );
+            assertThat( statusAfter.getDiscoveryStatus().getDiscoveryLastMessage(), containsString( "blocked" ) );
         }
         finally
         {

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithGroupRepositoryIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithGroupRepositoryIT.java
@@ -72,8 +72,9 @@ public class WhitelistWithGroupRepositoryIT
         throws Exception
     {
         // wait for central
-        waitForWLDiscoveryOutcome( "central" );
-        waitForWLPublishingOutcomes( "central", REPO_ID );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( "central" );
+        // waitForWLPublishingOutcomes( "central", REPO_ID );
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
     }
@@ -88,8 +89,9 @@ public class WhitelistWithGroupRepositoryIT
             final DiscoveryConfiguration config = whitelist().getDiscoveryConfigurationFor( "central" );
             config.setEnabled( false );
             whitelist().setDiscoveryConfigurationFor( "central", config );
-            waitForWLDiscoveryOutcome( "central" );
-            waitForWLPublishingOutcomes( "central", REPO_ID );
+            whitelistTest().waitForAllWhitelistUpdateJobToStop();
+            // waitForWLDiscoveryOutcome( "central" );
+            // waitForWLPublishingOutcomes( "central", REPO_ID );
         }
         assertThat( exists( PREFIX_FILE_LOCATION ), is( false ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( true ) );
@@ -97,8 +99,9 @@ public class WhitelistWithGroupRepositoryIT
             final DiscoveryConfiguration config = whitelist().getDiscoveryConfigurationFor( "central" );
             config.setEnabled( true );
             whitelist().setDiscoveryConfigurationFor( "central", config );
-            waitForWLDiscoveryOutcome( "central" );
-            waitForWLPublishingOutcomes( "central", REPO_ID );
+            whitelistTest().waitForAllWhitelistUpdateJobToStop();
+            // waitForWLDiscoveryOutcome( "central" );
+            // waitForWLPublishingOutcomes( "central", REPO_ID );
         }
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithProxyRepositoryIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithProxyRepositoryIT.java
@@ -71,7 +71,8 @@ public class WhitelistWithProxyRepositoryIT
         throws Exception
     {
         // wait for central
-        waitForWLDiscoveryOutcome( REPO_ID );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( REPO_ID );
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
     }
@@ -86,7 +87,8 @@ public class WhitelistWithProxyRepositoryIT
             final DiscoveryConfiguration config = whitelist().getDiscoveryConfigurationFor( REPO_ID );
             config.setEnabled( false );
             whitelist().setDiscoveryConfigurationFor( REPO_ID, config );
-            waitForWLDiscoveryOutcome( REPO_ID );
+            whitelistTest().waitForAllWhitelistUpdateJobToStop();
+            // waitForWLDiscoveryOutcome( REPO_ID );
         }
         assertThat( exists( PREFIX_FILE_LOCATION ), is( false ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( true ) );
@@ -94,7 +96,8 @@ public class WhitelistWithProxyRepositoryIT
             final DiscoveryConfiguration config = whitelist().getDiscoveryConfigurationFor( REPO_ID );
             config.setEnabled( true );
             whitelist().setDiscoveryConfigurationFor( REPO_ID, config );
-            waitForWLDiscoveryOutcome( REPO_ID );
+            whitelistTest().waitForAllWhitelistUpdateJobToStop();
+            // waitForWLDiscoveryOutcome( REPO_ID );
         }
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
@@ -108,11 +111,13 @@ public class WhitelistWithProxyRepositoryIT
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
         content().delete( PREFIX_FILE_LOCATION );
-        waitForWLDiscoveryOutcome( REPO_ID );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( REPO_ID );
         assertThat( exists( PREFIX_FILE_LOCATION ), is( false ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( true ) );
         whitelist().updateWhitelist( REPO_ID );
-        waitForWLDiscoveryOutcome( REPO_ID );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
+        // waitForWLDiscoveryOutcome( REPO_ID );
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
     }

--- a/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/whitelist/api/WhitelistWaitForPlexusResource.java
+++ b/nexus-test/nexus-it-helper-plugin/src/main/java/org/sonatype/nexus/plugins/whitelist/api/WhitelistWaitForPlexusResource.java
@@ -1,0 +1,98 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.whitelist.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.restlet.Context;
+import org.restlet.data.Form;
+import org.restlet.data.Request;
+import org.restlet.data.Response;
+import org.restlet.data.Status;
+import org.restlet.resource.ResourceException;
+import org.restlet.resource.Variant;
+import org.sonatype.nexus.proxy.maven.wl.WLManager;
+import org.sonatype.nexus.proxy.maven.wl.internal.WLManagerImpl;
+import org.sonatype.plexus.rest.resource.AbstractPlexusResource;
+import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
+
+/**
+ * Exposing {@link WLManagerImpl#isUpdateWhitelistJobRunning()} for ITs.
+ * 
+ * @author cstamas
+ * @since 2.4
+ */
+@Named
+@Singleton
+public class WhitelistWaitForPlexusResource
+    extends AbstractPlexusResource
+{
+
+    private static final String RESOURCE_URI = "/whitelist/waitFor";
+
+    private final WLManager wlManager;
+
+    @Inject
+    public WhitelistWaitForPlexusResource( final WLManager wlManager )
+    {
+        this.wlManager = checkNotNull( wlManager );
+    }
+
+    @Override
+    public String getResourceUri()
+    {
+        return RESOURCE_URI;
+    }
+
+    @Override
+    public PathProtectionDescriptor getResourceProtection()
+    {
+        return new PathProtectionDescriptor( getResourceUri(), "anon" );
+    }
+
+    @Override
+    public Object getPayloadInstance()
+    {
+        return null;
+    }
+
+    public Object get( Context context, Request request, Response response, Variant variant )
+        throws ResourceException
+    {
+        Form form = request.getResourceRef().getQueryAsForm();
+        final long timeout = Long.parseLong( form.getFirstValue( "timeout", "60000" ) );
+        try
+        {
+            final long startTime = System.currentTimeMillis();
+            while ( System.currentTimeMillis() - startTime <= timeout )
+            {
+                if ( !( (WLManagerImpl) wlManager ).isUpdateWhitelistJobRunning() )
+                {
+                    response.setStatus( Status.SUCCESS_OK );
+                    return "Ok";
+                }
+                Thread.sleep( 500 );
+            }
+        }
+        catch ( final InterruptedException ignore )
+        {
+            // ignore
+        }
+        response.setStatus( Status.SUCCESS_ACCEPTED );
+        return "Still munching on them...";
+    }
+}

--- a/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/WhitelistTest.java
+++ b/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/WhitelistTest.java
@@ -1,0 +1,30 @@
+package org.sonatype.nexus.testsuite.client;
+
+import org.sonatype.nexus.testsuite.client.exception.WhitelistJobsAreStillRunningException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * IT client for whitelist feature.
+ * 
+ * @author cstamas
+ * @since 2.4
+ */
+public interface WhitelistTest
+{
+    /**
+     * Blocks for one minute, or less, if white-list update jobs finished earlier.
+     * 
+     * @throws WhitelistJobsAreStillRunningException
+     */
+    void waitForAllWhitelistUpdateJobToStop()
+        throws WhitelistJobsAreStillRunningException;
+
+    /**
+     * Blocks for given timeout, or less, if white-list update jobs finished earlier.
+     * 
+     * @param timeout
+     * @throws WhitelistJobsAreStillRunningException
+     */
+    void waitForAllWhitelistUpdateJobToStop( Time timeout )
+        throws WhitelistJobsAreStillRunningException;
+}

--- a/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/WhitelistTest.java
+++ b/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/WhitelistTest.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.testsuite.client;
 
 import org.sonatype.nexus.testsuite.client.exception.WhitelistJobsAreStillRunningException;

--- a/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/WhitelistJobsAreStillRunningException.java
+++ b/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/exception/WhitelistJobsAreStillRunningException.java
@@ -1,0 +1,33 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.exception;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.sonatype.nexus.client.core.exception.NexusClientException;
+import org.sonatype.sisu.goodies.common.Time;
+
+/**
+ * Thrown when waiting for Nexus to not run tasks but tasks are still running in the configured timeout period.
+ * 
+ * @since 2.4
+ */
+public class WhitelistJobsAreStillRunningException
+    extends NexusClientException
+{
+    public WhitelistJobsAreStillRunningException( final Time timeout )
+    {
+        super( "Nexus was still running white-list update jobs, configured timeout of "
+            + checkNotNull( timeout.toString() ) );
+    }
+}

--- a/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyWhitelistTest.java
+++ b/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/internal/JerseyWhitelistTest.java
@@ -1,0 +1,95 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.internal;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.client.core.spi.SubsystemSupport;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.WhitelistTest;
+import org.sonatype.nexus.testsuite.client.exception.WhitelistJobsAreStillRunningException;
+import org.sonatype.sisu.goodies.common.Time;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+/**
+ * Jersey based {@link WhitelistTest} Nexus Client Subsystem implementation.
+ * 
+ * @since 2.4
+ */
+public class JerseyWhitelistTest
+    extends SubsystemSupport<JerseyNexusClient>
+    implements WhitelistTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger( WhitelistTest.class );
+
+    public JerseyWhitelistTest( final JerseyNexusClient nexusClient )
+    {
+        super( nexusClient );
+    }
+
+    @Override
+    public void waitForAllWhitelistUpdateJobToStop()
+        throws WhitelistJobsAreStillRunningException
+    {
+        waitForAllWhitelistUpdateJobToStop( null );
+    }
+
+    @Override
+    public void waitForAllWhitelistUpdateJobToStop( @Nullable final Time timeout )
+        throws WhitelistJobsAreStillRunningException
+    {
+        try
+        {
+            Time actualTimeout = timeout;
+            if ( actualTimeout == null )
+            {
+                actualTimeout = Time.minutes( 1 );
+            }
+
+            LOG.info( "Waiting for Nexus to not execute any task (timeouts in {})", actualTimeout.toString() );
+
+            final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+            params.add( "timeout", String.valueOf( actualTimeout.toMillis() ) );
+
+            final ClientResponse response =
+                getNexusClient().serviceResource( "whitelist/waitFor", params ).get( ClientResponse.class );
+
+            response.close();
+
+            if ( Response.Status.ACCEPTED.getStatusCode() == response.getStatus() )
+            {
+                throw new WhitelistJobsAreStillRunningException( actualTimeout );
+            }
+            else if ( !response.getClientResponseStatus().getFamily().equals( Response.Status.Family.SUCCESSFUL ) )
+            {
+                throw getNexusClient().convert( new UniformInterfaceException( response ) );
+            }
+        }
+        catch ( ClientHandlerException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+        catch ( UniformInterfaceException e )
+        {
+            throw getNexusClient().convert( e );
+        }
+    }
+}

--- a/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyWhitelistTestSubsystemFactory.java
+++ b/nexus-test/nexus-testsuite-client/src/main/java/org/sonatype/nexus/testsuite/client/rest/JerseyWhitelistTestSubsystemFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.testsuite.client.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.client.core.Condition;
+import org.sonatype.nexus.client.core.condition.NexusStatusConditions;
+import org.sonatype.nexus.client.core.spi.SubsystemFactory;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.testsuite.client.WhitelistTest;
+import org.sonatype.nexus.testsuite.client.internal.JerseyWhitelistTest;
+
+/**
+ * Jersey based {@link WhitelistTest} Nexus Client Subsystem factory.
+ *
+ * @since 2.4
+ */
+@Named
+@Singleton
+public class JerseyWhitelistTestSubsystemFactory
+    implements SubsystemFactory<WhitelistTest, JerseyNexusClient>
+{
+    @Override
+    public Condition availableWhen()
+    {
+        return NexusStatusConditions.any20AndLater();
+    }
+
+    @Override
+    public Class<WhitelistTest> getType()
+    {
+        return WhitelistTest.class;
+    }
+
+    @Override
+    public WhitelistTest create( final JerseyNexusClient nexusClient )
+    {
+        return new JerseyWhitelistTest( nexusClient );
+    }
+}

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/mwl/WLStatusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/mwl/WLStatusResource.java
@@ -154,7 +154,7 @@ public class WLStatusResource
                 discoveryPayload.setDiscoveryLastMessage( "" );
 
                 // if we have it run at all
-                if ( DStatus.ENABLED.ordinal() < status.getDiscoveryStatus().getStatus().ordinal() )
+                if ( DStatus.ENABLED_IN_PROGRESS.ordinal() < status.getDiscoveryStatus().getStatus().ordinal() )
                 {
                     if ( DStatus.SUCCESSFUL == status.getDiscoveryStatus().getStatus() )
                     {


### PR DESCRIPTION
Cumulative fixes gathered so far (mostly from RSO). 

Changes/Fixes:
- Repository#getLocalStatus proper handling (NEXUS-5591, NEXUS-5590)
- ProxyRepository#getProxyMode proper handling (NEXUS-5591)
- WL ThreadPool proper shutdown
- S3 scraper: did not neglect ".dot" files (NEXUS-5587)
- Apache HTTPD scraper: was too "tight" (NEXUS-5589)
- Added UTs (local status and proxy mode) and modified ITs to cover changes in NEXUS-5591

CI:
https://bamboo.zion.sonatype.com/browse/NXO-OSSF31-2
"passed" (with two unrelated failures)

CI:
https://bamboo.zion.sonatype.com/browse/NXO-OSSF31-3
