### PR TITLE
[NXCM-5131] Fix itemMaxAge settings for non-maven repositories

### DIFF
--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.client.core.subsystem.repository;
 
 /**

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
@@ -3,7 +3,7 @@ package org.sonatype.nexus.client.core.subsystem.repository;
 /**
  * Base class for hosted/proxy repositories.
  *
- * @since 2.4
+ * @since 2.5
  */
 interface BaseRepository<T extends Repository, S extends RepositoryStatus>
     extends Repository<T, S>

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/BaseRepository.java
@@ -1,0 +1,30 @@
+package org.sonatype.nexus.client.core.subsystem.repository;
+
+/**
+ * Base class for hosted/proxy repositories.
+ *
+ * @since 2.4
+ */
+interface BaseRepository<T extends Repository, S extends RepositoryStatus>
+    extends Repository<T, S>
+{
+
+    /**
+     * Enable browsing (see content of repository)
+     *
+     * @return itself, for fluent api usage
+     */
+    T enableBrowsing();
+
+    /**
+     * Disable browsing (see content of repository).
+     *
+     * @return itself, for fluent api usage
+     */
+    T disableBrowsing();
+
+    /**
+     * @return {@code true} if browsing is allowed for this repository, {@code false} otherwise.
+     */
+    boolean isBrowsable();
+}

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/HostedRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/HostedRepository.java
@@ -18,7 +18,7 @@ package org.sonatype.nexus.client.core.subsystem.repository;
  * @since 2.3
  */
 public interface HostedRepository<T extends HostedRepository>
-    extends Repository<T, RepositoryStatus>
+    extends BaseRepository<T, RepositoryStatus>
 {
 
     T withRepoPolicy( final String policy );
@@ -43,19 +43,5 @@ public interface HostedRepository<T extends HostedRepository>
      * @return itself, for fluent api usage
      */
     T disableRedeploy();
-
-    /**
-     * Enable browsing (see content of repository)
-     *
-     * @return itself, for fluent api usage
-     */
-    T enableBrowsing();
-
-    /**
-     * Disable browsing (see content of repository).
-     *
-     * @return itself, for fluent api usage
-     */
-    T disableBrowsing();
 
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/ProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/ProxyRepository.java
@@ -58,7 +58,7 @@ public interface ProxyRepository<T extends ProxyRepository>
 
     /**
      * @return {@code true} if auto-blocking is enabled, {@code false} otherwise.
-     * @since 2.4
+     * @since 2.5
      */
     boolean isAutoBlocking();
 
@@ -94,7 +94,7 @@ public interface ProxyRepository<T extends ProxyRepository>
 
     /**
      * @return the repository's max item age.
-     * @since 2.4
+     * @since 2.5
      */
     int itemMaxAge();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/ProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/ProxyRepository.java
@@ -18,7 +18,7 @@ package org.sonatype.nexus.client.core.subsystem.repository;
  * @since 2.3
  */
 public interface ProxyRepository<T extends ProxyRepository>
-    extends Repository<T, ProxyRepositoryStatus>
+    extends BaseRepository<T, ProxyRepositoryStatus>
 {
 
     /**
@@ -57,6 +57,12 @@ public interface ProxyRepository<T extends ProxyRepository>
     T doNotAutoBlock();
 
     /**
+     * @return {@code true} if auto-blocking is enabled, {@code false} otherwise.
+     * @since 2.4
+     */
+    boolean isAutoBlocking();
+
+    /**
      * Directly blocks the repository (no save required).
      *
      * @return itself, for fluent api usage
@@ -86,4 +92,9 @@ public interface ProxyRepository<T extends ProxyRepository>
      */
     T withItemMaxAge( int minutes );
 
+    /**
+     * @return the repository's max item age.
+     * @since 2.4
+     */
+    int itemMaxAge();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/Repository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/Repository.java
@@ -83,4 +83,9 @@ public interface Repository<T extends Repository, U extends RepositoryStatus>
      */
     T remove();
 
+    /**
+     * @return {@code true} if the repository is exposed, {@code false} otherwise.
+     * @since 2.4
+     */
+    boolean isExposed();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/Repository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/Repository.java
@@ -85,7 +85,7 @@ public interface Repository<T extends Repository, U extends RepositoryStatus>
 
     /**
      * @return {@code true} if the repository is exposed, {@code false} otherwise.
-     * @since 2.4
+     * @since 2.5
      */
     boolean isExposed();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/maven/MavenProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/maven/MavenProxyRepository.java
@@ -54,4 +54,16 @@ public interface MavenProxyRepository
      */
     MavenProxyRepository doNotDownloadRemoteIndexes();
 
+
+    /**
+     * @return the repository's max artifact age.
+     * @since 2.4
+     */
+    int artifactMaxAge();
+
+    /**
+     * @return the repository's max metadata age.
+     * @since 2.4
+     */
+    int metadataMaxAge();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/maven/MavenProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/core/subsystem/repository/maven/MavenProxyRepository.java
@@ -57,13 +57,13 @@ public interface MavenProxyRepository
 
     /**
      * @return the repository's max artifact age.
-     * @since 2.4
+     * @since 2.5
      */
     int artifactMaxAge();
 
     /**
      * @return the repository's max metadata age.
-     * @since 2.4
+     * @since 2.5
      */
     int metadataMaxAge();
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyHostedRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyHostedRepository.java
@@ -104,4 +104,9 @@ public class JerseyHostedRepository<T extends HostedRepository>
         return me();
     }
 
+    @Override
+    public boolean isBrowsable()
+    {
+        return settings().isBrowseable();
+    }
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyProxyRepository.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.client.internal.rest.jersey.subsystem.repository;
 
 import org.sonatype.nexus.client.core.subsystem.repository.ProxyRepository;
 import org.sonatype.nexus.client.core.subsystem.repository.ProxyRepositoryStatus;
+import org.sonatype.nexus.client.core.subsystem.repository.Repository;
 import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
 import org.sonatype.nexus.rest.model.RepositoryProxyResource;
 import org.sonatype.nexus.rest.model.RepositoryResourceRemoteStorage;
@@ -133,6 +134,12 @@ public class JerseyProxyRepository<T extends ProxyRepository>
     }
 
     @Override
