### PR TITLE
REVIEW: Enhance password hashing

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade108to140.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/configuration/application/upgrade/Upgrade108to140.java
@@ -280,6 +280,7 @@ public class Upgrade108to140
                     "Failed to decrype anonymous password in nexus.xml, password might be encrypted in memory.", e );
             }
             securityConfig.setEnabled( oldsecurity.isEnabled() );
+            securityConfig.setHashIterations(1024);
             
             List<String> realms = oldsecurity.getRealms();
             

--- a/nexus-core/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityData204Upgrade.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/configuration/security/upgrade/SecurityData204Upgrade.java
@@ -20,9 +20,9 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.configuration.upgrade.ConfigurationIsCorruptedException;
-import org.sonatype.security.model.CRole;
-import org.sonatype.security.model.CUserRoleMapping;
-import org.sonatype.security.model.Configuration;
+import org.sonatype.security.model.v2_0_5.CRole;
+import org.sonatype.security.model.v2_0_5.CUserRoleMapping;
+import org.sonatype.security.model.v2_0_5.Configuration;
 import org.sonatype.security.model.upgrade.AbstractDataUpgrader;
 import org.sonatype.security.model.upgrade.SecurityDataUpgrader;
 

--- a/nexus-core/src/main/resources/META-INF/security/security-configuration.xml
+++ b/nexus-core/src/main/resources/META-INF/security/security-configuration.xml
@@ -13,7 +13,7 @@
 
 -->
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -22,5 +22,5 @@
     <realm>XmlAuthenticatingRealm</realm>
     <realm>XmlAuthorizingRealm</realm>
   </realms>
-  
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/main/resources/META-INF/security/security.xml
+++ b/nexus-core/src/main/resources/META-INF/security/security.xml
@@ -16,7 +16,7 @@
 <!-- Default nexus security configuration -->
 <!-- used as default config source -->
 <security>
-	<version>2.0.5</version>
+	<version>2.0.6</version>
 	<users>
 		<user>
 			<id>admin</id>

--- a/nexus-core/src/test/java/org/sonatype/nexus/jsecurity/DefaultPasswordGeneratorTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/jsecurity/DefaultPasswordGeneratorTest.java
@@ -12,6 +12,11 @@
  */
 package org.sonatype.nexus.jsecurity;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import junit.framework.Assert;
+
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusConstants;
 import org.sonatype.nexus.test.PlexusTestCaseSupport;
@@ -74,5 +79,44 @@ public class DefaultPasswordGeneratorTest
         assertFalse( newPw.equals( newEncrypted2 ) );
         assertTrue( newEncrypted.equals( newEncrypted2 ) );
         assertFalse( encrypted.equals( newEncrypted ) );
+    }
+    
+    @Test
+    public void testHashSaltedPassword()
+    	throws Exception
+    {
+    	String password = "test-password";
+    	String salt = pwGenerator.generateSalt();
+    	int hashIterations = 1024;
+    	
+    	String hash1 = pwGenerator.hashPassword(password, salt, hashIterations);
+    	String hash2 = pwGenerator.hashPassword(password, salt, hashIterations);
+    	
+    	Assert.assertEquals(hash1, hash2);
+    	
+    	String salt2 = pwGenerator.generateSalt();
+    	String hash3 = pwGenerator.hashPassword(password, salt2, hashIterations);
+    	
+    	Assert.assertFalse(hash1.equals(hash3));
+    	
+    	String hash4 = pwGenerator.hashPassword(password, salt, 1);
+    	
+    	Assert.assertFalse(hash1.equals(hash4));
+    }
+    
+    @Test
+    public void testGenerateSalt()
+    	throws Exception
+    {
+    	//Just make sure that a unique salt is generated each time generateSalt is called
+    	int iterations = 1000;
+    	Set<String> salts = new HashSet<String>();
+    	
+    	for(int x = 0; x < iterations; ++x)
+    	{
+    		salts.add(pwGenerator.generateSalt());
+    	}
+    	
+    	Assert.assertTrue(salts.size() == iterations);
     }
 }

