### PR TITLE
[2.5] NEXUS-5658: timeline plugin does not honour lucene.fsdirectory.type property

### DIFF
--- a/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
+++ b/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
@@ -15,6 +15,7 @@ package org.sonatype.timeline.internal;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -187,8 +188,8 @@ public class DefaultTimeline
     }
 
     @Override
-    public void retrieve( int fromItem, int count, Set<String> types, Set<String> subTypes, TimelineFilter
-        filter, TimelineCallback callback )
+    public void retrieve( int fromItem, int count, Set<String> types, Set<String> subTypes, TimelineFilter filter,
+                          TimelineCallback callback )
     {
         if ( !started )
         {
@@ -199,7 +200,7 @@ public class DefaultTimeline
 
     @Override
     public void retrieve( long fromTime, long toTime, int from, int count, Set<String> types, Set<String> subTypes,
-        TimelineFilter filter, TimelineCallback callback )
+                          TimelineFilter filter, TimelineCallback callback )
     {
         if ( !started )
         {
@@ -225,7 +226,7 @@ public class DefaultTimeline
     }
 
     protected int purgeFromIndexer( final long timestamp, final Set<String> types, final Set<String> subTypes,
-        final TimelineFilter filter )
+                                    final TimelineFilter filter )
     {
         return doShared( new Work<Integer>()
         {
@@ -239,8 +240,8 @@ public class DefaultTimeline
     }
 
     protected void retrieveFromIndexer( final long fromTime, final long toTime, final int from, final int count,
-        final Set<String> types, final Set<String> subTypes, final TimelineFilter filter,
-        final TimelineCallback callback )
+                                        final Set<String> types, final Set<String> subTypes,
+                                        final TimelineFilter filter, final TimelineCallback callback )
     {
         doShared( new Work<Void>()
         {
@@ -254,7 +255,7 @@ public class DefaultTimeline
         } );
     }
 
-// ==
+    // ==
 
     protected static interface Work<E>
     {

--- a/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
+++ b/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimeline.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -44,12 +46,20 @@ public class DefaultTimeline
 
     private final ReentrantReadWriteLock timelineLock;
 
-    public DefaultTimeline()
+    /**
+     * Constructor. See {@link DefaultTimelineIndexer} constructor for meaning of {@code luceneFSDirectoryType}. Note:
+     * The {@code luceneFSDirectoryType} is copied from nexus-indexer-lucene-plugin's DefaultIndexerManager as part of
+     * fix for NEXUS-5658, hence, the key used here must be kept in sync with the one used in DefaultIndexerManager!
+     * 
+     * @param luceneFSDirectoryType
+     */
+    @Inject
+    public DefaultTimeline( @Nullable @Named( "${lucene.fsdirectory.type}" ) final String luceneFSDirectoryType )
     {
         this.logger = LoggerFactory.getLogger( getClass() );
         this.started = false;
         this.persistor = new DefaultTimelinePersistor();
-        this.indexer = new DefaultTimelineIndexer();
+        this.indexer = new DefaultTimelineIndexer( luceneFSDirectoryType );
         this.timelineLock = new ReentrantReadWriteLock();
     }
 

--- a/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimelineIndexer.java
+++ b/plugins/nexus-timeline-plugin/src/main/java/org/sonatype/timeline/internal/DefaultTimelineIndexer.java
@@ -146,8 +146,8 @@ public class DefaultTimelineIndexer
     }
 
     protected void retrieve( final long fromTime, final long toTime, final Set<String> types,
-        final Set<String> subTypes,
-        int from, int count, final TimelineFilter filter, final TimelineCallback callback )
+                             final Set<String> subTypes, int from, int count, final TimelineFilter filter,
+                             final TimelineCallback callback )
         throws IOException
     {
         if ( count == 0 )
@@ -178,7 +178,7 @@ public class DefaultTimelineIndexer
                 // return
                 topDocs =
                     searcher.search( buildQuery( fromTime, toTime, types, subTypes ), null, Integer.MAX_VALUE,
-                                     new Sort( new SortField( TIMESTAMP, SortField.LONG, true ) ) );
+                        new Sort( new SortField( TIMESTAMP, SortField.LONG, true ) ) );
             }
             if ( topDocs.scoreDocs.length == 0 )
             {
@@ -240,7 +240,7 @@ public class DefaultTimelineIndexer
             // just to know how many will we delete, will not actually load 'em up
             final TopFieldDocs topDocs =
                 searcher.search( q, null, searcher.maxDoc(),
-                                 new Sort( new SortField( TIMESTAMP, SortField.LONG, true ) ) );
+                    new Sort( new SortField( TIMESTAMP, SortField.LONG, true ) ) );
             if ( topDocs.scoreDocs.length == 0 )
             {
                 // nothing matched to be purged
@@ -279,7 +279,7 @@ public class DefaultTimelineIndexer
     {
         final Document doc = new Document();
         doc.add( new Field( TIMESTAMP, DateTools.timeToString( record.getTimestamp(), TIMELINE_RESOLUTION ),
-                            Field.Store.YES, Field.Index.NOT_ANALYZED ) );
+            Field.Store.YES, Field.Index.NOT_ANALYZED ) );
         doc.add( new Field( TYPE, record.getType(), Field.Store.YES, Field.Index.NOT_ANALYZED ) );
         doc.add( new Field( SUBTYPE, record.getSubType(), Field.Store.YES, Field.Index.NOT_ANALYZED ) );
         for ( Map.Entry<String, String> dataEntry : record.getData().entrySet() )
@@ -294,14 +294,14 @@ public class DefaultTimelineIndexer
         if ( isEmptySet( types ) && isEmptySet( subTypes ) )
         {
             return new TermRangeQuery( TIMESTAMP, DateTools.timeToString( from, TIMELINE_RESOLUTION ),
-                                       DateTools.timeToString( to, TIMELINE_RESOLUTION ), true, true );
+                DateTools.timeToString( to, TIMELINE_RESOLUTION ), true, true );
         }
         else
         {
             final BooleanQuery result = new BooleanQuery();
             result.add(
                 new TermRangeQuery( TIMESTAMP, DateTools.timeToString( from, TIMELINE_RESOLUTION ),
-                                    DateTools.timeToString( to, TIMELINE_RESOLUTION ), true, true ), Occur.MUST );
+                    DateTools.timeToString( to, TIMELINE_RESOLUTION ), true, true ), Occur.MUST );
             if ( !isEmptySet( types ) )
             {
                 final BooleanQuery typeQ = new BooleanQuery();


### PR DESCRIPTION
Two commits. First is only reformat without code change. Second actually copy-pastes the fstype selection code from the indexer plugin.

Issue:
https://issues.sonatype.org/browse/NEXUS-5658
