### PR TITLE
23x nexus 5418 store checksum in item attributes

### DIFF
--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUid.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/DefaultRepositoryItemUid.java
@@ -86,16 +86,11 @@ public class DefaultRepositoryItemUid
 
         return lock;
     }
-    
+
     @Override
     public synchronized RepositoryItemUidLock getAttributeLock()
     {
-        if ( lock == null )
-        {
-            lock = factory.createUidAttributeLock( this );
-        }
-
-        return lock;
+        return getLock();
     }
 
     @Override

--- a/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/RepositoryItemUid.java
+++ b/nexus/nexus-api/src/main/java/org/sonatype/nexus/proxy/item/RepositoryItemUid.java
@@ -95,6 +95,8 @@ public interface RepositoryItemUid
      * As you can see on {@link RepositoryItemUidLock#unlock()} method javadoc, last of the boxed unlocks (if any boxing
      * at all, simply last invocation) also releases the lazily created lock.
      * 
+     * @deprecated this method is fully equivalent to {@link #getLock()}
+     * 
      * @return
      */
     RepositoryItemUidLock getAttributeLock();

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -12,11 +12,22 @@
  */
 package org.sonatype.nexus.proxy.maven;
 
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.ATTR_REMOTE_MD5;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.ATTR_REMOTE_SHA1;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.SUFFIX_MD5;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.SUFFIX_SHA1;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.doRetrieveMD5;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.doRetrieveSHA1;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.doStoreSHA1;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.doStoreMD5;
+import static org.sonatype.nexus.proxy.maven.ChecksumContentValidator.newHashItem;
+
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.StringUtils;
@@ -24,7 +35,6 @@ import org.sonatype.configuration.ConfigurationException;
 import org.sonatype.nexus.proxy.AccessDeniedException;
 import org.sonatype.nexus.proxy.IllegalOperationException;
 import org.sonatype.nexus.proxy.ItemNotFoundException;
-import org.sonatype.nexus.proxy.RemoteAccessException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.StorageException;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
@@ -32,6 +42,7 @@ import org.sonatype.nexus.proxy.events.RepositoryEventEvictUnusedItems;
 import org.sonatype.nexus.proxy.events.RepositoryEventRecreateMavenMetadata;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.maven.EvictUnusedMavenItemsWalkerProcessor.EvictUnusedMavenItemsWalkerFilter;
 import org.sonatype.nexus.proxy.maven.packaging.ArtifactPackagingMapper;
@@ -55,6 +66,7 @@ public abstract class AbstractMavenRepository
     extends AbstractProxyRepository
     implements MavenRepository, MavenHostedRepository, MavenProxyRepository
 {
+
     /**
      * Metadata manager.
      */
@@ -390,16 +402,78 @@ public abstract class AbstractMavenRepository
             throw new ItemNotFoundException( request, this );
         }
 
+        if ( getRepositoryKind().isFacetAvailable( ProxyRepository.class )
+            && !request.getRequestPath().startsWith( "/." ) )
+        {
+            if ( request.getRequestPath().endsWith( SUFFIX_SHA1 ) )
+            {
+                return doRetrieveSHA1( this, request, doRetrieveArtifactItem( request, SUFFIX_SHA1 ) ).getHashItem();
+            }
+
+            if ( request.getRequestPath().endsWith( SUFFIX_MD5 ) )
+            {
+                return doRetrieveMD5( this, request, doRetrieveArtifactItem( request, SUFFIX_MD5 ) ).getHashItem();
+            }
+        }
+
         return super.doRetrieveItem( request );
+    }
+
+    /**
+     * Retrieves artifact corresponding to .sha1/.md5 request (or any request suffix).
+     */
+    private StorageItem doRetrieveArtifactItem( ResourceStoreRequest hashRequest, String suffix )
+        throws ItemNotFoundException, StorageException, IllegalOperationException
+    {
+        final String hashPath = hashRequest.getRequestPath();
+        final String itemPath = hashPath.substring( 0, hashPath.length() - suffix.length() );
+        hashRequest.pushRequestPath( itemPath );
+        try
+        {
+            return super.doRetrieveItem( hashRequest );
+        }
+        finally
+        {
+            hashRequest.popRequestPath();
+        }
     }
 
     @Override
     public void storeItem( boolean fromTask, StorageItem item )
         throws UnsupportedStorageOperationException, IllegalOperationException, StorageException
     {
-        if ( shouldServeByPolicies( new ResourceStoreRequest( item ) ) )
+        final ResourceStoreRequest request = new ResourceStoreRequest( item ); // this is local only request
+        if ( shouldServeByPolicies( request ) )
         {
-            super.storeItem( fromTask, item );
+            if ( getRepositoryKind().isFacetAvailable( ProxyRepository.class ) && item instanceof StorageFileItem
+                && !item.getPath().startsWith( "/." ) )
+            {
+                try
+                {
+                    if ( item.getPath().endsWith( SUFFIX_SHA1 ) )
+                    {
+                        doStoreSHA1( this, doRetrieveArtifactItem( request, SUFFIX_SHA1 ), (StorageFileItem) item );
+                    }
+                    else if ( item.getPath().endsWith( SUFFIX_MD5 ) )
+                    {
+                        doStoreMD5( this, doRetrieveArtifactItem( request, SUFFIX_MD5 ), (StorageFileItem) item );
+                    }
+                    else
+                    {
+                        super.storeItem( fromTask, item );
+                    }
+                }
+                catch ( ItemNotFoundException e )
+                {
+                    // ignore storeItem request
+                    // this is a maven2 proxy repository, it is requested to store .sha1/.md5 file
+                    // and not there is not corresponding artifact
+                }
+            }
+            else
+            {
+                super.storeItem( fromTask, item );
+            }
         }
         else
         {
@@ -430,65 +504,48 @@ public abstract class AbstractMavenRepository
     // DefaultRepository customizations
 
     @Override
-    protected AbstractStorageItem doRetrieveRemoteItem( ResourceStoreRequest request )
-        throws ItemNotFoundException, RemoteAccessException, StorageException
+    protected Collection<StorageItem> doListItems( ResourceStoreRequest request )
+        throws ItemNotFoundException, StorageException
     {
-        String path = request.getRequestPath();
-
-        if ( !path.endsWith( ".sha1" ) && !path.endsWith( ".md5" ) )
+        Collection<StorageItem> items = super.doListItems( request );
+        if ( getRepositoryKind().isFacetAvailable( ProxyRepository.class ) )
         {
-            // we are about to download an artifact from remote repository
-            // lets clean any existing (stale) checksum files
-            removeLocalChecksum( request );
-        }
+            Map<String, StorageItem> result = new TreeMap<String, StorageItem>();
+            for ( StorageItem item : items )
+            {
+                putChecksumItem( result, request, item, ATTR_REMOTE_SHA1, SUFFIX_SHA1 );
+                putChecksumItem( result, request, item, ATTR_REMOTE_MD5, SUFFIX_MD5 );
+            }
 
-        return super.doRetrieveRemoteItem( request );
+            for ( StorageItem item : items )
+            {
+                if ( !result.containsKey( item.getPath() ) )
+                {
+                    result.put( item.getPath(), item );
+                }
+            }
+
+            items = result.values();
+        }
+        return items;
     }
 
-    private void removeLocalChecksum( ResourceStoreRequest request )
-        throws StorageException
+    private void putChecksumItem( Map<String, StorageItem> checksums, ResourceStoreRequest request,
+                                  StorageItem artifact, String attrname, String suffix )
     {
-        try
+        String hash = artifact.getRepositoryItemAttributes().get( attrname );
+        if ( hash != null )
         {
+            String hashPath = artifact.getPath() + suffix;
+            request.pushRequestPath( hashPath );
             try
             {
-                request.pushRequestPath( request.getRequestPath() + ".sha1" );
-
-                try
-                {
-                    getLocalStorage().deleteItem( this, request );
-                }
-                catch ( ItemNotFoundException e )
-                {
-                    // this is exactly what we're trying to achieve
-                }
+                checksums.put( hashPath, newHashItem( this, request, artifact, hash ) );
             }
             finally
             {
                 request.popRequestPath();
             }
-
-            try
-            {
-                request.pushRequestPath( request.getRequestPath() + ".md5" );
-
-                try
-                {
-                    getLocalStorage().deleteItem( this, request );
-                }
-                catch ( ItemNotFoundException e )
-                {
-                    // this is exactly what we're trying to achieve
-                }
-            }
-            finally
-            {
-                request.popRequestPath();
-            }
-        }
-        catch ( UnsupportedStorageOperationException e )
-        {
-            // huh?
         }
     }
 }

