### PR TITLE
REVIEW: [NEXUS-5420] Prepend base URL to all emails (Take 2)

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/email/DefaultNexusEmailer.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/email/DefaultNexusEmailer.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.email;
 
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
@@ -30,6 +31,7 @@ import org.sonatype.nexus.configuration.AbstractConfigurable;
 import org.sonatype.nexus.configuration.Configurator;
 import org.sonatype.nexus.configuration.CoreConfiguration;
 import org.sonatype.nexus.configuration.application.ApplicationConfiguration;
+import org.sonatype.nexus.configuration.application.GlobalRestApiSettings;
 import org.sonatype.nexus.configuration.model.CSmtpConfiguration;
 import org.sonatype.nexus.configuration.model.CSmtpConfigurationCoreConfiguration;
 
@@ -50,6 +52,9 @@ public class DefaultNexusEmailer
 
     @Requirement
     private ApplicationConfiguration applicationConfiguration;
+
+    @Requirement
+    private GlobalRestApiSettings globalRestApiSettings;
 
     @Requirement
     private ApplicationStatusSource applicationStatusSource;
@@ -81,7 +86,7 @@ public class DefaultNexusEmailer
 
     public String getDefaultMailTypeId()
     {
-        return DefaultMailType.DEFAULT_TYPE_ID;
+        return NexusDefaultMailType.ID;
     }
 
     public MailRequest getDefaultMailRequest( String subject, String body )
@@ -95,6 +100,12 @@ public class DefaultNexusEmailer
         request.getBodyContext().put( DefaultMailType.SUBJECT_KEY, subject );
 
         request.getBodyContext().put( DefaultMailType.BODY_KEY, body );
+
+        final String baseUrl = globalRestApiSettings.getBaseUrl();
+        if ( StringUtils.isNotBlank( baseUrl ) )
+        {
+            request.getBodyContext().put( BASE_URL_KEY, baseUrl );
+        }
 
         return request;
     }

--- a/nexus-core/src/main/java/org/sonatype/nexus/email/NexusDefaultMailType.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/email/NexusDefaultMailType.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.email;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * The Nexus specific simple default mail type.
+ *
+ * @since 2.5
+ */
+@Named( NexusDefaultMailType.ID )
+@Singleton
+public class NexusDefaultMailType
+    extends NexusMailType
+{
+
+    public static final String ID = "nexus.default";
+
+    public NexusDefaultMailType()
+    {
+        setTypeId( ID );
+        setBodyIsHtml( false );
+    }
+
+}

--- a/nexus-core/src/main/java/org/sonatype/nexus/email/NexusEmailer.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/email/NexusEmailer.java
@@ -27,6 +27,14 @@ import org.sonatype.nexus.configuration.Configurable;
 public interface NexusEmailer
     extends Configurable
 {
+
+    /**
+     * Key of Nexus base URL.
+     *
+     * @since 2.5
+     */
+    public static final String BASE_URL_KEY = "baseUrl";
+
     /**
      * Gets the preconfigured EMailer instance for prepared for using it.
      * 

--- a/nexus-core/src/main/java/org/sonatype/nexus/email/NexusHtmlMailType.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/email/NexusHtmlMailType.java
@@ -1,0 +1,37 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.email;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * The Nexus specific html mail type.
+ *
+ * @since 2.5
+ */
+@Named( NexusHtmlMailType.ID )
+@Singleton
+public class NexusHtmlMailType
+    extends NexusMailType
+{
+
+    public static final String ID = "nexus.html";
+
+    public NexusHtmlMailType()
+    {
+        setTypeId( ID );
+        setBodyIsHtml( true );
+    }
+
+}

--- a/nexus-core/src/main/java/org/sonatype/nexus/email/NexusMailType.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/email/NexusMailType.java
@@ -1,0 +1,80 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.email;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.micromailer.MailType;
+import org.sonatype.micromailer.imp.AbstractMailType;
+import com.google.common.io.Closeables;
+
+/**
+ * Base class for Nexus specific {@link MailType}s.
+ *
+ * @since 2.5
+ */
+public class NexusMailType
+    extends AbstractMailType
+{
+
+    private final Logger log = LoggerFactory.getLogger( getClass() );
+
+    public NexusMailType()
+    {
+        this( null );
+    }
+
+    public NexusMailType( final String template )
+    {
+        setSubjectTemplate( "$" + SUBJECT_KEY );
+
+        String actualTemplate = template;
+        if ( actualTemplate == null )
+        {
+            actualTemplate = getClass().getSimpleName() + "-body.vm";
+        }
+
+        final URL resource = this.getClass().getResource( actualTemplate );
+        if ( resource == null )
+        {
+            log.warn( "Missing resource for template: {}; for owner: {}", actualTemplate, getClass().getName() );
+        }
+        else
+        {
+            InputStream in = null;
+            try
+            {
+                in = resource.openStream();
+                setBodyTemplate( IOUtils.toString( in, "UTF-8" ) );
+            }
+            catch ( IOException e )
+            {
+                log.warn( "Could not read content of template {}", actualTemplate, e );
+            }
+            finally
+            {
+                Closeables.closeQuietly( in );
+            }
+        }
+        if ( getBodyTemplate() == null )
+        {
+            setBodyTemplate( "$" + BODY_KEY );
+        }
+    }
+
+}

--- a/nexus-core/src/main/resources/org/sonatype/nexus/email/NexusDefaultMailType-body.vm
+++ b/nexus-core/src/main/resources/org/sonatype/nexus/email/NexusDefaultMailType-body.vm
@@ -1,0 +1,19 @@
+#*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#if( $baseUrl )
+Message from: $baseUrl
+#else
+Message from: (Set the Base URL parameter in Nexus Server Administration to include in future emails)
+#end
+
+$body

--- a/nexus-core/src/main/resources/org/sonatype/nexus/email/NexusHtmlMailType-body.vm
+++ b/nexus-core/src/main/resources/org/sonatype/nexus/email/NexusHtmlMailType-body.vm
@@ -1,0 +1,19 @@
+#*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ *#
+#if( $baseUrl )
+Message from: <a href="$baseUrl"/>
+#else
+Message from: <i>(Set the Base URL parameter in Nexus Server Administration to include in future emails)</i>
+#end
+<br/><br/>
+$body


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-5420
https://bamboo.zion.sonatype.com/browse/NXO-OSSF31

Beside solving the issue, the pull introduces two new Nexus specific Mail types. When used those will prepend the email with Nexus base url. User still can use the micromailer default/html types that will work as before (no prepend).

The templates are read from VM files.