+    public int itemMaxAge()
+    {
+        return settings().getItemMaxAge();
+    }
+
+    @Override
     public T autoBlock()
     {
         settings().setAutoBlockActive( true );
@@ -144,6 +151,12 @@ public class JerseyProxyRepository<T extends ProxyRepository>
     {
         settings().setAutoBlockActive( false );
         return me();
+    }
+
+    @Override
+    public boolean isAutoBlocking()
+    {
+        return settings().isAutoBlockActive();
     }
 
     @Override
@@ -164,4 +177,23 @@ public class JerseyProxyRepository<T extends ProxyRepository>
         return me();
     }
 
+    @Override
+    public T enableBrowsing()
+    {
+        settings().setBrowseable( true );
+        return me();
+    }
+
+    @Override
+    public T disableBrowsing()
+    {
+        settings().setBrowseable( false );
+        return me();
+    }
+
+    @Override
+    public boolean isBrowsable()
+    {
+        return settings().isBrowseable();
+    }
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/JerseyRepository.java
@@ -322,4 +322,8 @@ public abstract class JerseyRepository<T extends Repository, S extends Repositor
         }
     }
 
+    public boolean isExposed() {
+        return settings().isExposed();
+    }
+
 }

--- a/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/maven/JerseyMavenProxyRepository.java
+++ b/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/jersey/subsystem/repository/maven/JerseyMavenProxyRepository.java
@@ -84,4 +84,16 @@ public class JerseyMavenProxyRepository
         return me();
     }
 