--- a/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/nexus/nexus-proxy/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -20,10 +20,15 @@ import org.sonatype.nexus.proxy.LocalStorageException;
 import org.sonatype.nexus.proxy.RemoteAccessException;
 import org.sonatype.nexus.proxy.RemoteStorageException;
 import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.access.Action;
+import org.sonatype.nexus.proxy.attributes.Attributes;
 import org.sonatype.nexus.proxy.attributes.inspectors.DigestCalculatingInspector;
 import org.sonatype.nexus.proxy.item.AbstractStorageItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
+import org.sonatype.nexus.proxy.item.StorageFileItem;
+import org.sonatype.nexus.proxy.item.StorageItem;
+import org.sonatype.nexus.proxy.item.StringContentLocator;
 import org.sonatype.nexus.proxy.repository.ItemContentValidator;
 import org.sonatype.nexus.proxy.repository.ProxyRepository;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
@@ -38,6 +43,33 @@ public class ChecksumContentValidator
     extends AbstractChecksumContentValidator
     implements ItemContentValidator
 {
+    public static final String SUFFIX_MD5 = ".md5";
+
+    public static final String SUFFIX_SHA1 = ".sha1";
+
+    /**
+     * Key of item attribute that holds contents of remote .sha1 file. The attribute is not present if the item does not
+     * have corresponding .sha1 file
+     */
+    public static final String ATTR_REMOTE_SHA1 = "remote.sha1";
+
+    /**
+     * Key of item attribute that is set to <code>true</code> if and only if the item does not have corresponding remote
+     * .sha1 file.
+     */
+    public static final String ATTR_NO_REMOTE_SHA1 = "remote.no-sha1";
+
+    /**
+     * Key of item attribute that holds contents of remote .md5 file. The attribute is not present if the item does not
+     * have corresponding .md5 file
+     */
+    public static final String ATTR_REMOTE_MD5 = "remote.md5";
+
+    /**
+     * Key of item attribute that is set to <code>true</code> if and only if the item does not have corresponding remote
+     * .md5 file.
+     */
+    public static final String ATTR_NO_REMOTE_MD5 = "remote.no-md5";
 
     @Override
     protected void cleanup( ProxyRepository proxy, RemoteHashResponse remoteHash, boolean contentValid )
@@ -48,8 +80,8 @@ public class ChecksumContentValidator
             // TODO should we remove bad checksum if policy==WARN?
             try
             {
-                proxy.getLocalStorage().deleteItem( proxy,
-                    new ResourceStoreRequest( remoteHash.getHashItem().getRepositoryItemUid().getPath(), true ) );
+                String path = remoteHash.getHashItem().getRepositoryItemUid().getPath();
+                proxy.getLocalStorage().deleteItem( proxy, new ResourceStoreRequest( path, true ) );
             }
             catch ( ItemNotFoundException e )
             {
@@ -99,81 +131,191 @@ public class ChecksumContentValidator
 
         ResourceStoreRequest request = new ResourceStoreRequest( item );
 
-        DefaultStorageFileItem hashItem = null;
-
-        String inspector;
-        // we prefer SHA1 ...
+        RemoteHashResponse response = null;
         try
         {
-            inspector = DigestCalculatingInspector.DIGEST_SHA1_KEY;
-
-            request.pushRequestPath( uid.getPath() + ".sha1" );
-
-            hashItem = doRetriveRemoteChecksumItem( proxy, request );
-        }
-        catch ( ItemNotFoundException sha1e )
-        {
-            // ... but MD5 will do too
-            inspector = DigestCalculatingInspector.DIGEST_MD5_KEY;
+            // we prefer SHA1 ...
+            request.pushRequestPath( uid.getPath() + SUFFIX_SHA1 );
             try
             {
-                request.popRequestPath();
-
-                request.pushRequestPath( uid.getPath() + ".md5" );
-
-                hashItem = doRetriveRemoteChecksumItem( proxy, request );
+                response = doRetrieveSHA1( proxy, request, item );
             }
-            catch ( ItemNotFoundException md5e )
+            finally
+            {
+                request.popRequestPath();
+            }
+        }
+        catch ( ItemNotFoundException e )
+        {
+            // ... but MD5 will do too
+            request.pushRequestPath( uid.getPath() + SUFFIX_MD5 );
+            try
+            {
+                response = doRetrieveMD5( proxy, request, item );
+            }
+            catch ( ItemNotFoundException e1 )
             {
                 getLogger().debug( "Item checksums (SHA1, MD5) remotely unavailable " + uid.toString() );
             }
-        }
-
-        String remoteHash = null;
-
-        if ( hashItem != null )
-        {
-            // store checksum file locally
-            hashItem = (DefaultStorageFileItem) proxy.doCacheItem( hashItem );
-
-            // read checksum
-            try
+            finally
             {
-                remoteHash = MUtils.readDigestFromFileItem( hashItem );
-            }
-            catch ( IOException e )
-            {
-                getLogger().warn( "Cannot read hash string for remotely fetched StorageFileItem: " + uid.toString(), e );
+                request.popRequestPath();
             }
         }
 
-        if ( remoteHash == null )
-        {
-            return null;
-        }
-
-        return new RemoteHashResponse( inspector, remoteHash, hashItem );
+        return response;
     }
 
     private boolean isChecksum( String path )
     {
-        return path.endsWith( ".sha1" ) || path.endsWith( ".md5" );
+        return path.endsWith( SUFFIX_SHA1 ) || path.endsWith( SUFFIX_MD5 );
     }
 
-    private DefaultStorageFileItem doRetriveRemoteChecksumItem( ProxyRepository proxy, ResourceStoreRequest request )
-        throws ItemNotFoundException
+    public static RemoteHashResponse doRetrieveSHA1( ProxyRepository proxy, ResourceStoreRequest hashRequest,
+                                                     StorageItem artifact )
+        throws LocalStorageException, ItemNotFoundException
+    {
+        return doRetrieveChecksumItem( proxy, hashRequest, artifact, DigestCalculatingInspector.DIGEST_SHA1_KEY,
+                                       ATTR_REMOTE_SHA1, ATTR_NO_REMOTE_SHA1 );
+    }
+
+    public static RemoteHashResponse doRetrieveMD5( ProxyRepository proxy, ResourceStoreRequest hashRequest,
+                                                    StorageItem artifact )
+        throws LocalStorageException, ItemNotFoundException
+    {
+        return doRetrieveChecksumItem( proxy, hashRequest, artifact, DigestCalculatingInspector.DIGEST_MD5_KEY,
+                                       ATTR_REMOTE_MD5, ATTR_NO_REMOTE_MD5 );
+    }
+
+    private static RemoteHashResponse doRetrieveChecksumItem( ProxyRepository proxy, ResourceStoreRequest request,
+                                                              StorageItem artifact, String inspector, String attrname,
+                                                              String noattrname )
+        throws ItemNotFoundException, LocalStorageException
+    {
+        final RepositoryItemUid itemUid = artifact.getRepositoryItemUid();
+        itemUid.getLock().lock( Action.read );
+        try
+        {
+            final Attributes attributes = artifact.getRepositoryItemAttributes();
+
+            if ( attributes == null )
+            {
+                throw new LocalStorageException( "Null item repository attributes" );
+            }
+
+            if ( Boolean.parseBoolean( attributes.get( noattrname ) ) )
+            {
+                throw new ItemNotFoundException( request );
+            }
+
+            String hash = attributes.get( attrname );
+            if ( hash == null )
+            {
+                try
+                {
+                    final StorageFileItem remoteItem =
+                        (StorageFileItem) proxy.getRemoteStorage().retrieveItem( proxy, request, proxy.getRemoteUrl() );
+                    hash = MUtils.readDigestFromFileItem( remoteItem ); // closes http input stream
+                }
+                catch ( ItemNotFoundException e )
+                {
+                    // fall through
+                }
+                catch ( RemoteAccessException e )
+                {
+                    // fall through
+                }
+                catch ( RemoteStorageException e )
+                {
+                    // this is (potentially) transient network or remote server problem will be cached
+                    // there is no automatic retry for this hash time
+                    // either expire the artifact or request the hash asExpired to retry
+                }
+
+                doStoreChechsumItem( proxy, artifact, attrname, noattrname, hash );
+            }
+
+            if ( hash != null )
+            {
+                return new RemoteHashResponse( inspector, hash, newHashItem( proxy, request, artifact, hash ) );
+            }
+            else
+            {
+                throw new ItemNotFoundException( request );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new LocalStorageException( e );
+        }
+        finally
+        {
+            itemUid.getLock().unlock();
+        }
+    }
+
+    public static void doStoreSHA1( ProxyRepository proxy, StorageItem artifact, StorageFileItem hash )
+        throws LocalStorageException
     {
         try
         {
-            return (DefaultStorageFileItem) proxy.getRemoteStorage().retrieveItem( proxy, request, proxy.getRemoteUrl() );
+            doStoreChechsumItem( proxy, artifact, ATTR_REMOTE_SHA1, ATTR_NO_REMOTE_SHA1,
+                                 MUtils.readDigestFromFileItem( hash ) );
         }
-        catch ( RemoteAccessException e )
+        catch ( IOException e )
         {
-            throw new ItemNotFoundException( request, proxy, e );
+            throw new LocalStorageException( e );
         }
-        catch ( RemoteStorageException e )
+    }
+
+    public static void doStoreMD5( ProxyRepository proxy, StorageItem artifact, StorageFileItem hash )
+        throws LocalStorageException
+    {
+        try
         {
-            throw new ItemNotFoundException( request, proxy, e );
+            doStoreChechsumItem( proxy, artifact, ATTR_REMOTE_MD5, ATTR_NO_REMOTE_MD5,
+                                 MUtils.readDigestFromFileItem( hash ) );
         }
+        catch ( IOException e )
+        {
+            throw new LocalStorageException( e );
+        }
+    }
+
+    private static void doStoreChechsumItem( ProxyRepository proxy, StorageItem artifact, String attrname,
+                                             String noattrname, String hash )
+        throws IOException
+    {
+        final RepositoryItemUid itemUid = artifact.getRepositoryItemUid();
+        itemUid.getLock().lock( Action.update );
+        final Attributes attributes = artifact.getRepositoryItemAttributes();
+        try
+        {
+            if ( hash != null )
+            {
+                attributes.put( attrname, hash );
+            }
+            else
+            {
+                attributes.put( noattrname, Boolean.toString( true ) );
+            }
+            proxy.getAttributesHandler().storeAttributes( artifact );
+        }
+        finally
+        {
+            itemUid.getLock().unlock();
+        }
+    }
+
+    public static DefaultStorageFileItem newHashItem( ProxyRepository proxy, ResourceStoreRequest request,
+                                                      StorageItem artifact, String hash )
+    {
+        StringContentLocator content = new StringContentLocator( hash );
+        // XXX do we need to clone request here?
+        DefaultStorageFileItem hashItem =
+            new DefaultStorageFileItem( proxy, request, true /* canRead */, false/* canWrite */, content );
+        hashItem.setLength( content.getLength() );
+        hashItem.setModified( artifact.getModified() );
+        return hashItem;
     }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/RepoChecksumPolicyTest.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/RepoChecksumPolicyTest.java
@@ -12,15 +12,26 @@
  */
 package org.sonatype.nexus.proxy;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.sonatype.jettytestsuite.ServletServer;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
 import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.storage.local.LocalRepositoryStorage;
 
 public class RepoChecksumPolicyTest
     extends AbstractProxyTestEnvironment
 {
+
+    private static final String ITEM_WITH_WRONG_SHA1 =
+        "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar";
+
+    private static final String ITEM = "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar";
+
+    private static final String ITEM_WITH_MD5 = "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar";
+
+    private static final String ITEM_WITH_SHA1_AND_MD5 = "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar";
 
     private M2TestsuiteEnvironmentBuilder jettyTestsuiteEnvironmentBuilder;
 
@@ -39,10 +50,12 @@ public class RepoChecksumPolicyTest
         return (M2Repository) getRepositoryRegistry().getRepository( "checksumTestRepo" );
     }
 
-    public StorageFileItem requestWithPolicy( ChecksumPolicy policy, ResourceStoreRequest request )
+    public StorageFileItem requestWithPolicy( ChecksumPolicy policy, String requestPath )
         throws Exception
     {
         M2Repository repo = getRepository();
+
+        ResourceStoreRequest request = new ResourceStoreRequest( requestPath, false, false );
 
         repo.setChecksumPolicy( policy );
         repo.getCurrentCoreConfiguration().commitChanges();
@@ -52,6 +65,14 @@ public class RepoChecksumPolicyTest
         return item;
     }
 
+    private boolean cachedHashItem( final String itemPath, String suffix )
+        throws Exception
+    {
+        final M2Repository repository = getRepository();
+        return repository.getLocalStorage().containsItem( repository,
+                                                          new ResourceStoreRequest( itemPath + suffix, true, false ) );
+    }
+
     @Test
     public void testPolicyIgnore()
         throws Exception
@@ -59,41 +80,25 @@ public class RepoChecksumPolicyTest
         ChecksumPolicy policy = ChecksumPolicy.IGNORE;
 
         // it should simply pull all four without problem
-        StorageFileItem file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        StorageFileItem file = requestWithPolicy( policy, ITEM_WITH_SHA1_AND_MD5 );
         checkForFileAndMatchContents( file );
         // IGNORE: the req ignores checksum
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM_WITH_SHA1_AND_MD5, ".sha1" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_MD5 );
         checkForFileAndMatchContents( file );
         // IGNORE: the req ignores checksum
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM_WITH_SHA1_AND_MD5, ".md5" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM );
         checkForFileAndMatchContents( file );
         // IGNORE: the req ignores checksum
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".sha1" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_WRONG_SHA1 );
         checkForFileAndMatchContents( file );
         // IGNORE: the req ignores checksum
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM_WITH_WRONG_SHA1, ".sha1" ) );
     }
 
     @Test
