### PR TITLE
WL update misbehaving

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
@@ -18,11 +18,8 @@ import java.io.IOException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonatype.nexus.configuration.Configurable;
-import org.sonatype.nexus.configuration.ConfigurationChangeEvent;
 import org.sonatype.nexus.proxy.RequestContext;
 import org.sonatype.nexus.proxy.events.RepositoryConfigurationUpdatedEvent;
-import org.sonatype.nexus.proxy.events.RepositoryGroupMembersChangedEvent;
 import org.sonatype.nexus.proxy.events.RepositoryItemEvent;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventCache;
 import org.sonatype.nexus.proxy.events.RepositoryItemEventDelete;
@@ -31,7 +28,6 @@ import org.sonatype.nexus.proxy.events.RepositoryItemEventStore;
 import org.sonatype.nexus.proxy.events.RepositoryRegistryEventAdd;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.uid.IsHiddenAttribute;
-import org.sonatype.nexus.proxy.maven.MavenGroupRepository;
 import org.sonatype.nexus.proxy.maven.MavenHostedRepository;
 import org.sonatype.nexus.proxy.maven.MavenRepository;
 import org.sonatype.nexus.proxy.maven.maven2.Maven2ContentClass;
@@ -310,50 +306,6 @@ public class EventDispatcher
         {
             final MavenRepository mavenRepository = evt.getRepository().adaptToFacet( MavenRepository.class );
             handleRepositoryModified( mavenRepository );
-        }
-    }
-
-    // == Handlers for Group changes (WL of group and groups of groups needs to be updated)
-
-    /**
-     * This subscription is disabled, as this event is fired BEFORE configuration is committed, so group members are NOT
-     * discovered properly and leading to bad WL content!
-     * 
-     * @param evt
-     */
-    // @Subscribe
-    // @AllowConcurrentEvents
-    public void onRepositoryGroupMembersChangedEvent( final RepositoryGroupMembersChangedEvent evt )
-    {
-        if ( isRepositoryHandled( evt.getRepository() ) )
-        {
-            final MavenRepository mavenRepository = evt.getRepository().adaptToFacet( MavenRepository.class );
-            handleRepositoryModified( mavenRepository );
-        }
-    }
-
-    /**
-     * Workaround for method above! This tricky subscriber actually listens for group member changes, but it does it by
-     * hooking to {@link ConfigurationChangeEvent} instead of {@link RepositoryGroupMembersChangedEvent}, since former
-     * is fired AFTER configuration is committed, while latter is fired BEFORE.
-     * 
-     * @param evt
-     */
-    // @Subscribe
-    // @AllowConcurrentEvents
-    public void onConfigurationChangeEvent( final ConfigurationChangeEvent evt )
-    {
-        for ( Configurable configurable : evt.getChanges() )
-        {
-            if ( configurable instanceof Repository )
-            {
-                final Repository repository = (Repository) configurable;
-                final MavenGroupRepository mavenGroupRepository = repository.adaptToFacet( MavenGroupRepository.class );
-                if ( mavenGroupRepository != null && isRepositoryHandled( mavenGroupRepository ) )
-                {
-                    handleRepositoryModified( mavenGroupRepository );
-                }
-            }
         }
     }
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
@@ -95,7 +95,7 @@ public class EventDispatcher
         {
             // we will end up here regularly if reconfiguration was about putting repository out of service
             getLogger().debug( "Repository {} is in bad state for white-list update: {}",
-                RepositoryStringUtils.getHumanizedNameString( mavenRepository ), e.getMessage() );
+                mavenRepository, e.getMessage() );
         }
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/EventDispatcher.java
@@ -339,8 +339,8 @@ public class EventDispatcher
      * 
      * @param evt
      */
-    @Subscribe
-    @AllowConcurrentEvents
+    // @Subscribe
+    // @AllowConcurrentEvents
     public void onConfigurationChangeEvent( final ConfigurationChangeEvent evt )
     {
         for ( Configurable configurable : evt.getChanges() )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteContentDiscovererImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteContentDiscovererImpl.java
@@ -30,7 +30,6 @@ import org.sonatype.nexus.proxy.maven.wl.discovery.RemoteContentDiscoverer;
 import org.sonatype.nexus.proxy.maven.wl.discovery.RemoteStrategy;
 import org.sonatype.nexus.proxy.maven.wl.discovery.StrategyFailedException;
 import org.sonatype.nexus.proxy.maven.wl.discovery.StrategyResult;
-import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * Default {@link RemoteContentDiscoverer} implementation.
@@ -73,8 +72,7 @@ public class RemoteContentDiscovererImpl
             new DiscoveryResult<MavenProxyRepository>( mavenProxyRepository );
         for ( RemoteStrategy strategy : remoteStrategies )
         {
-            getLogger().debug( "Discovery of {} with strategy {} attempted",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), strategy.getId() );
+            getLogger().debug( "Discovery of {} with strategy {} attempted", mavenProxyRepository, strategy.getId() );
             try
             {
                 final StrategyResult strategyResult = strategy.discover( mavenProxyRepository );
@@ -103,14 +101,14 @@ public class RemoteContentDiscovererImpl
 
             if ( discoveryResult.isSuccessful() )
             {
-                getLogger().debug( "Discovery of {} with strategy {} successful",
-                    RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), strategy.getId() );
+                getLogger().debug( "Discovery of {} with strategy {} successful", mavenProxyRepository,
+                    strategy.getId() );
                 break;
             }
             else
             {
-                getLogger().debug( "Discovery of {} with strategy {} unsuccessful",
-                    RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), strategy.getId() );
+                getLogger().debug( "Discovery of {} with strategy {} unsuccessful", mavenProxyRepository,
+                    strategy.getId() );
             }
         }
         return discoveryResult;

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemotePrefixFileStrategy.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemotePrefixFileStrategy.java
@@ -35,7 +35,6 @@ import org.sonatype.nexus.proxy.maven.wl.WLManager;
 import org.sonatype.nexus.proxy.maven.wl.discovery.RemoteStrategy;
 import org.sonatype.nexus.proxy.maven.wl.discovery.StrategyFailedException;
 import org.sonatype.nexus.proxy.maven.wl.discovery.StrategyResult;
