### PR TITLE
REVIEW: [NEXUS-5651] Siesta resources authorisation

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/guice/FilterChainModule.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/guice/FilterChainModule.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+package org.sonatype.nexus.guice;
+
+import org.sonatype.nexus.security.FilterChain;
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+/**
+ * Support module for configuring {@link FilterChain}s.
+ *
+ * @since 2.5
+ */
+public abstract class FilterChainModule
+    extends AbstractModule
+{
+
+    protected void addFilterChain( final String pathPattern, final String filterExpression )
+    {
+        bind( FilterChain.class )
+            .annotatedWith( Names.named( pathPattern ) )
+            .toInstance( new FilterChain( pathPattern, filterExpression )
+            );
+    }
+
+}

--- a/nexus-core/src/main/java/org/sonatype/nexus/security/FilterChain.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/security/FilterChain.java
@@ -1,0 +1,45 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.security;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A Shiro filter chain (mapping between a path pattern and a filter expression).
+ *
+ * @since 2.5
+ */
+public class FilterChain
+{
+
+    private final String pathPattern;
+
+    private final String filterExpression;
+
+    public FilterChain( final String pathPattern, final String filterExpression )
+    {
+        this.pathPattern = checkNotNull( pathPattern );
+        this.filterExpression = checkNotNull( filterExpression );
+    }
+
+    public String getPathPattern()
+    {
+        return pathPattern;
+    }
+
+    public String getFilterExpression()
+    {
+        return filterExpression;
+    }
+
+}

--- a/nexus-web-utils/src/main/java/org/sonatype/nexus/web/FilterChainInstaller.java
+++ b/nexus-web-utils/src/main/java/org/sonatype/nexus/web/FilterChainInstaller.java
@@ -10,11 +10,11 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.siesta;
+package org.sonatype.nexus.web;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sonatype.nexus.plugins.siesta.SiestaModule.MOUNT_POINT;
 
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -22,30 +22,35 @@ import javax.inject.Provider;
 import org.sonatype.inject.EagerSingleton;
 import org.sonatype.nexus.proxy.events.NexusStartedEvent;
 import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+import org.sonatype.nexus.security.FilterChain;
 import org.sonatype.security.web.ProtectedPathManager;
 import org.sonatype.sisu.goodies.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 /**
- * Configures Siesta protected resources.
+ * Installs configured {@link FilterChain}s with {@link ProtectedPathManager}.
  *
- * @since 2.5.0
+ * @since 2.5
  */
 @Named
 @EagerSingleton
-public class SiestaProtectedPaths
+public class FilterChainInstaller
 {
 
     private final EventBus eventBus;
 
     private final Provider<ProtectedPathManager> protectedPathManager;
 
+    private final List<FilterChain> filterChains;
+
     @Inject
-    public SiestaProtectedPaths( final EventBus eventBus,
-                                 final Provider<ProtectedPathManager> protectedPathManager )
+    public FilterChainInstaller( final EventBus eventBus,
+                                 final Provider<ProtectedPathManager> protectedPathManager,
+                                 final List<FilterChain> filterChains )
     {
         this.eventBus = checkNotNull( eventBus );
         this.protectedPathManager = checkNotNull( protectedPathManager );
+        this.filterChains = checkNotNull( filterChains );
 
         eventBus.register( this );
     }
@@ -53,16 +58,18 @@ public class SiestaProtectedPaths
     @Subscribe
     public void onEvent( final NexusStartedEvent event )
     {
-        protectedPathManager.get().addProtectedResource(
-            MOUNT_POINT + "/**", "noSessionCreation,authcBasic"
-        );
+        for ( final FilterChain filterChain : filterChains )
+        {
+            protectedPathManager.get().addProtectedResource(
+                filterChain.getPathPattern(), filterChain.getFilterExpression()
+            );
+        }
     }
 
     @Subscribe
-    public void onEvent( final NexusStoppedEvent evt )
+    public void onEvent( final NexusStoppedEvent event )
     {
         eventBus.unregister( this );
     }
-
 
 }

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/security/filter/authc/NexusHttpAuthenticationFilter.java
@@ -49,7 +49,7 @@ public class NexusHttpAuthenticationFilter
 
     public static final String FAKE_AUTH_SCHEME = "NxBASIC";
 
-    public static final String ANONYMOUS_LOGIN = "nexus.anonynmous";
+    public static final String ANONYMOUS_LOGIN = "nexus.anonymous";
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/AuthorizationExceptionMapper.java
+++ b/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/AuthorizationExceptionMapper.java
@@ -12,8 +12,11 @@
  */
 package org.sonatype.nexus.plugins.siesta;
 
+import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 import org.apache.shiro.authz.AuthorizationException;
@@ -21,7 +24,8 @@ import org.sonatype.sisu.siesta.common.error.ErrorXO;
 import org.sonatype.sisu.siesta.server.ErrorExceptionMapperSupport;
 
 /**
- * Maps {@link AuthorizationException} to 403 with a {@link ErrorXO} body.
+ * Maps {@link AuthorizationException} to 403 with a {@link ErrorXO} body in case that a user is logged in or to an
+ * 401 in case that no user is authenticated.
  *
  * @since 2.4
  */
