### PR TITLE
REVIEW: NEXUS-5602: Using the periodic update thread for initial updates too

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/EventDispatcher.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/EventDispatcher.java
@@ -58,19 +58,15 @@ public class EventDispatcher
 
     private final Manager wlManager;
 
-    private final boolean active;
-
     /**
      * Da constructor.
      * 
      * @param wlManager
-     * @param active
      */
-    public EventDispatcher( final Manager wlManager, final boolean active )
+    public EventDispatcher( final Manager wlManager )
     {
         this.logger = LoggerFactory.getLogger( getClass() );
         this.wlManager = checkNotNull( wlManager );
-        this.active = active;
     }
 
     protected Logger getLogger()
@@ -156,11 +152,6 @@ public class EventDispatcher
 
     // == Filters
 
-    protected boolean isActive()
-    {
-        return active;
-    }
-
     protected boolean isRequestContextMarked( final RequestContext context )
     {
         return context.containsKey( Manager.ROUTING_INITIATED_FILE_OPERATION_FLAG_KEY );
@@ -168,10 +159,9 @@ public class EventDispatcher
 
     protected boolean isRepositoryHandled( final Repository repository )
     {
-        // we handle repository events after this isActive, is not out of service, and only for non-shadow repository
+        // we handle repository events if repo is not out of service, and only for non-shadow repository
         // that are Maven2 reposes
-        return isActive() && repository != null
-            && repository.getRepositoryKind().isFacetAvailable( MavenRepository.class )
+        return repository != null && repository.getRepositoryKind().isFacetAvailable( MavenRepository.class )
             && !repository.getRepositoryKind().isFacetAvailable( ShadowRepository.class )
             && Maven2ContentClass.ID.equals( repository.getRepositoryContentClass().getId() );
     }

--- a/nexus-test/nexus-core-testsuite/src/test/java/core/routing/DisabledSmokeIT.java
+++ b/nexus-test/nexus-core-testsuite/src/test/java/core/routing/DisabledSmokeIT.java
@@ -76,6 +76,7 @@ public class DisabledSmokeIT
         // public
         final Status publicStatus = routing().getStatus( "public" );
         assertThat( publicStatus.getPublishedStatus(), equalTo( Outcome.FAILED ) );
+        assertThat( publicStatus.getDiscoveryStatus(), is( nullValue() ) );
     }
 
     @Test
@@ -83,7 +84,7 @@ public class DisabledSmokeIT
     {
         // releases
         final Status releasesStatus = routing().getStatus( "releases" );
-        assertThat( releasesStatus.getPublishedStatus(), equalTo( Outcome.SUCCEEDED ) );
+        assertThat( releasesStatus.getPublishedStatus(), equalTo( Outcome.FAILED ) );
         assertThat( releasesStatus.getDiscoveryStatus(), is( nullValue() ) );
     }
 


### PR DESCRIPTION
On 1st boot of updated instances, a lot of MavenRepository
instances (hosted and proxy) will be piled up in the array
needUpdateRepositories in WLManagerImpl#startup().

Currently, as the thread pool with fixed size of 5 and
blocking queue was deferring update.

With this change, the for-loop doing initial WL build
(walk of the content for hosted and discovery for proxies)
is deferred, and periodic updater thread is used.

This also means, that upon boot, the initial delay of
first run will be applied, and on that moment on, hosted
reposes will have WL, not before that.