--- a/nexus-core/src/test/java/org/sonatype/nexus/jsecurity/DefaultPasswordGeneratorTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/jsecurity/DefaultPasswordGeneratorTest.java
@@ -12,6 +12,10 @@
  */
 package org.sonatype.nexus.jsecurity;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -92,16 +96,16 @@ public class DefaultPasswordGeneratorTest
     	String hash1 = pwGenerator.hashPassword(password, salt, hashIterations);
     	String hash2 = pwGenerator.hashPassword(password, salt, hashIterations);
     	
-    	Assert.assertEquals(hash1, hash2);
+    	assertThat(hash2, is(hash1));
     	
     	String salt2 = pwGenerator.generateSalt();
     	String hash3 = pwGenerator.hashPassword(password, salt2, hashIterations);
-    	
-    	Assert.assertFalse(hash1.equals(hash3));
+
+    	assertThat(hash3, not(hash1));
     	
     	String hash4 = pwGenerator.hashPassword(password, salt, 1);
     	
-    	Assert.assertFalse(hash1.equals(hash4));
+    	assertThat(hash4, not(hash1));
     }
     
     @Test
@@ -117,6 +121,6 @@ public class DefaultPasswordGeneratorTest
     		salts.add(pwGenerator.generateSalt());
     	}
     	
-    	Assert.assertTrue(salts.size() == iterations);
+    	assertThat(salts.size(), is(iterations));
     }
 }

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/TextFilePrefixSourceMarshallerTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/wl/internal/TextFilePrefixSourceMarshallerTest.java
@@ -141,7 +141,7 @@ public class TextFilePrefixSourceMarshallerTest
         assertThat( outputStream.size(), greaterThan( 15 ) );
 
         final String output = new String( outputStream.toByteArray(), UTF8 );
-        assertThat( output, equalTo( withStandardHeaders( prefixFile1( false ) ) ) );
+        assertThat( output.replace("\r", ""), equalTo( withStandardHeaders( prefixFile1( false ) ).replace("\r", "") ) );
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TextFilePrefixSourceMarshallerTest
         // once read, the file looses "peculiarities" as dots from start and comments
         // naturally this applies to all nexus-managed files only (hosted + groups) as proxy WLs are
         // passed on as-is (unchanged)
-        assertThat( output, equalTo( withStandardHeaders( prefixFile1( false ) ) ) );
+        assertThat( output.replace("\r", ""), equalTo( withStandardHeaders( prefixFile1( false ) ).replace("\r", "") ) );
     }
 
     @Test
@@ -185,7 +185,7 @@ public class TextFilePrefixSourceMarshallerTest
         // once read, the file looses "peculiarities" as dots from start and comments
         // naturally this applies to all nexus-managed files only (hosted + groups) as proxy WLs are
         // passed on as-is (unchanged)
-        assertThat( output, equalTo( withStandardHeaders( prefixFile3( false ) ) ) );
+        assertThat( output.replace("\r", ""), equalTo( withStandardHeaders( prefixFile3( false ) ).replace("\r", "") ) );
     }
 
     @Test
@@ -207,6 +207,6 @@ public class TextFilePrefixSourceMarshallerTest
         // once read, the file looses "peculiarities" as dots from start and comments
         // naturally this applies to all nexus-managed files only (hosted + groups) as proxy WLs are
         // passed on as-is (unchanged)
-        assertThat( output, equalTo( withStandardHeaders( prefixFile4( false, true ) ) ) );
+        assertThat( output.replace("\r", ""), equalTo( withStandardHeaders( prefixFile4( false, true ) ).replace("\r", "") ) );
     }
 }

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/security-configuration-103.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-1/security-configuration-103.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/security-configuration-103.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/103-2/security-configuration-103.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/security-configuration-1710.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/nexus1710/security-configuration-1710.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -11,4 +11,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-1.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-2.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-3.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-001-3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-100.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-101.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-101.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-104.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-104.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous2</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-105.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-105.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous2</anonymousUsername>
@@ -10,4 +10,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-108.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/configuration/upgrade/security-configuration-108.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
@@ -11,4 +11,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/nexus-core/src/test/resources/org/sonatype/nexus/security/upgrade/security.result.xml
+++ b/nexus-core/src/test/resources/org/sonatype/nexus/security/upgrade/security.result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <security>
-  <version>2.0.5</version>
+  <version>2.0.6</version>
   <users>
     <user>
       <id>admin</id>

