### PR TITLE
[REVIEW] NEXUS-2450: [M1 to M2] EJB artifacts are served from **/jars/ directory instead of **/ejbs/

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/LayoutConverterShadowRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/LayoutConverterShadowRepository.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.proxy.maven;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +47,8 @@ import org.sonatype.nexus.proxy.repository.IncompatibleMasterRepositoryException
 import org.sonatype.nexus.proxy.repository.Repository;
 import org.sonatype.nexus.proxy.repository.RepositoryKind;
 import org.sonatype.nexus.proxy.storage.UnsupportedStorageOperationException;
+
+import com.google.common.collect.Lists;
 
 /**
  * Base class for shadows that make "gateways" from M1 to M2 lauouts and vice versa.
@@ -449,13 +450,13 @@ public abstract class LayoutConverterShadowRepository
         {
             return null;
         }
-        final ArrayList<String> exts = new ArrayList<String>();
+        final List<String> exts = Lists.newArrayList();
         exts.add( gav.getExtension() + "s" );
         if ( extraFolders != null && !extraFolders.isEmpty() )
         {
             exts.addAll( extraFolders );
         }
-        final ArrayList<String> result = new ArrayList<String>( exts.size() );
+        final List<String> result = Lists.newArrayListWithCapacity( exts.size() );
         for ( String ext : exts )
         {
             // m1 repo is layouted as:

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/LayoutConverterShadowRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/LayoutConverterShadowRepository.java
@@ -596,12 +596,33 @@ public abstract class LayoutConverterShadowRepository
 
             for ( String transformedPath : transformedPaths )
             {
-                // delegate the call to the master
-                request.pushRequestPath( transformedPath );
-
                 try
                 {
+                    // delegate the call to the master
+                    request.pushRequestPath( transformedPath );
+
                     result = doRetrieveItemFromMaster( request );
+
+                    // try to create link on the fly
+                    try
+                    {
+                        StorageLinkItem link = createLink( result );
+
+                        if ( link != null )
+                        {
+                            return link;
+                        }
+                        else
+                        {
+                            // fallback to result, but will not happen, see above
+                            return result;
+                        }
+                    }
+                    catch ( Exception e1 )
+                    {
+                        // fallback to result, but will not happen, see above
+                        return result;
+                    }
                 }
                 catch ( ItemNotFoundException ex )
                 {
@@ -610,27 +631,6 @@ public abstract class LayoutConverterShadowRepository
                 finally
                 {
                     request.popRequestPath();
-                }
-
-                // try to create link on the fly
-                try
-                {
-                    StorageLinkItem link = createLink( result );
-
-                    if ( link != null )
-                    {
-                        return link;
-                    }
-                    else
-                    {
-                        // fallback to result, but will not happen, see above
-                        return result;
-                    }
-                }
-                catch ( Exception e1 )
-                {
-                    // fallback to result, but will not happen, see above
-                    return result;
                 }
             }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1LayoutedM2ShadowRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven1/M1LayoutedM2ShadowRepository.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.proxy.maven.maven1;
 
+import java.util.List;
+
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -89,13 +91,13 @@ public class M1LayoutedM2ShadowRepository
     }
 
     @Override
-    protected String transformMaster2Shadow( final String path )
+    protected List<String> transformMaster2Shadow( final String path )
     {
-        return transformM2toM1( path );
+        return transformM2toM1( path, null );
     }
 
     @Override
-    protected String transformShadow2Master( final String path )
+    protected List<String> transformShadow2Master( final String path )
     {
         return transformM1toM2( path );
     }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2LayoutedM1ShadowRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/maven2/M2LayoutedM1ShadowRepository.java
@@ -12,6 +12,9 @@
  */
 package org.sonatype.nexus.proxy.maven.maven2;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -89,15 +92,15 @@ public class M2LayoutedM1ShadowRepository
     }
 
     @Override
-    protected String transformMaster2Shadow( final String path )
+    protected List<String> transformMaster2Shadow( final String path )
     {
         return transformM1toM2( path );
     }
 
     @Override
-    protected String transformShadow2Master( final String path )
+    protected List<String> transformShadow2Master( final String path )
     {
-        return transformM2toM1( path );
+        return transformM2toM1( path, Collections.singletonList( "ejbs" ) );
     }
 
     @Override


### PR DESCRIPTION
Fixes
https://issues.sonatype.org/browse/NEXUS-2450

Use case: using Maven3, and you need to access some legacy Maven1 layouted repository with EJBs. As Nexus has not enough information (especially the "type" of the artifact in question) only the path, this change simply makes Nexus to iterate one extra M1 folder when looking for artifact. This happens in doRetrieveItem method.

No other change, despite introduction on List<String> as return params on coversion methods, as all the effected metods (naturally except the doRetrieveItem) just use the 1st element of the list, retaining same behaviour as before (when only single string was returned).