@@ -103,44 +108,26 @@ public class RepoChecksumPolicyTest
         ChecksumPolicy policy = ChecksumPolicy.WARN;
 
         // it should simply pull all four without problem
-        StorageFileItem file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        StorageFileItem file = requestWithPolicy( policy, ITEM_WITH_SHA1_AND_MD5 );
         checkForFileAndMatchContents( file );
         // WARN: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_SHA1_AND_MD5, ".sha1" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_MD5 );
         checkForFileAndMatchContents( file );
         // WARN: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_MD5, ".md5" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM );
         checkForFileAndMatchContents( file );
         // WARN: the req implicitly gets the "best" checksum available implicitly
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".sha1" ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".md5" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_WRONG_SHA1 );
         checkForFileAndMatchContents( file );
         // WARN: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_WRONG_SHA1, ".sha1" ) );
     }
 
     @Test
@@ -150,53 +137,35 @@ public class RepoChecksumPolicyTest
         ChecksumPolicy policy = ChecksumPolicy.STRICT_IF_EXISTS;
 
         // it should simply pull all four without problem
-        StorageFileItem file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        StorageFileItem file = requestWithPolicy( policy, ITEM_WITH_SHA1_AND_MD5 );
         checkForFileAndMatchContents( file );
         // STRICT_IF_EXISTS: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_SHA1_AND_MD5, ".sha1" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_MD5 );
         checkForFileAndMatchContents( file );
         // STRICT_IF_EXISTS: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_MD5, ".md5" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM );
         checkForFileAndMatchContents( file );
         // STRICT_IF_EXISTS: the req implicitly gets the "best" checksum available implicitly
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".sha1" ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".md5" ) );
 
         try
         {
-            file = requestWithPolicy( policy, new ResourceStoreRequest(
-                "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar",
-                false ) );
+            file = requestWithPolicy( policy, ITEM_WITH_WRONG_SHA1 );
             checkForFileAndMatchContents( file );
             // STRICT_IF_EXISTS: the req implicitly gets the "best" checksum available implicitly
 
-            fail();
+            Assert.fail();
         }
         catch ( ItemNotFoundException e )
         {
             // good
         }
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM_WITH_WRONG_SHA1, ".sha1" ) );
     }
 
     @Test