-import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * Remote prefix file strategy.
@@ -72,11 +71,10 @@ public class RemotePrefixFileStrategy
         final List<String> remoteFilePath = config.getRemotePrefixFilePaths();
         for ( String path : remoteFilePath )
         {
-            getLogger().debug( "Looking for remote prefix on {} at path {}",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), path );
+            getLogger().debug( "Looking for remote prefix on {} at path {}", mavenProxyRepository, path );
             // we keep exclusive lock on UID during discovery to prevent other WL threads grabbing this file
             // prematurely. We release the lock only when file is present locally, and is validated.
-            // in that moment it's not published yet, but the content is correct and it will be 
+            // in that moment it's not published yet, but the content is correct and it will be
             // the same that will get published.
             final RepositoryItemUid uid = mavenProxyRepository.createUid( path );
             uid.getLock().lock( Action.update );
@@ -85,8 +83,7 @@ public class RemotePrefixFileStrategy
                 item = retrieveFromRemoteIfExists( mavenProxyRepository, path );
                 if ( item != null )
                 {
-                    getLogger().debug( "Remote prefix on {} at path {} found!",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), path );
+                    getLogger().debug( "Remote prefix on {} at path {} found!", mavenProxyRepository, path );
                     long prefixFileAgeInDays = ( System.currentTimeMillis() - item.getModified() ) / 86400000L;
                     final PrefixSource prefixSource = createPrefixSource( mavenProxyRepository, path );
                     if ( prefixSource != null )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteScrapeStrategy.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/RemoteScrapeStrategy.java
@@ -38,7 +38,6 @@ import org.sonatype.nexus.proxy.maven.wl.internal.scrape.Page;
 import org.sonatype.nexus.proxy.maven.wl.internal.scrape.ScrapeContext;
 import org.sonatype.nexus.proxy.maven.wl.internal.scrape.Scraper;
 import org.sonatype.nexus.proxy.storage.remote.httpclient.HttpClientManager;
