### PR TITLE
Checkum policy blocks prefix list

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractChecksumContentValidator.java
@@ -40,6 +40,14 @@ public abstract class AbstractChecksumContentValidator
             return true;
         }
 
+        final ChecksumPolicy requestChecksumPolicy =
+            (ChecksumPolicy) req.getRequestContext().get( ChecksumPolicy.REQUEST_CHECKSUM_POLICY_KEY );
+        if ( requestChecksumPolicy != null )
+        {
+            // found, it overrides the repository-set checksum policy then
+            checksumPolicy = requestChecksumPolicy;
+        }
+
         RemoteHashResponse remoteHash = retrieveRemoteHash( item, proxy, baseUrl );
 
         // let compiler make sure I did not forget to populate validation results

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumContentValidator.java
@@ -75,7 +75,7 @@ public class ChecksumContentValidator
     protected void cleanup( ProxyRepository proxy, RemoteHashResponse remoteHash, boolean contentValid )
         throws LocalStorageException
     {
-        if ( !contentValid && remoteHash.getHashItem() != null )
+        if ( !contentValid && remoteHash != null && remoteHash.getHashItem() != null )
         {
             // TODO should we remove bad checksum if policy==WARN?
             try

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumPolicy.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/ChecksumPolicy.java
@@ -12,6 +12,9 @@
  */
 package org.sonatype.nexus.proxy.maven;
 
+import org.sonatype.nexus.proxy.RequestContext;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+
 /**
  * Checksum policies known in Maven1/2 repositories where checksums are available according to maven layout.
  * 
@@ -38,6 +41,21 @@ public enum ChecksumPolicy
      * In case of checksum inconsistency, Nexus will behave like the Artifact was not found -- will refuse to serve it.
      */
     STRICT;
+
+    /**
+     * Key to be used in {@link ResourceStoreRequest} context to mark per-request "override" of the
+     * {@link MavenProxyRepository} checksum policy. The policy put with this key into request context will be applied
+     * to given request execution (and all sub-requests, as {@link RequestContext} hierarchy is used). The use of this
+     * key has effect only on Maven1/2 proxy repositories, as {@link ChecksumPolicy} itself is a Maven specific
+     * property, and is globally (on repository level) controlled by getters and setters on {@link MavenProxyRepository}
+     * interface. This "request override" - usually to relax the policy - should be used sparingly, for cases when it's
+     * known that global repository level checksum policy might pose a blocker to the tried content retrieval, but even
+     * a corrupted content would not pose any downstream problems (as Nexus would shield downstream consumers by some
+     * other means, like processing and checking content in-situ).
+     * 
+     * @since 2.5
+     */
+    public static String REQUEST_CHECKSUM_POLICY_KEY = "request.maven.checksumPolicy";
 
     public boolean shouldCheckChecksum()
     {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/FilePrefixSource.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/FilePrefixSource.java
@@ -303,6 +303,12 @@ public class FilePrefixSource
             new DefaultStorageFileItem( getMavenRepository(), request, true, true, content );
         try
         {
+            // NXCM-5188: Remark to not get tempted to change these to storeItemWithChecksums() method:
+            // Since NEXUS-5418 was fixed (in 2.4), Nexus serves up ALL request for existing items that
+            // has extra trailing ".sha1" or ".md5" from item attributes. This means, that when prefix file
+            // is published in Nexus, there is no need anymore to save checksums to disk, as they will
+            // be served up just fine. This is true for all items in Nexus storage, not just prefix
+            // file related ones!
             getMavenRepository().storeItem( true, file );
         }
         catch ( UnsupportedStorageOperationException e )
@@ -325,6 +331,12 @@ public class FilePrefixSource
         request.getRequestContext().put( Manager.ROUTING_INITIATED_FILE_OPERATION_FLAG_KEY, Boolean.TRUE );
         try
         {
+            // NXCM-5188: Remark to not get tempted to change these to deleteItemWithChecksums() method:
+            // Since NEXUS-5418 was fixed (in 2.4), Nexus serves up ALL request for existing items that
+            // has extra trailing ".sha1" or ".md5" from item attributes. This means, that when prefix file
+            // is published in Nexus, there is no need anymore to save checksums to disk, as they will
+            // be served up just fine. This is true for all items in Nexus storage, not just prefix
+            // file related ones!
             getMavenRepository().deleteItem( true, request );
         }
         catch ( ItemNotFoundException e )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
@@ -29,6 +29,7 @@ import org.sonatype.nexus.proxy.access.Action;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
+import org.sonatype.nexus.proxy.maven.ChecksumPolicy;
 import org.sonatype.nexus.proxy.maven.MavenProxyRepository;
 import org.sonatype.nexus.proxy.maven.routing.Config;
 import org.sonatype.nexus.proxy.maven.routing.Manager;
@@ -147,8 +148,14 @@ public class RemotePrefixFileStrategy
         throws IOException
     {
         final ResourceStoreRequest request = new ResourceStoreRequest( path );
-        request.getRequestContext().put( Manager.ROUTING_INITIATED_FILE_OPERATION_FLAG_KEY, Boolean.TRUE );
         request.setRequestRemoteOnly( true );
+        request.getRequestContext().put( Manager.ROUTING_INITIATED_FILE_OPERATION_FLAG_KEY, Boolean.TRUE );
+        if ( ChecksumPolicy.STRICT == mavenProxyRepository.getChecksumPolicy() )
+        {
+            // NXCM-5188: Relax checksum policy for prefix file request, if needed
+            request.getRequestContext().put( ChecksumPolicy.REQUEST_CHECKSUM_POLICY_KEY,
+                ChecksumPolicy.STRICT_IF_EXISTS );
+        }
 
         // check for remote presence, as fetching with setRequestRemoteOnly has a side effect of
         // DELETING the file from local cache if not present remotely. In this case, prefix

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategy.java
@@ -125,7 +125,7 @@ public class RemotePrefixFileStrategy
                 if ( prefixFileAgeInDays < 1 )
                 {
                     return new StrategyResult( "Remote publishes prefix file (is less than a day old), using it.",
-                                               prefixSource, true );
+                        prefixSource, true );
                 }
                 else
                 {
@@ -150,12 +150,8 @@ public class RemotePrefixFileStrategy
         final ResourceStoreRequest request = new ResourceStoreRequest( path );
         request.setRequestRemoteOnly( true );
         request.getRequestContext().put( Manager.ROUTING_INITIATED_FILE_OPERATION_FLAG_KEY, Boolean.TRUE );
-        if ( ChecksumPolicy.STRICT == mavenProxyRepository.getChecksumPolicy() )
-        {
-            // NXCM-5188: Relax checksum policy for prefix file request, if needed
-            request.getRequestContext().put( ChecksumPolicy.REQUEST_CHECKSUM_POLICY_KEY,
-                ChecksumPolicy.STRICT_IF_EXISTS );
-        }
+        // NXCM-5188: Disable checksum policy for prefix file request, it will be processed and checked anyway
+        request.getRequestContext().put( ChecksumPolicy.REQUEST_CHECKSUM_POLICY_KEY, ChecksumPolicy.IGNORE );
 
         // check for remote presence, as fetching with setRequestRemoteOnly has a side effect of
         // DELETING the file from local cache if not present remotely. In this case, prefix

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategyTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategyTest.java
@@ -296,7 +296,7 @@ public class RemotePrefixFileStrategyTest
                 Behaviours.content( prefixFile1( true ) ) ).start();
         try
         {
-            // setting the policy to String, and note that server set up above publishes
+            // setting the policy to STRICT, and note that server set up above publishes
             // the prefix file only, no checksums!
             final MavenProxyRepository mavenProxyRepository =
                 getRepositoryRegistry().getRepositoryWithFacet( PROXY_REPO_ID, MavenProxyRepository.class );

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategyTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/RemotePrefixFileStrategyTest.java
@@ -275,4 +275,48 @@ public class RemotePrefixFileStrategyTest
         }
     }
 
+    /**
+     * https://issues.sonatype.org/browse/NXCM-5188 Strict Checksum enforcement breaks Automatic Routing
+     * <p>
+     * Prefix file retrieval uses plain Proxy transport to get the file from remote peer. This causes problems (actually
+     * prevents happening it) if following conditions are met: Proxy repository has STRICT checksum policy and remote
+     * prefix file has no checksum published. In this case, relaxing the policy for this request only is okay to do,
+     * since "this" Nexus will properly process the prefix file anyway, detecting any problems with it, thus protecting
+     * downstream clients too.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void discoverPlaintextPrefixFileWithoutChecksumsWithStrictChecksumPolicy()
+        throws Exception
+    {
+        server.stop();
+        server =
+            Server.withPort( remoteServerPort ).serve( "/.meta/prefixes.txt" ).withBehaviours(
+                Behaviours.content( prefixFile1( true ) ) ).start();
+        try
+        {
+            // setting the policy to String, and note that server set up above publishes
+            // the prefix file only, no checksums!
+            final MavenProxyRepository mavenProxyRepository =
+                getRepositoryRegistry().getRepositoryWithFacet( PROXY_REPO_ID, MavenProxyRepository.class );
+            mavenProxyRepository.setChecksumPolicy( ChecksumPolicy.STRICT );
+            getApplicationConfiguration().saveConfiguration();
+
+            final RemoteStrategy subject = lookup( RemoteStrategy.class, RemotePrefixFileStrategy.ID );
+            final StrategyResult result = subject.discover( mavenProxyRepository );
+            assertThat( result.getMessage(),
+                equalTo( "Remote publishes prefix file (is less than a day old), using it." ) );
+
+            final PrefixSource entrySource = result.getPrefixSource();
+            assertThat( entrySource.supported(), is( true ) );
+            assertThat( entrySource.readEntries(), contains( "/org/apache/maven", "/org/sonatype", "/eu/flatwhite" ) );
+            assertThat( entrySource.readEntries().size(), equalTo( 3 ) );
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes
http://issues.sonatype.org/browse/NXCM-5188

Multiple fixes:
- NPE fixed that is apparent in log in the issue (is general, not prefix file related!)
- Implemented a fix: override per-request the ChecksumPolicy in Maven repositories
- making use of the core change in `RemotePrefixFileStrategy`, added UT
- added comments to remove temptation (like I had)

CI
https://bamboo.zion.sonatype.com/browse/NXO-OSSF1-1