@@ -206,61 +175,43 @@ public class RepoChecksumPolicyTest
         ChecksumPolicy policy = ChecksumPolicy.STRICT;
 
         // it should simply pull all four without problem
-        StorageFileItem file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        StorageFileItem file = requestWithPolicy( policy, ITEM_WITH_SHA1_AND_MD5 );
         checkForFileAndMatchContents( file );
         // STRICT: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-all/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_SHA1_AND_MD5, ".sha1" ) );
 
-        file = requestWithPolicy( policy, new ResourceStoreRequest(
-            "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar",
-            false ) );
+        file = requestWithPolicy( policy, ITEM_WITH_MD5 );
         checkForFileAndMatchContents( file );
         // STRICT: the req implicitly gets the "best" checksum available implicitly
-        assertTrue( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-md5/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertTrue( cachedHashItem( ITEM_WITH_MD5, ".md5" ) );
 
         try
         {
-            file = requestWithPolicy( policy, new ResourceStoreRequest(
-                "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar",
-                false ) );
+            file = requestWithPolicy( policy, ITEM );
             checkForFileAndMatchContents( file );
             // STRICT: the req implicitly gets the "best" checksum available implicitly
 
-            fail();
+            Assert.fail();
         }
         catch ( ItemNotFoundException e )
         {
             // good
         }
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-none/activemq-core/1.2/activemq-core-1.2.jar.md5", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".sha1" ) );
+        Assert.assertFalse( cachedHashItem( ITEM, ".md5" ) );
 
         try
         {
-            file = requestWithPolicy( policy, new ResourceStoreRequest(
-                "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar",
-                false ) );
+            file = requestWithPolicy( policy, ITEM_WITH_WRONG_SHA1 );
             checkForFileAndMatchContents( file );
             // STRICT: the req implicitly gets the "best" checksum available implicitly
 
-            fail();
+            Assert.fail();
         }
         catch ( ItemNotFoundException e )
         {
             // good
         }
-        assertFalse( getRepository().getLocalStorage().containsItem(
-            getRepository(),
-            new ResourceStoreRequest( "/activemq-with-wrong-sha1/activemq-core/1.2/activemq-core-1.2.jar.sha1", true ) ) );
+        Assert.assertFalse( cachedHashItem( ITEM_WITH_WRONG_SHA1, ".sha1" ) );
     }
 }

--- a/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/internal/MockRemoteStorage.java
+++ b/nexus/nexus-proxy/src/test/java/org/sonatype/nexus/proxy/internal/MockRemoteStorage.java
@@ -197,8 +197,21 @@ public class MockRemoteStorage
         public MockRequestRecord( ProxyRepository repository, ResourceStoreRequest request, String baseUrl )
         {
             this.repository = repository;
-            this.request = request;
+            this.request = clone( request ); // clone to capture snapshot at the time of the request
             this.baseUrl = baseUrl;
+        }
+
+        private static ResourceStoreRequest clone( ResourceStoreRequest request )
+        {
+            if ( request == null )
+            {
+                return null;
+            }
+            ResourceStoreRequest result =
+                new ResourceStoreRequest( request.getRequestPath(), request.isRequestLocalOnly(),
+                                          request.isRequestRemoteOnly() );
+            // only requestPath is used at the moment
+            return result;
         }
 
         @Override


### PR DESCRIPTION
This is 2.3.x version of https://github.com/sonatype/nexus/pull/770 . I decided not to remove item uid #getAttributeLock method, but changed implementation to delegate to #getLock. There are also minor differences due to changes in RepositoryRequest, but otherwise the two pulls are equivalent.