-import org.sonatype.nexus.proxy.utils.RepositoryStringUtils;
 
 /**
  * Remote scrape strategy.
@@ -81,8 +80,7 @@ public class RemoteScrapeStrategy
     public StrategyResult discover( final MavenProxyRepository mavenProxyRepository )
         throws StrategyFailedException, IOException
     {
-        getLogger().debug( "Remote scrape on {} tried",
-            RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+        getLogger().debug( "Remote scrape on {} tried", mavenProxyRepository );
         // check does a proxy have a valid URL at all
         final String remoteRepositoryRootUrl = mavenProxyRepository.getRemoteUrl();
         boolean isValidHttpUrl;
@@ -110,8 +108,7 @@ public class RemoteScrapeStrategy
             new ScrapeContext( mavenProxyRepository, httpClient, config.getRemoteScrapeDepth() );
         if ( isMarkedForNoScrape( context ) )
         {
-            getLogger().debug( "Remote {} marked as no-scrape, giving up.",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+            getLogger().debug( "Remote {} marked as no-scrape, giving up.", mavenProxyRepository );
             throw new StrategyFailedException( "Remote forbids scraping, is flagged as \"no-scrape\"." );
         }
         final Page rootPage = Page.getPageFor( context, remoteRepositoryRootUrl );
@@ -119,30 +116,27 @@ public class RemoteScrapeStrategy
         Collections.sort( appliedScrapers, new PriorityOrderingComparator<Scraper>() );
         for ( Scraper scraper : appliedScrapers )
         {
-            getLogger().debug( "Remote scraping {} with Scraper {}",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), scraper.getId() );
+            getLogger().debug( "Remote scraping {} with Scraper {}", mavenProxyRepository, scraper.getId() );
             scraper.scrape( context, rootPage );
             if ( context.isStopped() )
             {
                 if ( context.isSuccessful() )
                 {
-                    getLogger().debug( "Remote scraping {} with Scraper {} succeeded.",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), scraper.getId() );
+                    getLogger().debug( "Remote scraping {} with Scraper {} succeeded.", mavenProxyRepository,
+                        scraper.getId() );
                     return new StrategyResult( context.getMessage(), context.getPrefixSource() );
                 }
                 else
                 {
-                    getLogger().debug( "Remote scraping {} with Scraper {} stopped execution.",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), scraper.getId() );
+                    getLogger().debug( "Remote scraping {} with Scraper {} stopped execution.", mavenProxyRepository,
+                        scraper.getId() );
                     throw new StrategyFailedException( context.getMessage() );
                 }
             }
-            getLogger().debug( "Remote scraping {} with Scraper {} skipped.",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ), scraper.getId() );
+            getLogger().debug( "Remote scraping {} with Scraper {} skipped.", mavenProxyRepository, scraper.getId() );
         }
 
-        getLogger().debug( "Not possible remote scrape of {}, no scraper succeeded.",
-            RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+        getLogger().debug( "Not possible remote scrape of {}, no scraper succeeded.", mavenProxyRepository );
         throw new StrategyFailedException( "No scraper was able to scrape remote (or remote prevents scraping)." );
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -262,7 +262,7 @@ public class WLManagerImpl
             // spawn update, this will do whatever is needed (and handle cases like blocked, out of service etc),
             // and publish
             updateWhitelist( mavenRepository );
-            getLogger().info( "Initializing non existing white-list of newly added {}",
+            getLogger().info( "Initializing non-existing white-list of newly added {}",
                 RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
         }
         catch ( Exception e )
@@ -306,7 +306,7 @@ public class WLManagerImpl
                 // mark it for noscrape if not marked yet
                 // this is mainly important on 1st boot or newly added reposes
                 unpublish( mavenRepository, false );
-                getLogger().info( "Initializing non existing white-list of {}",
+                getLogger().info( "Initializing non-existing white-list of {}",
                     RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
                 return true;
             }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -187,7 +187,8 @@ public class WLManagerImpl
             initableRepositories.addAll( repositoryRegistry.getRepositoriesWithFacet( MavenProxyRepository.class ) );
             for ( MavenRepository mavenRepository : initableRepositories )
             {
-                if ( mavenRepository.getLocalStatus().shouldServiceRequest() )
+                if ( isMavenRepositorySupported( mavenRepository )
+                    && mavenRepository.getLocalStatus().shouldServiceRequest() )
                 {
                     if ( doInitializeWhitelistOnStartup( mavenRepository ) )
                     {
@@ -204,7 +205,8 @@ public class WLManagerImpl
             initableGroupRepositories.addAll( repositoryRegistry.getRepositoriesWithFacet( MavenGroupRepository.class ) );
             for ( MavenRepository mavenRepository : initableGroupRepositories )
             {
-                if ( mavenRepository.getLocalStatus().shouldServiceRequest() )
+                if ( isMavenRepositorySupported( mavenRepository )
+                    && mavenRepository.getLocalStatus().shouldServiceRequest() )
                 {
                     // groups will not be collected to needs-update list
                     doInitializeWhitelistOnStartup( mavenRepository );

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WLManagerImpl.java
@@ -254,8 +254,7 @@ public class WLManagerImpl
     @Override
     public void initializeWhitelist( final MavenRepository mavenRepository )
     {
-        getLogger().debug( "Initializing white-list of newly added {}",
-            RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
+        getLogger().debug( "Initializing white-list of newly added {}", mavenRepository );
         try
         {
             // mark it for noscrape if not marked yet
@@ -290,8 +289,7 @@ public class WLManagerImpl
      */
     protected boolean doInitializeWhitelistOnStartup( final MavenRepository mavenRepository )
     {
-        getLogger().debug( "Initializing white-list of {}",
-            RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
+        getLogger().debug( "Initializing white-list of {}", mavenRepository );
         final PrefixSource prefixSource = getPrefixSourceFor( mavenRepository );
         try
         {
@@ -347,7 +345,7 @@ public class WLManagerImpl
             catch ( IllegalStateException e )
             {
                 // just neglect it and continue, this one might be auto blocked if proxy or put out of service
-                getLogger().trace( "Proxy repository {} is not in state to be updated", mavenProxyRepository.getId() );
+                getLogger().trace( "Proxy repository {} is not in state to be updated", mavenProxyRepository );
             }
             catch ( Exception e )
             {
@@ -381,23 +379,19 @@ public class WLManagerImpl
             {
                 if ( discoveryStatus.getStatus() == DStatus.ENABLED_IN_PROGRESS )
                 {
-                    getLogger().debug( "Proxy {} has never been discovered before",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                    getLogger().debug( "Proxy {} has never been discovered before", mavenProxyRepository );
                 }
                 else if ( discoveryStatus.getStatus() == DStatus.ENABLED_NOT_POSSIBLE )
                 {
-                    getLogger().debug( "Proxy {} discovery was not possible before",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                    getLogger().debug( "Proxy {} discovery was not possible before", mavenProxyRepository );
                 }
                 else if ( discoveryStatus.getStatus() == DStatus.ERROR )
                 {
-                    getLogger().debug( "Proxy {} previous discovery hit an error",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                    getLogger().debug( "Proxy {} previous discovery hit an error", mavenProxyRepository );
                 }
                 else
                 {
-                    getLogger().debug( "Proxy {} needs periodic remote discovery update",
-                        RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                    getLogger().debug( "Proxy {} needs periodic remote discovery update", mavenProxyRepository );
                 }
                 final boolean updateSpawned = doUpdateWhitelistAsync( false, mavenProxyRepository );
                 if ( !updateSpawned )
@@ -412,14 +406,13 @@ public class WLManagerImpl
             }
             else
             {
-                getLogger().debug( "Proxy {} white-list is up to date",
-                    RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                getLogger().debug( "Proxy {} white-list is up to date", mavenProxyRepository );
             }
         }
         else
         {
             getLogger().debug( "Proxy {} white-list update requested, but it's remote discovery is disabled",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+                mavenProxyRepository );
         }
         return false;
     }
@@ -447,8 +440,7 @@ public class WLManagerImpl
         checkUpdateConditions( mavenProxyRepository );
         try
         {
-            getLogger().debug( "Quick updating white-list of {}",
-                RepositoryStringUtils.getHumanizedNameString( mavenProxyRepository ) );
+            getLogger().debug( "Quick updating white-list of {}", mavenProxyRepository );
             constrainedExecutor.cancelRunningWithKey( mavenProxyRepository.getId() );
             final PrefixSource prefixSource =
                 updateProxyWhitelist( mavenProxyRepository, Collections.singletonList( quickRemoteStrategy ) );
@@ -546,7 +538,7 @@ public class WLManagerImpl
                 // this is okay, as forced happens rarely, currently only when proxy repo changes remoteURL
                 // (reconfiguration happens)
                 getLogger().debug( "Forced white-list update on {} canceled currently running discovery job",
-                    RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
+                    mavenRepository );
             }
             return canceledPreviousJob;
         }
@@ -573,7 +565,7 @@ public class WLManagerImpl
     protected void updateAndPublishWhitelist( final MavenRepository mavenRepository, final boolean notify )
         throws IOException
     {
-        getLogger().debug( "Updating white-list of {}", RepositoryStringUtils.getHumanizedNameString( mavenRepository ) );
+        getLogger().debug( "Updating white-list of {}", mavenRepository );
         try
         {
             final PrefixSource prefixSource;
@@ -658,7 +650,7 @@ public class WLManagerImpl
                     remoteContentDiscoverer.discoverRemoteContent( mavenProxyRepository, remoteStrategies );
             }
 
-            getLogger().debug( "Results of {} remote discovery: {}", mavenProxyRepository.getId(),
+            getLogger().debug( "Results of {} remote discovery: {}", mavenProxyRepository,
                 discoveryResult.getAllResults() );
 
             if ( discoveryResult.isSuccessful() )
@@ -709,8 +701,7 @@ public class WLManagerImpl
         }
         else
         {
-            getLogger().debug( "{} local discovery unsuccessful",
-                RepositoryStringUtils.getHumanizedNameString( mavenHostedRepository ) );
+            getLogger().debug( "{} local discovery unsuccessful", mavenHostedRepository );
         }
         return prefixSource;
     }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WritablePrefixSourceModifier.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/wl/internal/WritablePrefixSourceModifier.java
@@ -106,7 +106,7 @@ public class WritablePrefixSourceModifier
             {
                 if ( whitelistEntry.startsWith( normalizedEntry ) )
                 {
-                    toBeRemoved.add( normalizedEntry );
+                    toBeRemoved.add( whitelistEntry );
                     modified = true;
                 }
             }

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLMaintenanceTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLMaintenanceTest.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.proxy.maven.wl.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -167,14 +168,14 @@ public class WLMaintenanceTest
         // initially WL is empty
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 0 ) );
+            assertThat( entries, hasSize( 0 ) );
         }
 
         addSomeContent( mavenRepository, PATHS1 );
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 5 ) );
+            assertThat( entries, hasSize( 5 ) );
             assertThat(
                 entries,
                 containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
@@ -185,7 +186,7 @@ public class WLMaintenanceTest
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 6 ) );
+            assertThat( entries, hasSize( 6 ) );
             assertThat(
                 entries,
                 containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
@@ -198,7 +199,7 @@ public class WLMaintenanceTest
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 6 ) );
+            assertThat( entries, hasSize( 6 ) );
             assertThat(
                 entries,
                 containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
@@ -211,7 +212,7 @@ public class WLMaintenanceTest
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 5 ) );
+            assertThat( entries, hasSize( 5 ) );
             assertThat(
                 entries,
                 containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
@@ -224,7 +225,7 @@ public class WLMaintenanceTest
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 4 ) );
+            assertThat( entries, hasSize( 4 ) );
             assertThat(
                 entries,
                 containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLMaintenanceTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLMaintenanceTest.java
@@ -13,8 +13,8 @@
 package org.sonatype.nexus.proxy.maven.wl.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -142,7 +142,7 @@ public class WLMaintenanceTest
         for ( String path : paths )
         {
             final ResourceStoreRequest request = new ResourceStoreRequest( path );
-            mavenRepository.deleteItemWithChecksums( request );
+            mavenRepository.deleteItem( request );
         }
     }
 
