### PR TITLE
[NXCM-5131] Change item age value type from Integer to int

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-model/src/main/mdo/vos.xml
+++ b/plugins/restlet1x/nexus-restlet1x-model/src/main/mdo/vos.xml
@@ -958,7 +958,7 @@
         <field>
           <name>itemMaxAge</name>
           <version>1.0.0+</version>
-          <type>Integer</type>
+          <type>int</type>
           <required>false</required>
           <description>The max age of items (not artifact not metadata) before we will check remote again for updated (in minutes, -1 for never).</description>
         </field>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryListPlexusResource.java
@@ -304,10 +304,7 @@ public class RepositoryListPlexusResource
 
         exConf.setMetadataMaxAge( model.getMetadataMaxAge() );
 
-        if ( model.getItemMaxAge() != null )
-        {
-            exConf.setItemMaxAge( model.getItemMaxAge() );
-        }
+        exConf.setItemMaxAge( model.getItemMaxAge() );
 
         // set auto block
         exConf.setAutoBlockActive( model.isAutoBlockActive() );

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
@@ -292,10 +292,7 @@ public class RepositoryPlexusResource
 
                                 pRepository.setMetadataMaxAge( proxyModel.getMetadataMaxAge() );
 
-                                if ( proxyModel.getItemMaxAge() != null )
-                                {
-                                    pRepository.setItemMaxAge( proxyModel.getItemMaxAge() );
-                                }
+                                pRepository.setItemMaxAge( proxyModel.getItemMaxAge() );
                             }
                         }
                         else
@@ -320,7 +317,7 @@ public class RepositoryPlexusResource
                                 {
                                     metadataMethod.invoke( repository, proxyModel.getMetadataMaxAge() );
                                 }
-                                if ( itemMethod != null && proxyModel.getItemMaxAge() != null)
+                                if ( itemMethod != null )
                                 {
                                     itemMethod.invoke( repository, proxyModel.getItemMaxAge() );
                                 }

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/repositories/RepositoryCreateUpdateTest.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/repositories/RepositoryCreateUpdateTest.java
@@ -76,7 +76,7 @@ public class RepositoryCreateUpdateTest
         Assert.assertEquals( "maven2", result.getFormat() );
         Assert.assertEquals( false, result.isIndexable() );
         Assert.assertEquals( 23, result.getMetadataMaxAge() );
-        Assert.assertEquals( Integer.valueOf( 234 ), result.getItemMaxAge() );
+        Assert.assertEquals( 234, result.getItemMaxAge() );
         Assert.assertEquals( "test-name", result.getName() );
         Assert.assertEquals( 11, result.getNotFoundCacheTTL() );
         Assert.assertEquals( "maven2", result.getProvider() );
@@ -180,7 +180,7 @@ public class RepositoryCreateUpdateTest
         Assert.assertEquals( "maven2", result.getFormat() );
         Assert.assertEquals( false, result.isIndexable() );
         Assert.assertEquals( 23, result.getMetadataMaxAge() );
-        Assert.assertEquals( Integer.valueOf( 234 ), result.getItemMaxAge() );
+        Assert.assertEquals( 234, result.getItemMaxAge() );
         Assert.assertEquals( "test-name", result.getName() );
         Assert.assertEquals( 11, result.getNotFoundCacheTTL() );
         Assert.assertEquals( "maven2", result.getProvider() );


### PR DESCRIPTION
The problem is that NuGet is not configuring these values at all. The default value for an int while serializing is `0`, default value for Integer is `null` which explains the different values for the age configuration in the UI. (0<>'empty value').

https://bamboo.zion.sonatype.com/browse/NXO-OSSF14-1