--- a/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/test-conf/security-configuration.xml
+++ b/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/test-conf/security-configuration.xml
@@ -1,5 +1,5 @@
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>false</anonymousAccessEnabled>
   <anonymousUsername>anonymous-user</anonymousUsername>
@@ -9,5 +9,5 @@
       <realm>XmlAuthenticatingRealm</realm>
       <realm>XmlAuthorizingRealm</realm>
   </realms>
-  
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/META-INF/security/security-configuration.xml
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/META-INF/security/security-configuration.xml
@@ -13,7 +13,7 @@
 
 -->
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>false</anonymousAccessEnabled>
   <anonymousUsername>anonymous-user</anonymousUsername>
@@ -22,5 +22,5 @@
     <realm>XmlAuthenticatingRealm</realm>
     <realm>XmlAuthorizingRealm</realm>
   </realms>
-  
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/org/sonatype/nexus/security/UserPrincipalsHelperTest-security-configuration.xml
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/org/sonatype/nexus/security/UserPrincipalsHelperTest-security-configuration.xml
@@ -1,5 +1,5 @@
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <anonymousAccessEnabled>true</anonymousAccessEnabled>
   <anonymousUsername>anonymous</anonymousUsername>
   <anonymousPassword>{oHoWkZPMDS8Hc3TVuAGDRGYK/NRIM/047Idl50aU19U=}</anonymousPassword>
@@ -8,4 +8,5 @@
     <realm>XmlAuthorizingRealm</realm>
   </realms>
   <securityManager>default</securityManager>
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/org/sonatype/security/web/testapp/SampleAppTest-security-configuration.xml
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/resources/org/sonatype/security/web/testapp/SampleAppTest-security-configuration.xml
@@ -13,7 +13,7 @@
 
 -->
 <security-configuration>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <enabled>true</enabled>
   <anonymousAccessEnabled>false</anonymousAccessEnabled>
   <anonymousUsername>anonymous-user</anonymousUsername>
@@ -22,5 +22,5 @@
     <realm>XmlAuthorizingRealm</realm>
     <realm>XmlAuthenticatingRealm</realm>
   </realms>
-  
+  <hashIterations>1024</hashIterations>
 </security-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <aether.version>1.13.1</aether.version>
     <jetty.version>8.1.8.v20121106</jetty.version>
     <maven.version>3.0.4</maven.version>
-    <plexus-security.version>3.0.2-SNAPSHOT</plexus-security.version>
+    <plexus-security.version>3.1-SNAPSHOT</plexus-security.version>
     <shiro.version>1.2.1</shiro.version>
     <jackson.version>1.9.10</jackson.version>
     <goodies.version>1.6</goodies.version>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <aether.version>1.13.1</aether.version>
     <jetty.version>8.1.8.v20121106</jetty.version>
     <maven.version>3.0.4</maven.version>
-    <plexus-security.version>3.0.2</plexus-security.version>
+    <plexus-security.version>3.0.2-SNAPSHOT</plexus-security.version>
     <shiro.version>1.2.1</shiro.version>
     <jackson.version>1.9.10</jackson.version>
     <goodies.version>1.6</goodies.version>


### PR DESCRIPTION
These changes are for NXCM-4361, which requested that we start salting password hashes. The bulk of the changes for this task are in sonatype/security, which has a corresponding pull request open

Salting:
Passwords are now salted prior to hashing. Salts are unique per user, per password. The salt is stored along side the password hash in security.xml. The model version of security.xml has been updated

Hashing algorithm:
Passwords are now hashed with SHA-512. Previously, passwords were hashed with SHA-1. The credentials matcher is backwards compatible with SHA-1 and MD5 hashes

Key Stretching:
The hashing algorithm is now applied N times, where N is defined in security-configuration.xml, in the new hashIterations element. The model version of security-configuration.xml has been updated.

Upgrading legacy users:
In order to convert old SHA-1 password hashes, we must wait for the user to login. When they do, we detect that their password hash is old, generate a unique salt, and regenerate a SHA-512 hash