@@ -177,7 +177,7 @@ public class WLMaintenanceTest
             assertThat( entries.size(), equalTo( 5 ) );
             assertThat(
                 entries,
-                hasItems( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
+                containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
                     "/org/apache", "/org/sonatype" ) );
         }
 
@@ -188,7 +188,7 @@ public class WLMaintenanceTest
             assertThat( entries.size(), equalTo( 6 ) );
             assertThat(
                 entries,
-                hasItems( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
+                containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
                     "/com/sonatype", "/org/apache", "/org/sonatype" ) );
         }
 
@@ -201,7 +201,7 @@ public class WLMaintenanceTest
             assertThat( entries.size(), equalTo( 6 ) );
             assertThat(
                 entries,
-                hasItems( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
+                containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
                     "/com/sonatype", "/org/apache", "/org/sonatype" ) );
         }
 
@@ -214,7 +214,7 @@ public class WLMaintenanceTest
             assertThat( entries.size(), equalTo( 5 ) );
             assertThat(
                 entries,
-                hasItems( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
+                containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
                     "/com/sonatype", "/org/apache" ) );
         }
 
@@ -224,11 +224,11 @@ public class WLMaintenanceTest
 
         {
             final List<String> entries = getEntriesOf( mavenRepository );
-            assertThat( entries.size(), equalTo( 5 ) );
+            assertThat( entries.size(), equalTo( 4 ) );
             assertThat(
                 entries,
-                hasItems( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
-                    "/com/sonatype", "/org/apache" ) );
+                containsInAnyOrder( "/archetype-catalog.xml", "/archetype-catalog.xml.sha1", "/archetype-catalog.xml.md5",
+                    "/org/apache" ) );
         }
     }
 }

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationContentTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationContentTest.java
@@ -1,0 +1,365 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.wl.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.After;
+import org.junit.Test;
+import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.configuration.model.CLocalStorage;
+import org.sonatype.nexus.configuration.model.CRemoteStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
+import org.sonatype.nexus.proxy.AbstractProxyTestEnvironment;
+import org.sonatype.nexus.proxy.EnvironmentBuilder;
+import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
+import org.sonatype.nexus.proxy.maven.MavenGroupRepository;
+import org.sonatype.nexus.proxy.maven.MavenRepository;
+import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepository;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.wl.PrefixSource;
+import org.sonatype.nexus.proxy.maven.wl.WLManager;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.tests.http.server.fluent.Behaviours;
+import org.sonatype.tests.http.server.fluent.Server;
+
+/**
+ * Testing group WL content on group member changes.
+ * 
+ * @author cstamas
+ */
+public class WLUpdatePropagationContentTest
+    extends AbstractWLProxyTest
+{
+    private static final String PROXY1_REPO_ID = "proxy1";
+
+    private static final String PROXY2_REPO_ID = "proxy2";
+
+    private static final String PROXY3_REPO_ID = "proxy3";
+
+    private static final String GROUP_REPO_ID = "group";
+
+    private final Server server1;
+
+    private final Server server2;
+
+    private final Server server3;
+
+    public WLUpdatePropagationContentTest()
+        throws Exception
+    {
+        this.server1 =
+            Server.withPort( 0 ).serve( "/.meta/prefixes.txt" ).withBehaviours( Behaviours.content( prefixFile1() ) );
+        this.server2 =
+            Server.withPort( 0 ).serve( "/.meta/prefixes.txt" ).withBehaviours( Behaviours.content( prefixFile2() ) );
+        this.server3 =
+            Server.withPort( 0 ).serve( "/.meta/prefixes.txt" ).withBehaviours( Behaviours.content( prefixFile3() ) );
+        server1.start();
+        server2.start();
+        server3.start();
+    }
+
+    @After
+    public void stopServers()
+        throws Exception
+    {
+        server1.stop();
+        server2.stop();
+        server3.stop();
+    }
+
+    @Override
+    protected boolean enableWLFeature()
+    {
+        return true;
+    }
+
+    protected String prefixFile1()
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter( sw );
+        pw.println( "# This is first prefix file!" );
+        pw.println( "/org/apache" );
+        return sw.toString();
+    }
+
+    protected String prefixFile2()
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter( sw );
+        pw.println( "# This is second prefix file!" );
+        pw.println( "/org/sonatype" );
+        pw.println( "/com/sonatype" );
+        return sw.toString();
+    }
+
+    protected String prefixFile3()
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter( sw );
+        pw.println( "# This is third prefix file!" );
+        pw.println( "/eu/flatwhite" );
+        return sw.toString();
+    }
+
+    @Override
+    protected EnvironmentBuilder createEnvironmentBuilder()
+        throws Exception
+    {
+        // we need one hosted repo only, so build it
+        return new EnvironmentBuilder()
+        {
+            @Override
+            public void startService()
+            {
+            }
+
+            @Override
+            public void stopService()
+            {
+            }
+
+            @Override
+            public void buildEnvironment( AbstractProxyTestEnvironment env )
+                throws ConfigurationException, IOException, ComponentLookupException
+            {
+                final PlexusContainer container = env.getPlexusContainer();
+                final List<String> reposes = new ArrayList<String>();
+                {
+                    // adding one proxy
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY1_REPO_ID );
+                    repoConf.setName( PROXY1_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY1_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server1.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding one proxy
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY2_REPO_ID );
+                    repoConf.setName( PROXY2_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY2_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server2.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding one proxy
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( PROXY3_REPO_ID );
+                    repoConf.setName( PROXY3_REPO_ID );
+                    repoConf.setNotFoundCacheActive( true );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + PROXY3_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom ex = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( ex );
+                    M2RepositoryConfiguration exConf = new M2RepositoryConfiguration( ex );
+                    exConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repoConf.setRemoteStorage( new CRemoteStorage() );
+                    repoConf.getRemoteStorage().setProvider(
+                        env.getRemoteProviderHintFactory().getDefaultHttpRoleHint() );
+                    repoConf.getRemoteStorage().setUrl( "http://localhost:" + server3.getPort() + "/" );
+                    repo.configure( repoConf );
+                    // repo.setCacheManager( env.getCacheManager() );
+                    // reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // add a group
+                    final M2GroupRepository group =
+                        (M2GroupRepository) container.lookup( GroupRepository.class, "maven2" );
+                    CRepository repoGroupConf = new DefaultCRepository();
+                    repoGroupConf.setProviderRole( GroupRepository.class.getName() );
+                    repoGroupConf.setProviderHint( "maven2" );
+                    repoGroupConf.setId( GROUP_REPO_ID );
+                    repoGroupConf.setName( GROUP_REPO_ID );
+                    repoGroupConf.setLocalStorage( new CLocalStorage() );
+                    repoGroupConf.getLocalStorage().setProvider( "file" );
+                    repoGroupConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/test" ).toURI().toURL().toString() );
+                    Xpp3Dom exGroupRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoGroupConf.setExternalConfiguration( exGroupRepo );
+                    M2GroupRepositoryConfiguration exGroupRepoConf = new M2GroupRepositoryConfiguration( exGroupRepo );
+                    exGroupRepoConf.setMemberRepositoryIds( reposes );
+                    exGroupRepoConf.setMergeMetadata( true );
+                    group.configure( repoGroupConf );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoGroupConf );
+                    env.getRepositoryRegistry().addRepository( group );
+                }
+            }
+        };
+    }
+
+    @Test
+    public void contentUponBoot()
+        throws Exception
+    {
+        final WLManager wm = lookup( WLManager.class );
+        waitForWLBackgroundUpdates();
+
+        // after boot, we should have group WL exist (as all 2 member WLs should exist)
+        // group WL should be union of the 2 proxy member WLs
+
+        final PrefixSource groupPrefixSource =
+            wm.getPrefixSourceFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenRepository.class ) );
+
+        assertThat( "Group should have WL", groupPrefixSource.exists() );
+
+        final List<String> groupEntries = groupPrefixSource.readEntries();
+        assertThat( groupEntries, hasSize( 3 ) );
+        assertThat( groupEntries, hasItem( "/com/sonatype" ) );
+        assertThat( groupEntries, hasItem( "/org/sonatype" ) );
+        assertThat( groupEntries, hasItem( "/org/apache" ) );
+    }
+
+    @Test
+    public void contentOnMemberRemoval()
+        throws Exception
+    {
+        // remove the proxy2 from group
+        getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenGroupRepository.class ).removeMemberRepositoryId(
+            PROXY2_REPO_ID );
+        getApplicationConfiguration().saveConfiguration();
+
+        final WLManager wm = lookup( WLManager.class );
+        waitForWLBackgroundUpdates();
+
+        // group WL should have only proxy1 WL
+
+        final PrefixSource groupPrefixSource =
+            wm.getPrefixSourceFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenRepository.class ) );
+
+        assertThat( "Group should have WL", groupPrefixSource.exists() );
+
+        final List<String> groupEntries = groupPrefixSource.readEntries();
+        assertThat( groupEntries, hasSize( 1 ) );
+        assertThat( groupEntries, hasItem( "/org/apache" ) );
+    }
+
+    @Test
+    public void contentOnMemberAddition()
+        throws Exception
+    {
+        // add the proxy3 to group
+        getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenGroupRepository.class ).addMemberRepositoryId(
+            PROXY3_REPO_ID );
+        getApplicationConfiguration().saveConfiguration();
+
+        final WLManager wm = lookup( WLManager.class );
+        waitForWLBackgroundUpdates();
+
+        // after member addition, we should have all 3 WLs member in group
+        // group WL should be union of the 3 proxy member WLs
+
+        final PrefixSource groupPrefixSource =
+            wm.getPrefixSourceFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenRepository.class ) );
+
+        assertThat( "Group should have WL", groupPrefixSource.exists() );
+
+        final List<String> groupEntries = groupPrefixSource.readEntries();
+        assertThat( groupEntries, hasSize( 4 ) );
+        assertThat( groupEntries, hasItem( "/com/sonatype" ) );
+        assertThat( groupEntries, hasItem( "/org/sonatype" ) );
+        assertThat( groupEntries, hasItem( "/org/apache" ) );
+        assertThat( groupEntries, hasItem( "/eu/flatwhite" ) );
+    }
+
+    @Test
+    public void contentOnMemberAdditionAndRemoval()
+        throws Exception
+    {
+        // remove the proxy2 from group
+        // add the proxy3 to group
+        getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenGroupRepository.class ).removeMemberRepositoryId(
+            PROXY2_REPO_ID );
+        getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenGroupRepository.class ).addMemberRepositoryId(
+            PROXY3_REPO_ID );
+        getApplicationConfiguration().saveConfiguration();
+
+        final WLManager wm = lookup( WLManager.class );
+        waitForWLBackgroundUpdates();
+
+        // after member additionand removal, we should have proxy1 and proxt3 WL in group
+
+        final PrefixSource groupPrefixSource =
+            wm.getPrefixSourceFor( getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenRepository.class ) );
+
+        assertThat( "Group should have WL", groupPrefixSource.exists() );
+
+        final List<String> groupEntries = groupPrefixSource.readEntries();
+        assertThat( groupEntries, hasSize( 2 ) );
+        assertThat( groupEntries, hasItem( "/org/apache" ) );
+        assertThat( groupEntries, hasItem( "/eu/flatwhite" ) );
+    }
+}

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationGroupUpdatesTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationGroupUpdatesTest.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.proxy.maven.wl.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
 
 import java.io.File;
 import java.io.IOException;
