### PR TITLE
NXCM-5194: G level metadata merge creates duplicated entries

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperation.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperation.java
@@ -12,7 +12,7 @@
  */
 package org.sonatype.nexus.proxy.maven.metadata.operations;
 
-import static org.sonatype.nexus.proxy.maven.metadata.operations.MetadataUtil.isPluginEquals;
+import static org.sonatype.nexus.proxy.maven.metadata.operations.MetadataUtil.isPluginPrefixAndNameEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,8 +88,9 @@ public class AddPluginOperation
         {
             if ( p.getArtifactId().equals( plugin.getArtifactId() ) )
             {
-                if ( isPluginEquals( p, plugin ) )
+                if ( isPluginPrefixAndNameEquals( p, plugin ) )
                 {
+                    p.setName( plugin.getName() );
                     // plugin already enlisted
                     return false;
                 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperation.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperation.java
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.proxy.maven.metadata.operations;
 
-import static org.sonatype.nexus.proxy.maven.metadata.operations.MetadataUtil.isPluginPrefixAndNameEquals;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,6 +20,8 @@ import java.util.List;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Plugin;
+
+import static org.sonatype.nexus.proxy.maven.metadata.operations.MetadataUtil.isPluginPrefixAndArtifactIdEquals;
 
 /**
  * adds new plugin to metadata
@@ -88,7 +88,7 @@ public class AddPluginOperation
         {
             if ( p.getArtifactId().equals( plugin.getArtifactId() ) )
             {
-                if ( isPluginPrefixAndNameEquals( p, plugin ) )
+                if ( isPluginPrefixAndArtifactIdEquals( p, plugin ) )
                 {
                     p.setName( plugin.getName() );
                     // plugin already enlisted

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
@@ -56,4 +56,15 @@ public class MetadataUtil
         return false;
     }
 
+    public static boolean isPluginPrefixAndNameEquals( Plugin p1, Plugin p2 )
+    {
+        if ( StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
+            && StringUtils.equals( p1.getPrefix(), p2.getPrefix() ) )
+        {
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
@@ -56,7 +56,7 @@ public class MetadataUtil
         return false;
     }
 
-    public static boolean isPluginPrefixAndNameEquals( Plugin p1, Plugin p2 )
+    public static boolean isPluginPrefixAndArtifactIdEquals( Plugin p1, Plugin p2 )
     {
         if ( StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
             && StringUtils.equals( p1.getPrefix(), p2.getPrefix() ) )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/operations/MetadataUtil.java
@@ -47,24 +47,14 @@ public class MetadataUtil
             p2.setName( "" );
         }
 
-        if ( StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
-            && StringUtils.equals( p1.getPrefix(), p2.getPrefix() ) && StringUtils.equals( p1.getName(), p2.getName() ) )
-        {
-            return true;
-        }
-
-        return false;
+        return StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
+            && StringUtils.equals( p1.getPrefix(), p2.getPrefix() ) && StringUtils.equals( p1.getName(), p2.getName() );
     }
 
     public static boolean isPluginPrefixAndArtifactIdEquals( Plugin p1, Plugin p2 )
     {
-        if ( StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
-            && StringUtils.equals( p1.getPrefix(), p2.getPrefix() ) )
-        {
-            return true;
-        }
-
-        return false;
+        return StringUtils.equals( p1.getArtifactId(), p2.getArtifactId() )
+            && StringUtils.equals( p1.getPrefix(), p2.getPrefix() );
     }
 
 }

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperationTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/metadata/operations/AddPluginOperationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.maven.metadata.operations;
+
+import java.util.Collections;
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Plugin;
+import org.junit.Test;
+import org.sonatype.nexus.proxy.maven.metadata.operations.ModelVersionUtility.Version;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class AddPluginOperationTest
+{
+    @Test
+    public void testAddingPluginsDoesNotDuplicatesEntries()
+        throws Exception
+    {
+        final Metadata md = new Metadata();
+        {
+            final Plugin plugin = new Plugin();
+            plugin.setArtifactId( "bar-maven-plugin" );
+            plugin.setPrefix( "bar" );
+            plugin.setName( "Bar plugin" );
+            md.addPlugin( plugin );
+        }
+
+        // new plugin addition
+        {
+            final Plugin plugin1 = new Plugin();
+            plugin1.setPrefix( "foo" );
+            plugin1.setArtifactId( "foo-maven-plugin" );
+            plugin1.setName( "Foo plugin" );
+            MetadataBuilder.changeMetadata( md, Collections.<MetadataOperation> singletonList( new AddPluginOperation(
+                new PluginOperand( Version.V110, plugin1 ) ) ) );
+        }
+        assertThat( "New plugin should be added!", md.getPlugins(), hasSize( 2 ) );
+        assertThat( md.getPlugins().get( 0 ).getPrefix(), equalTo( "bar" ) );
+        assertThat( md.getPlugins().get( 0 ).getName(), equalTo( "Bar plugin" ) );
+        assertThat( md.getPlugins().get( 1 ).getPrefix(), equalTo( "foo" ) );
+        assertThat( md.getPlugins().get( 1 ).getName(), equalTo( "Foo plugin" ) );
+
+        // existing plugin addition
+        {
+            final Plugin plugin1 = new Plugin();
+            plugin1.setPrefix( "foo" );
+            plugin1.setArtifactId( "foo-maven-plugin" );
+            plugin1.setName( "The new Foo plugin" );
+            MetadataBuilder.changeMetadata( md, Collections.<MetadataOperation> singletonList( new AddPluginOperation(
+                new PluginOperand( Version.V110, plugin1 ) ) ) );
+        }
+        assertThat( "No new plugin should be added!", md.getPlugins(), hasSize( 2 ) );
+        assertThat( md.getPlugins().get( 0 ).getPrefix(), equalTo( "bar" ) );
+        assertThat( md.getPlugins().get( 0 ).getName(), equalTo( "Bar plugin" ) );
+        assertThat( md.getPlugins().get( 1 ).getPrefix(), equalTo( "foo" ) );
+        assertThat( md.getPlugins().get( 1 ).getName(), equalTo( "The new Foo plugin" ) );
+        
+        // existing plugin addition
+        {
+            final Plugin plugin1 = new Plugin();
+            plugin1.setPrefix( "bar" );
+            plugin1.setArtifactId( "bar-maven-plugin" );
+            plugin1.setName( "The new Bar plugin" );
+            MetadataBuilder.changeMetadata( md, Collections.<MetadataOperation> singletonList( new AddPluginOperation(
+                new PluginOperand( Version.V110, plugin1 ) ) ) );
+        }
+        assertThat( "No new plugin should be added!", md.getPlugins(), hasSize( 2 ) );
+        assertThat( md.getPlugins().get( 0 ).getPrefix(), equalTo( "bar" ) );
+        assertThat( md.getPlugins().get( 0 ).getName(), equalTo( "The new Bar plugin" ) );
+        assertThat( md.getPlugins().get( 1 ).getPrefix(), equalTo( "foo" ) );
+        assertThat( md.getPlugins().get( 1 ).getName(), equalTo( "The new Foo plugin" ) );
+
+        // new plugin addition wrt plugin order, plugins are ordered by ArtifactID
+        {
+            final Plugin plugin1 = new Plugin();
+            plugin1.setPrefix( "alpha" );
+            plugin1.setArtifactId( "alpha-maven-plugin" );
+            plugin1.setName( "Alpha plugin" );
+            MetadataBuilder.changeMetadata( md, Collections.<MetadataOperation> singletonList( new AddPluginOperation(
+                new PluginOperand( Version.V110, plugin1 ) ) ) );
+        }
+        assertThat( "New plugin should be added!", md.getPlugins(), hasSize( 3 ) );
+        assertThat( md.getPlugins().get( 0 ).getPrefix(), equalTo( "alpha" ) );
+        assertThat( md.getPlugins().get( 0 ).getName(), equalTo( "Alpha plugin" ) );
+        assertThat( md.getPlugins().get( 1 ).getPrefix(), equalTo( "bar" ) );
+        assertThat( md.getPlugins().get( 1 ).getName(), equalTo( "The new Bar plugin" ) );
+        assertThat( md.getPlugins().get( 2 ).getPrefix(), equalTo( "foo" ) );
+        assertThat( md.getPlugins().get( 2 ).getName(), equalTo( "The new Foo plugin" ) );
+    }
+}


### PR DESCRIPTION
Reason is that entry equality was checked by comparing all
three properties of the Plugin: prefix, artifactId and name.

This commit "improves" this, by performing comparison
on prefix and artifactId only. This means that
duplication will not happen anymore on new
deploys, and will be corrected if maven metadata
rebuild task is run against repository (dupe entries will be removed). Still,
the one (edge) case "changing prefix" mentioned
in related issue is NOT fixed by this change.

Related:
https://issues.sonatype.org/browse/NEXUS-4448
