### PR TITLE
REVIEW [NXCM-5147] allow for persistent tooltips

### DIFF
--- a/nexus-webapp/src/main/webapp/js/ext/form/field.js
+++ b/nexus-webapp/src/main/webapp/js/ext/form/field.js
@@ -16,10 +16,12 @@ Ext.override(Ext.form.Field, {
   /*
    * Override default form field rendering to include help text quick tip on
    * question mark rendered after field label.
+   * Specifying 'helpText' will cause a help icon and text to be added as a QuickTip.
+   * Specifying 'persistent' in conjunction with 'helpTest' will create a ToolTip that remains visible, useful for embedding links in the text.
    */
   afterRenderOrig : Ext.form.Field.prototype.afterRender,
   afterRender : function() {
-    var helpClass = null, wrapDiv = null, helpMark = null;
+    var helpClass = null, wrapDiv = null, helpMark = null, self = this;
     if ( this.helpMarker === true )
     {
       wrapDiv = this.getEl().up('div');
@@ -79,12 +81,27 @@ Ext.override(Ext.form.Field, {
         cls : helpClass
       });
 
-      Ext.QuickTips.register({
-        target : helpMark,
-        title : '',
-        text : this.helpText,
-        enabled : true
-      });
+      // Use a ToolTip instead of QuickTip if we want the tip to remain in place.
+      // In this case the entire html fo the ToolTip will be set to the provided
+      // 'helpText'.
+      if(this.persistent)
+      {
+        var help = new Ext.ToolTip({
+          html :  self.helpText,
+          anchor: 'left',
+          hideDelay: 10000
+        });
+        help.initTarget(helpMark);
+      }
+      else
+      {
+        Ext.QuickTips.register({
+          target : helpMark,
+          title : '',
+          text : this.helpText,
+          enabled : true
+        });
+      }
     }
 
     // original method


### PR DESCRIPTION
https://issues.sonatype.org/browse/NXCM-5147
Move code originally implemented as a one-off in nexus-clm to core for reuse.

NXCM-5147 - Resolve Technical Debt introduced by borrowing of helpText code in CLM plugin