@@ -223,9 +224,16 @@ public class WLUpdatePropagationGroupUpdatesTest
         // boot already happened
         // we have 2 hosted and both are members of the group
         // as we have no WL (clean boot/kinda upgrade), all of them was 1st marked for noscrape,
-        // and then H1 and H2 got WL updated, and as side effect group WL got updated too
-        assertThat( wlUpdateListener.getPublished(),
-            containsInAnyOrder( HOSTED1_REPO_ID, HOSTED2_REPO_ID, GROUP_REPO_ID, GROUP_REPO_ID ) );
+        // and then H1 and H2 got WL updated concurrently in bg job, and as side effect group WL got updated too
+        // This means, that group might be updated once or twice, depending on concurrency.
+        // So the list might contain (in any order):
+        // HOSTED1, HOSTED2, GROUP
+        // or
+        // HOSTED1, HOSTED2, GROUP, GROUP
+        // (group two times updated).
+        assertThat( wlUpdateListener.getPublished(), hasItem( HOSTED1_REPO_ID ) );
+        assertThat( wlUpdateListener.getPublished(), hasItem( HOSTED2_REPO_ID ) );
+        assertThat( wlUpdateListener.getPublished(), hasItem( GROUP_REPO_ID ) );
     }
 
     @Test

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationGroupUpdatesTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WLUpdatePropagationGroupUpdatesTest.java
@@ -1,0 +1,250 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.wl.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+import org.sonatype.configuration.ConfigurationException;
+import org.sonatype.nexus.configuration.model.CLocalStorage;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.DefaultCRepository;
+import org.sonatype.nexus.proxy.AbstractProxyTestEnvironment;
+import org.sonatype.nexus.proxy.EnvironmentBuilder;
+import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
+import org.sonatype.nexus.proxy.maven.MavenGroupRepository;
+import org.sonatype.nexus.proxy.maven.RepositoryPolicy;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepository;
+import org.sonatype.nexus.proxy.maven.maven2.M2GroupRepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.maven2.M2Repository;
+import org.sonatype.nexus.proxy.maven.maven2.M2RepositoryConfiguration;
+import org.sonatype.nexus.proxy.maven.wl.events.WLPublishedRepositoryEvent;
+import org.sonatype.nexus.proxy.maven.wl.events.WLUnpublishedRepositoryEvent;
+import org.sonatype.nexus.proxy.repository.GroupRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+
+import com.google.common.eventbus.Subscribe;
+
+/**
+ * Testing issues NEXUS-5602 and NEXUS-5608
+ * 
+ * @author cstamas
+ */
+public class WLUpdatePropagationGroupUpdatesTest
+    extends AbstractWLProxyTest
+{
+    private static final String HOSTED1_REPO_ID = "hosted1";
+
+    private static final String HOSTED2_REPO_ID = "hosted2";
+
+    private static final String GROUP_REPO_ID = "group";
+
+    private final WLUpdateListener wlUpdateListener;
+
+    public WLUpdatePropagationGroupUpdatesTest()
+        throws Exception
+    {
+        this.wlUpdateListener = new WLUpdateListener();
+    }
+
+    protected static class WLUpdateListener
+    {
+        private final List<String> publishedIds;
+
+        private final List<String> unpublishedIds;
+
+        public WLUpdateListener()
+        {
+            this.publishedIds = new ArrayList<String>();
+            this.unpublishedIds = new ArrayList<String>();
+            reset();
+        }
+
+        @Subscribe
+        public void on( final WLPublishedRepositoryEvent evt )
+        {
+            publishedIds.add( evt.getRepository().getId() );
+        }
+
+        @Subscribe
+        public void on( final WLUnpublishedRepositoryEvent evt )
+        {
+            unpublishedIds.add( evt.getRepository().getId() );
+        }
+
+        public List<String> getPublished()
+        {
+            return publishedIds;
+        }
+
+        public List<String> getUnpublished()
+        {
+            return unpublishedIds;
+        }
+
+        public void reset()
+        {
+            publishedIds.clear();
+            unpublishedIds.clear();
+        }
+    }
+
+    protected File getStorageRoot( final String repoId )
+    {
+        return getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + repoId );
+    }
+
+    @Override
+    protected EnvironmentBuilder createEnvironmentBuilder()
+        throws Exception
+    {
+        // we need one hosted repo only, so build it
+        return new EnvironmentBuilder()
+        {
+            @Override
+            public void startService()
+            {
+            }
+
+            @Override
+            public void stopService()
+            {
+            }
+
+            @Override
+            public void buildEnvironment( AbstractProxyTestEnvironment env )
+                throws ConfigurationException, IOException, ComponentLookupException
+            {
+                final PlexusContainer container = env.getPlexusContainer();
+                final List<String> reposes = new ArrayList<String>();
+                {
+                    // adding one hosted
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( HOSTED1_REPO_ID );
+                    repoConf.setName( HOSTED1_REPO_ID );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + HOSTED1_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom exRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( exRepo );
+                    M2RepositoryConfiguration exRepoConf = new M2RepositoryConfiguration( exRepo );
+                    exRepoConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exRepoConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repo.configure( repoConf );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // adding one hosted
+                    final M2Repository repo = (M2Repository) container.lookup( Repository.class, "maven2" );
+                    CRepository repoConf = new DefaultCRepository();
+                    repoConf.setProviderRole( Repository.class.getName() );
+                    repoConf.setProviderHint( "maven2" );
+                    repoConf.setId( HOSTED2_REPO_ID );
+                    repoConf.setName( HOSTED2_REPO_ID );
+                    repoConf.setLocalStorage( new CLocalStorage() );
+                    repoConf.getLocalStorage().setProvider( "file" );
+                    repoConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/" + HOSTED2_REPO_ID ).toURI().toURL().toString() );
+                    Xpp3Dom exRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoConf.setExternalConfiguration( exRepo );
+                    M2RepositoryConfiguration exRepoConf = new M2RepositoryConfiguration( exRepo );
+                    exRepoConf.setRepositoryPolicy( RepositoryPolicy.RELEASE );
+                    exRepoConf.setChecksumPolicy( ChecksumPolicy.STRICT_IF_EXISTS );
+                    repo.configure( repoConf );
+                    reposes.add( repo.getId() );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoConf );
+                    env.getRepositoryRegistry().addRepository( repo );
+                }
+                {
+                    // add a group
+                    final M2GroupRepository group =
+                        (M2GroupRepository) container.lookup( GroupRepository.class, "maven2" );
+                    CRepository repoGroupConf = new DefaultCRepository();
+                    repoGroupConf.setProviderRole( GroupRepository.class.getName() );
+                    repoGroupConf.setProviderHint( "maven2" );
+                    repoGroupConf.setId( GROUP_REPO_ID );
+                    repoGroupConf.setName( GROUP_REPO_ID );
+                    repoGroupConf.setLocalStorage( new CLocalStorage() );
+                    repoGroupConf.getLocalStorage().setProvider( "file" );
+                    repoGroupConf.getLocalStorage().setUrl(
+                        env.getApplicationConfiguration().getWorkingDirectory( "proxy/store/test" ).toURI().toURL().toString() );
+                    Xpp3Dom exGroupRepo = new Xpp3Dom( "externalConfiguration" );
+                    repoGroupConf.setExternalConfiguration( exGroupRepo );
+                    M2GroupRepositoryConfiguration exGroupRepoConf = new M2GroupRepositoryConfiguration( exGroupRepo );
+                    exGroupRepoConf.setMemberRepositoryIds( reposes );
+                    exGroupRepoConf.setMergeMetadata( true );
+                    group.configure( repoGroupConf );
+                    env.getApplicationConfiguration().getConfigurationModel().addRepository( repoGroupConf );
+                    env.getRepositoryRegistry().addRepository( group );
+                }
+
+                // register it here BEFORE boot process starts but plx is already created
+                container.lookup( EventBus.class ).register( wlUpdateListener );
+            }
+        };
+    }
+
+    @Override
+    protected boolean enableWLFeature()
+    {
+        return true;
+    }
+
+    @Test
+    public void testUpdateCountOnBootWithoutWL()
+    {
+        // boot already happened
+        // we have 2 hosted and both are members of the group
+        // as we have no WL (clean boot/kinda upgrade), all of them was 1st marked for noscrape,
+        // and then H1 and H2 got WL updated, and as side effect group WL got updated too
+        assertThat( wlUpdateListener.getPublished(),
+            containsInAnyOrder( HOSTED1_REPO_ID, HOSTED2_REPO_ID, GROUP_REPO_ID, GROUP_REPO_ID ) );
+    }
+
+    @Test
+    public void testUpdateCountOnGroupMemberChange()
+        throws Exception
+    {
+        wlUpdateListener.reset();
+
+        final MavenGroupRepository mgr =
+            getRepositoryRegistry().getRepositoryWithFacet( GROUP_REPO_ID, MavenGroupRepository.class );
+
+        mgr.removeMemberRepositoryId( HOSTED1_REPO_ID );
+        getApplicationConfiguration().saveConfiguration();
+
+        assertThat( wlUpdateListener.getPublished(), contains( GROUP_REPO_ID ) );
+
+        mgr.addMemberRepositoryId( HOSTED1_REPO_ID );
+        getApplicationConfiguration().saveConfiguration();
+
+        assertThat( wlUpdateListener.getPublished(), contains( GROUP_REPO_ID, GROUP_REPO_ID ) );
+    }
+}

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WritablePrefixSourceModifierTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/WritablePrefixSourceModifierTest.java
@@ -153,9 +153,9 @@ public class WritablePrefixSourceModifierTest
         assertThat( "Changes were added", wesm.hasChanges() );
         assertThat( "WL would be changed", wesm.revokeEntry( "/org/apache" ) ); // child is in list
         assertThat( "Changes were adde", wesm.hasChanges() );