@@ -30,6 +34,38 @@ import org.sonatype.sisu.siesta.server.ErrorExceptionMapperSupport;
 public class AuthorizationExceptionMapper
     extends ErrorExceptionMapperSupport<AuthorizationException>
 {
+
+    private static final String AUTH_SCHEME_KEY = "auth.scheme";
+
+    public static final String AUTH_REALM_KEY = "auth.realm";
+
+    private static final String ANONYMOUS_LOGIN = "nexus.anonynmous";
+
+    private static final String AUTHENTICATE_HEADER = "WWW-Authenticate";
+
+    @Inject
+    private Provider<HttpServletRequest> httpServletRequestProvider;
+
+    /**
+     * @since 2.5.0
+     */
+    @Override
+    protected Response convert( final AuthorizationException exception, final String id )
+    {
+        final Response.ResponseBuilder builder = Response.fromResponse( super.convert( exception, id ) );
+
+        final HttpServletRequest servletRequest = httpServletRequestProvider.get();
+        if ( servletRequest.getAttribute( ANONYMOUS_LOGIN ) != null )
+        {
+            String scheme = (String) servletRequest.getAttribute( AUTH_SCHEME_KEY );
+            String realm = (String) servletRequest.getAttribute( AUTH_REALM_KEY );
+
+            builder
+                .status( Response.Status.UNAUTHORIZED )
+                .header( AUTHENTICATE_HEADER, scheme + " realm=\"" + realm + "" );
+        }
+        return builder.build();
+    }
 
     @Override
     protected int getStatusCode( final AuthorizationException exception )

--- a/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/AuthorizationExceptionMapper.java
+++ b/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/AuthorizationExceptionMapper.java
@@ -39,7 +39,7 @@ public class AuthorizationExceptionMapper
 
     public static final String AUTH_REALM_KEY = "auth.realm";
 
-    private static final String ANONYMOUS_LOGIN = "nexus.anonynmous";
+    private static final String ANONYMOUS_LOGIN = "nexus.anonymous";
 
     private static final String AUTHENTICATE_HEADER = "WWW-Authenticate";
 

--- a/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/SiestaModule.java
+++ b/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/SiestaModule.java
@@ -16,6 +16,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.servlet.ServletModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.guice.FilterChainModule;
 import org.sonatype.security.web.guice.SecurityWebFilter;
 import org.sonatype.sisu.siesta.common.Resource;
 import org.sonatype.sisu.siesta.jackson.SiestaJacksonModule;
@@ -84,5 +85,15 @@ public class SiestaModule
                 filter(MOUNT_POINT + "/*").through(SecurityWebFilter.class);
             }
         });
+
+        install( new FilterChainModule()
+        {
+            @Override
+            protected void configure()
+            {
+                addFilterChain( MOUNT_POINT + "/**", "noSessionCreation,authcBasic" );
+            }
+
+        } );
     }
 }

--- a/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/SiestaProtectedPaths.java
+++ b/plugins/siesta/nexus-siesta-plugin/src/main/java/org/sonatype/nexus/plugins/siesta/SiestaProtectedPaths.java
@@ -1,0 +1,68 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.siesta;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sonatype.nexus.plugins.siesta.SiestaModule.MOUNT_POINT;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+
+import org.sonatype.inject.EagerSingleton;
+import org.sonatype.nexus.proxy.events.NexusStartedEvent;
+import org.sonatype.nexus.proxy.events.NexusStoppedEvent;
+import org.sonatype.security.web.ProtectedPathManager;
+import org.sonatype.sisu.goodies.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+/**
+ * Configures Siesta protected resources.
+ *
+ * @since 2.5.0
+ */
+@Named
+@EagerSingleton
+public class SiestaProtectedPaths
+{
+
+    private final EventBus eventBus;
+
+    private final Provider<ProtectedPathManager> protectedPathManager;
+
+    @Inject
+    public SiestaProtectedPaths( final EventBus eventBus,
+                                 final Provider<ProtectedPathManager> protectedPathManager )
+    {
+        this.eventBus = checkNotNull( eventBus );
+        this.protectedPathManager = checkNotNull( protectedPathManager );
+
+        eventBus.register( this );
+    }
+
+    @Subscribe
+    public void onEvent( final NexusStartedEvent event )
+    {
+        protectedPathManager.get().addProtectedResource(
+            MOUNT_POINT + "/**", "noSessionCreation,authcBasic"
+        );
+    }
+
+    @Subscribe
+    public void onEvent( final NexusStoppedEvent evt )
+    {
+        eventBus.unregister( this );
+    }
+
+
+}


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-5651
https://bamboo.zion.sonatype.com/browse/NXO-OSSF49

The fix will solve two issues:
1. Make browsers pop up the basic auth dialog in case that user is not authenticated
2. Make possible to access siesta resources via rest clients as wget/restclient/curl

The fix does not solve the issues related to accessing siesta resources when security is off. 

The fix requires that siesta resources (/service/siesta/**) to be filtered through Shiro "authBasic" filter. The pull request introduces a generic way to configure Shiro filter chains.