+    @Override
+    public int artifactMaxAge()
+    {
+        return settings().getArtifactMaxAge();
+    }
+
+    @Override
+    public int metadataMaxAge()
+    {
+        return settings().getMetadataMaxAge();
+    }
+
 }

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/AbstractRepositoryPlexusResource.java
@@ -392,21 +392,25 @@ public abstract class AbstractRepositoryPlexusResource
             // This is a total hack to be able to retrieve this data from a non core repo if available
             try
             {
-                Method artifactMethod = repository.getClass().getMethod( "getArtifactMaxAge", new Class<?>[0] );
-                Method metadataMethod = repository.getClass().getMethod( "getMetadataMaxAge", new Class<?>[0] );
-                Method itemMethod = repository.getClass().getMethod( "getItemMaxAge", new Class<?>[0] );
 
+                // NXCM-5131 Ask for itemMaxAge first, because it's already introduced in AbstractProxyRepository and
+                // may be a superclass for non-maven repositories (e.g. NuGet)
+                Method itemMethod = repository.getClass().getMethod( "getItemMaxAge", new Class<?>[0] );
+                if ( itemMethod != null )
+                {
+                    resource.setItemMaxAge( (Integer) itemMethod.invoke( repository, new Object[0] ) );
+                }
+
+                Method artifactMethod = repository.getClass().getMethod( "getArtifactMaxAge", new Class<?>[0] );
                 if ( artifactMethod != null )
                 {
                     resource.setArtifactMaxAge( (Integer) artifactMethod.invoke( repository, new Object[0] ) );
                 }
+
+                Method metadataMethod = repository.getClass().getMethod( "getMetadataMaxAge", new Class<?>[0] );
                 if ( metadataMethod != null )
                 {
                     resource.setMetadataMaxAge( (Integer) metadataMethod.invoke( repository, new Object[0] ) );
-                }
-                if ( itemMethod != null )
-                {
-                    resource.setItemMaxAge( (Integer) itemMethod.invoke( repository, new Object[0] ) );
                 }
             }
             catch ( Exception e )

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/repositories/RepositoryPlexusResource.java
@@ -303,26 +303,29 @@ public class RepositoryPlexusResource
                             // This is a total hack to be able to retrieve this data from a non core repo if available
                             try
                             {
-                                Method artifactMethod =
-                                    repository.getClass().getMethod( "setArtifactMaxAge", int.class );
-                                Method metadataMethod =
-                                    repository.getClass().getMethod( "setMetadataMaxAge", int.class );
-                                Method itemMethod =
-                                    repository.getClass().getMethod( "setItemMaxAge", int.class );
-
                                 RepositoryProxyResource proxyModel = (RepositoryProxyResource) model;
 
+                                // NXCM-5131 Ask for itemMaxAge first, because it's already introduced in AbstractProxyRepository and
+                                // may be a superclass for non-maven repositories (e.g. NuGet)
+                                Method itemMethod =
+                                    repository.getClass().getMethod( "setItemMaxAge", int.class );
+                                if ( itemMethod != null && proxyModel.getItemMaxAge() != null)
+                                {
+                                    itemMethod.invoke( repository, proxyModel.getItemMaxAge() );
+                                }
+
+                                Method artifactMethod =
+                                    repository.getClass().getMethod( "setArtifactMaxAge", int.class );
                                 if ( artifactMethod != null )
                                 {
                                     artifactMethod.invoke( repository, proxyModel.getArtifactMaxAge() );
                                 }
+
+                                Method metadataMethod =
+                                    repository.getClass().getMethod( "setMetadataMaxAge", int.class );
                                 if ( metadataMethod != null )
                                 {
                                     metadataMethod.invoke( repository, proxyModel.getMetadataMaxAge() );
-                                }
-                                if ( itemMethod != null && proxyModel.getItemMaxAge() != null)
-                                {
-                                    itemMethod.invoke( repository, proxyModel.getItemMaxAge() );
                                 }
                             }
                             catch ( Exception e )

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-restlet1x-parent</artifactId>
+    <version>2.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-restlet1x-testsuite</artifactId>
+
+  <dependencyManagement>
+
+    <dependencies>
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
+        <version>${project.version}</version>
+        <classifier>bundle</classifier>
+        <type>nexus-plugin</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-testsuite-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus.client</groupId>
+      <artifactId>nexus-client-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${it.nexus.bundle.groupId}</groupId>
+      <artifactId>${it.nexus.bundle.artifactId}</artifactId>
+      <version>${it.nexus.bundle.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+      <classifier>bundle</classifier>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-restlet1x-parent</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-restlet1x-testsuite</artifactId>

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2012 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/pom.xml
@@ -24,19 +24,6 @@
 
   <artifactId>nexus-restlet1x-testsuite</artifactId>
 
-  <dependencyManagement>
-
-    <dependencies>
-      <dependency>
-        <groupId>org.sonatype.nexus.plugins</groupId>
-        <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
-        <version>${project.version}</version>
-        <classifier>bundle</classifier>
-        <type>nexus-plugin</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.sonatype.nexus</groupId>
@@ -48,13 +35,8 @@
     </dependency>
 
     <dependency>
-      <groupId>${it.nexus.bundle.groupId}</groupId>
-      <artifactId>${it.nexus.bundle.artifactId}</artifactId>
-      <version>${it.nexus.bundle.version}</version>
-      <scope>test</scope>
-      <type>zip</type>
-      <classifier>bundle</classifier>
+      <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
     </dependency>
-
   </dependencies>
 </project>

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Nxcm5131DefaultValuesOnRepoCreationIT.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Nxcm5131DefaultValuesOnRepoCreationIT.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.restlet1x.testsuite;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Nxcm5131DefaultValuesOnRepoCreationIT.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Nxcm5131DefaultValuesOnRepoCreationIT.java
@@ -1,0 +1,130 @@
+package org.sonatype.nexus.restlet1x.testsuite;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.sonatype.nexus.testsuite.support.ParametersLoaders.systemTestParameters;
+import static org.sonatype.nexus.testsuite.support.ParametersLoaders.testParameters;
+
+import com.sun.jersey.api.client.UniformInterfaceException;
+import org.junit.Test;
+import org.sonatype.nexus.client.core.subsystem.repository.ProxyRepository;
+import org.sonatype.nexus.client.core.subsystem.repository.maven.MavenProxyRepository;
+import org.sonatype.nexus.client.internal.msg.ErrorMessage;
+import org.sonatype.nexus.client.internal.msg.ErrorResponse;
+import org.sonatype.nexus.client.rest.jersey.JerseyNexusClient;
+import org.sonatype.nexus.rest.model.RepositoryBaseResource;
+import org.sonatype.nexus.rest.model.RepositoryProxyResource;
+import org.sonatype.nexus.rest.model.RepositoryResourceRemoteStorage;
+import org.sonatype.nexus.rest.model.RepositoryResourceResponse;
+import org.sonatype.nexus.testsuite.support.NexusStartAndStopStrategy;
+
+/**
+ * Verify that default values are applied when a new repository is created with only the mandatory parameters.
+ */
+@NexusStartAndStopStrategy( NexusStartAndStopStrategy.Strategy.EACH_TEST )
+public class Nxcm5131DefaultValuesOnRepoCreationIT
+    extends Restlet1xITSupport
+{
+
+    public Nxcm5131DefaultValuesOnRepoCreationIT( final String nexusBundleCoordinates )
+    {
+        super( nexusBundleCoordinates );
+    }
+
+    @Test
+    public void createMaven2RepoWithDefaultValues()
+    {
+        final String id = uniqueName( "nxcm5131-m2" );
+
+        doCreateMaven2Repo( id );
+
+        MavenProxyRepository repository = repositories().get( id );
+
+        assertThat( repository.id(), is( id ) );
+        assertThat( repository.name(), is( id ) );
+
+        assertThat( repository.itemMaxAge(), is( 1440 ) );
+        assertThat( repository.artifactMaxAge(), is( 0 ) );
+        assertThat( repository.metadataMaxAge(), is( 0 ) );
+
+        assertThat( repository.isExposed(), is( false ) );
+        assertThat( repository.isBrowsable(), is( false ) );
+        assertThat( repository.isAutoBlocking(), is( true ) );
+    }
+
+    @Test
+    public void createNonMaven2RepoWithDefaultValues(){
+        final String id = uniqueName( "nxcm5131" );
+
+        doCreateNxcm5131Repo( id );
+
+        ProxyRepository repository = repositories().get( id );
+
+        assertThat( repository.id(), is( id ) );
+        assertThat( repository.name(), is( id ) );
+
+        assertThat( repository.itemMaxAge(), is( 1440 ) );
+
+        assertThat( repository.isExposed(), is( false ) );
+        assertThat( repository.isAutoBlocking(), is( true ) );
+    }
+
+    private void doCreateNxcm5131Repo( final String id )
+    {
+        final RepositoryResourceResponse request = new RepositoryResourceResponse();
+        final RepositoryProxyResource repo = new RepositoryProxyResource();
+        repo.setId( id );
+        repo.setFormat( "nxcm5131" );
+        repo.setRepoType( "proxy" );
+        repo.setRepoPolicy( "MIXED" );
+        repo.setChecksumPolicy( "IGNORE" );
+        repo.setProvider( "nxcm5131" );
+        repo.setProviderRole( "org.sonatype.nexus.proxy.repository.Repository" );
+        final RepositoryResourceRemoteStorage remoteStorage = new RepositoryResourceRemoteStorage();
+        remoteStorage.setRemoteStorageUrl( "http://obvious.fake/url" );
+        repo.setRemoteStorage( remoteStorage );
+        request.setData( repo );
+
+        doCreateRepo( request );
+    }
+
+    private void doCreateMaven2Repo( final String id )
+    {
+        final RepositoryResourceResponse request = new RepositoryResourceResponse();
+        final RepositoryProxyResource repo = new RepositoryProxyResource();
+        repo.setId( id );
+        repo.setFormat( "maven2" );
+        repo.setRepoType( "proxy" );
+        repo.setRepoPolicy( "RELEASE" );
+        repo.setChecksumPolicy( "IGNORE" );
+        repo.setProvider( "maven2" );
+        repo.setProviderRole( "org.sonatype.nexus.proxy.repository.Repository" );
+        final RepositoryResourceRemoteStorage remoteStorage = new RepositoryResourceRemoteStorage();
+        remoteStorage.setRemoteStorageUrl( "http://obvious.fake/url" );
+        repo.setRemoteStorage( remoteStorage );
+        request.setData( repo );
+
+        doCreateRepo( request );
+    }
+
+    private void doCreateRepo( final RepositoryResourceResponse request )
+    {
+        try
+        {
+            final RepositoryBaseResource response = ( (JerseyNexusClient) client() )
+                .serviceResource( "repositories" )
+                .post( RepositoryResourceResponse.class, request )
+                .getData();
+        }
+        catch ( UniformInterfaceException e )
+        {
+            final ErrorResponse response = e.getResponse().getEntity( ErrorResponse.class );
+            for ( ErrorMessage message : response.getErrors() )
+            {
+                System.err.println( message.getId() + ": " + message.getMsg() );
+            }
+            throw e;
+        }
+    }
+
+}

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Restlet1xITSupport.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Restlet1xITSupport.java
@@ -1,0 +1,55 @@
+package org.sonatype.nexus.restlet1x.testsuite;
+
+import static org.sonatype.nexus.testsuite.support.ParametersLoaders.firstAvailableTestParameters;
+import static org.sonatype.nexus.testsuite.support.ParametersLoaders.systemTestParameters;
+import static org.sonatype.nexus.testsuite.support.ParametersLoaders.testParameters;
+import static org.sonatype.sisu.goodies.common.Varargs.$;
+
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+
+import org.junit.runners.Parameterized;
+import org.sonatype.nexus.bundle.launcher.NexusBundleConfiguration;
+import org.sonatype.nexus.client.core.subsystem.repository.Repositories;
+import org.sonatype.nexus.testsuite.support.NexusRunningParametrizedITSupport;
+
+public class Restlet1xITSupport
+    extends NexusRunningParametrizedITSupport
+{
+
+    public Restlet1xITSupport( final String nexusBundleCoordinates )
+    {
+        super( nexusBundleCoordinates );
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data()
+    {
+        return firstAvailableTestParameters(
+            systemTestParameters(),
+            testParameters(
+                $( "${it.nexus.bundle.groupId}:${it.nexus.bundle.artifactId}:zip:bundle" )
+            )
+        ).load();
+    }
+
+    public static String uniqueName( final String prefix )
+    {
+        return prefix + "-" + new SimpleDateFormat( "yyyyMMdd-HHmmss-SSS" ).format( new Date() );
+    }
+
+    @Override
+    protected NexusBundleConfiguration configureNexus( final NexusBundleConfiguration configuration )
+    {
+        configuration.addPlugins( artifactResolver().resolvePluginFromDependencyManagement(
+                "org.sonatype.nexus.plugins", "nexus-restlet1x-testsupport-plugin" ) );
+
+        return configuration;
+    }
+
+    public Repositories repositories()
+    {
+        return client().getSubsystem( Repositories.class );
+    }
+}

--- a/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Restlet1xITSupport.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsuite/src/test/java/org/sonatype/nexus/restlet1x/testsuite/Restlet1xITSupport.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.restlet1x.testsuite;
 
 import static org.sonatype.nexus.testsuite.support.ParametersLoaders.firstAvailableTestParameters;

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-restlet1x-parent</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/pom.xml
@@ -1,0 +1,63 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2007-2012 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-restlet1x-parent</artifactId>
+    <version>2.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
+  <packaging>nexus-plugin</packaging>
+
+  <properties>
+    <pluginName>Nexus Restlet 1.x Test Support Plugin</pluginName>
+    <pluginDescription>Provides helpers for the restlet1x testsuite.</pluginDescription>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-restlet1x-model</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.nexus</groupId>
+        <artifactId>nexus-plugin-bundle-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131HostedRepository.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131HostedRepository.java
@@ -1,0 +1,12 @@
+package org.sonatype.nexus.restlet1x.nxcm5131;
+
+import org.sonatype.nexus.proxy.repository.HostedRepository;
+
+/**
+ * NXCM5131 hosted repository kind
+ */
+public interface Nxcm5131HostedRepository
+    extends HostedRepository
+{
+
+}

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131HostedRepository.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131HostedRepository.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.restlet1x.nxcm5131;
 
 import org.sonatype.nexus.proxy.repository.HostedRepository;

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131ProxyRepository.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131ProxyRepository.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.restlet1x.nxcm5131;
 
 import javax.inject.Inject;

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131ProxyRepository.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131ProxyRepository.java
@@ -1,0 +1,80 @@
+package org.sonatype.nexus.restlet1x.nxcm5131;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.sonatype.nexus.configuration.Configurator;
+import org.sonatype.nexus.configuration.model.CRepository;
+import org.sonatype.nexus.configuration.model.CRepositoryExternalConfigurationHolderFactory;
+import org.sonatype.nexus.proxy.registry.AbstractIdContentClass;
+import org.sonatype.nexus.proxy.registry.ContentClass;
+import org.sonatype.nexus.proxy.repository.AbstractProxyRepository;
+import org.sonatype.nexus.proxy.repository.AbstractProxyRepositoryConfiguration;
+import org.sonatype.nexus.proxy.repository.DefaultRepositoryKind;
+import org.sonatype.nexus.proxy.repository.MutableProxyRepositoryKind;
+import org.sonatype.nexus.proxy.repository.ProxyRepository;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.repository.RepositoryKind;
+
+/**
+ * A proxy repository extending AbstractProxyRepository and using the maven external configuration,
+ * but with a different facet.
+ */
+@Named("nxcm5131")
+public class Nxcm5131ProxyRepository
+    extends AbstractProxyRepository
+    implements Repository, Nxcm5131HostedRepository, ProxyRepository
+{
+
+    private final RepositoryKind repositoryKind =
+        new MutableProxyRepositoryKind( this, null, new DefaultRepositoryKind( Nxcm5131HostedRepository.class, null ),
+                                        new DefaultRepositoryKind( Nxcm5131ProxyRepository.class, null ) );
+    private final Nxcm5131RepositoryConfigurator configurator;
+
+    @Inject
+    public Nxcm5131ProxyRepository( final Nxcm5131RepositoryConfigurator configurator )
+    {
+        this.configurator = configurator;
+    }
+
+    @Override
+    protected Configurator getConfigurator()
+    {
+        return configurator;
+    }
+
+    @Override
+    protected CRepositoryExternalConfigurationHolderFactory<?> getExternalConfigurationHolderFactory()
+    {
+        return new CRepositoryExternalConfigurationHolderFactory<AbstractProxyRepositoryConfiguration>()
+        {
+            @Override
+            public AbstractProxyRepositoryConfiguration createExternalConfigurationHolder( final CRepository config )
+            {
+                return new AbstractProxyRepositoryConfiguration( (Xpp3Dom) config.getExternalConfiguration() )
+                {
+                };
+            }
+        };
+    }
+
+    @Override
+    public RepositoryKind getRepositoryKind()
+    {
+        return repositoryKind;
+    }
+
+    @Override
+    public ContentClass getRepositoryContentClass()
+    {
+        return new AbstractIdContentClass()
+        {
+            @Override
+            public String getId()
+            {
+                return "nxcm5131";
+            }
+        };
+    }
+}

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131RepositoryConfigurator.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131RepositoryConfigurator.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.restlet1x.nxcm5131;
 
 import javax.inject.Named;

--- a/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131RepositoryConfigurator.java
+++ b/plugins/restlet1x/nexus-restlet1x-testsupport-plugin/src/main/java/org/sonatype/nexus/restlet1x/nxcm5131/Nxcm5131RepositoryConfigurator.java
@@ -1,0 +1,12 @@
+package org.sonatype.nexus.restlet1x.nxcm5131;
+
+import javax.inject.Named;
+
+import org.sonatype.nexus.proxy.repository.AbstractProxyRepositoryConfigurator;
+
+@Named
+public class Nxcm5131RepositoryConfigurator
+    extends AbstractProxyRepositoryConfigurator
+{
+
+}

--- a/plugins/restlet1x/pom.xml
+++ b/plugins/restlet1x/pom.xml
@@ -159,6 +159,8 @@
   <modules>
     <module>nexus-restlet1x-model</module>
     <module>nexus-restlet1x-plugin</module>
+    <module>nexus-restlet1x-testsuite</module>
+    <module>nexus-restlet1x-testsupport-plugin</module>
   </modules>
 
 </project>

--- a/plugins/restlet1x/pom.xml
+++ b/plugins/restlet1x/pom.xml
@@ -153,6 +153,20 @@
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
+        <version>${nexus.version}</version>
+        <classifier>bundle</classifier>
+        <type>${nexus-plugin.type}</type>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-restlet1x-testsupport-plugin</artifactId>
+        <version>${nexus.version}</version>
+      </dependency>
+
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This pull reverts the initial change for NXCM-5131, because it affected behavior of non-maven-repositories inheriting from AbstractProxyRepository. instead of the implicit default of itemMaxAge (1440 minutes), 0 would be used instead.

With this change, the repository resource sets itemMaxAge for repositories that do not have the maven-specific artifact/metadataMaxAge.