-        assertThat( "WL would not be changed", wesm.revokeEntry( "/org/sonatype/nexus" ) );
+        assertThat( "WL would not be changed", !wesm.revokeEntry( "/org/sonatype/nexus" ) ); // already removed by parent above
         assertThat( "No changes added yet", wesm.hasChanges() );
-        assertThat( "WL would not be changed", wesm.revokeEntry( "/org/apache/maven" ) );
+        assertThat( "WL would not be changed", !wesm.revokeEntry( "/org/apache/maven" ) ); // already removed by parent above
         assertThat( "No changes added yet", wesm.hasChanges() );
 
         // adding some
@@ -209,9 +209,9 @@ public class WritablePrefixSourceModifierTest
         assertThat( "Changes were added", wesm.hasChanges() );
         assertThat( "WL is changed", wesm.revokeEntry( "/org/apache" ) ); // child is in list
         assertThat( "Changes were added", wesm.hasChanges() );
-        assertThat( "WL would not be changed", wesm.revokeEntry( "/org/sonatype/nexus" ) );
+        assertThat( "WL would not be changed", !wesm.revokeEntry( "/org/sonatype/nexus" ) ); // already removed by parent above
         assertThat( "No changes added yet", wesm.hasChanges() );
-        assertThat( "WL would not be changed", wesm.revokeEntry( "/org/apache/maven" ) );
+        assertThat( "WL would not be changed", !wesm.revokeEntry( "/org/apache/maven" ) ); // already removed by parent above
         assertThat( "No changes added yet", wesm.hasChanges() );
 
         // adding some

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithHostedRepositoryIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/whitelist/WhitelistWithHostedRepositoryIT.java
@@ -107,6 +107,7 @@ public class WhitelistWithHostedRepositoryIT
         assertThat( exists( PREFIX_FILE_LOCATION ), is( false ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( true ) );
         whitelist().updateWhitelist( REPO_ID );
+        whitelistTest().waitForAllWhitelistUpdateJobToStop();
         assertThat( exists( PREFIX_FILE_LOCATION ), is( true ) );
         assertThat( exists( NOSCRAPE_FILE_LOCATION ), is( false ) );
     }


