### PR TITLE
REVIEW: NEXUS-5660 add java.net.preferIPv4Stack system property via nexus.properties

### DIFF
--- a/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -26,11 +26,12 @@ wrapper.java.classpath.3=./conf/
 wrapper.java.library.path.1=bin/jsw/lib
 
 # Additional JVM parameters (tune if needed, but match the sequence of numbers!)
-#wrapper.java.additional.1=-Xdebug
-#wrapper.java.additional.2=-Xnoagent
-#wrapper.java.additional.3=-Djava.compiler=NONE
-#wrapper.java.additional.4=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#wrapper.java.additional.5=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.1=-Djava.net.preferIPv4Stack=true
+#wrapper.java.additional.2=-Xdebug
+#wrapper.java.additional.3=-Xnoagent
+#wrapper.java.additional.4=-Djava.compiler=NONE
+#wrapper.java.additional.5=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#wrapper.java.additional.6=-XX:+HeapDumpOnOutOfMemoryError
 
 wrapper.app.parameter.1=./conf/jetty.xml
 

--- a/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
+++ b/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
@@ -24,4 +24,3 @@ nexus-webapp-context-path=/nexus
 # Nexus section
 nexus-work=${bundleBasedir}/../sonatype-work/nexus
 runtime=${bundleBasedir}/nexus/WEB-INF
-java.net.preferIPv4Stack=true

--- a/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
+++ b/nexus-oss-webapp/src/main/resources/content/conf/nexus.properties
@@ -24,3 +24,4 @@ nexus-webapp-context-path=/nexus
 # Nexus section
 nexus-work=${bundleBasedir}/../sonatype-work/nexus
 runtime=${bundleBasedir}/nexus/WEB-INF
+java.net.preferIPv4Stack=true

--- a/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
+++ b/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
@@ -164,6 +164,7 @@ public abstract class AbstractNexusIntegrationTest
 
         // guice finalizer turned OFF
         System.setProperty( "guice.executor.class", "NONE" );
+        // NEXUS-5660 test with ipv4 as app runs with this set now
         System.setProperty( "java.net.preferIPv4Stack", "true" );
     }
 

--- a/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
+++ b/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/integrationtests/AbstractNexusIntegrationTest.java
@@ -164,6 +164,7 @@ public abstract class AbstractNexusIntegrationTest
 
         // guice finalizer turned OFF
         System.setProperty( "guice.executor.class", "NONE" );
+        System.setProperty( "java.net.preferIPv4Stack", "true" );
     }
 
     static


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-5660

NEXUS-5660 - java.net.preferIPv4Stack=true should be set by default in case Java 7+ or JMX is used with Nexus