### PR DESCRIPTION
This pull contains fix for multiple WL related issues: two related to WL performance, one for polluting logs and one about maintaing WL for hosted reposes.

First, group WL's were double updated in some cases (like group member addition or removal). This resulted in correct results but the "wl update" operation was done twice, redundantly.

Second, on Nexus boot groups were "inited" multiple times, redundantly. The "init loop" of WL was traversing hosted and proxy reposes only, leaving group init to happen as "side effect" of cascade operation (when a repo WL changes, it cascades to all groups where repo in question is member). But this also meant, that one group WL was updated (published, event fired, but no WL content change after 1st pass) as many times as many members it had. Now, the boot process is modified, to not use "cascade" and explicitly init group repositories too.

Third, logs were polluted on boot with M1 reposes not supported by WL feature (if you had non shadow M1 reposes in your config).

Fourth, when a parent folder was deleted (parent of a WL entry for hosted repo), the WL was not properly maintained.

Related issues:
https://issues.sonatype.org/browse/NEXUS-5602
https://issues.sonatype.org/browse/NEXUS-5608
https://issues.sonatype.org/browse/NEXUS-5618
https://issues.sonatype.org/browse/NEXUS-5623

CI:
https://bamboo.zion.sonatype.com/browse/NXO-OSSF39-1
