### PR TITLE
[REVIEW] NEXUS-5468: HTTP connection leak in case of LSEx

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/AbstractWrappingContentLocator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/AbstractWrappingContentLocator.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.proxy.item;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -22,7 +23,7 @@ import java.io.InputStream;
  * @author cstamas
  */
 public abstract class AbstractWrappingContentLocator
-    implements ContentLocator
+    implements ContentLocator, Closeable
 {
     private final ContentLocator contentLocator;
 
@@ -53,5 +54,23 @@ public abstract class AbstractWrappingContentLocator
     public boolean isReusable()
     {
         return getTarget().isReusable();
+    }
+
+    /**
+     * Cleans up, closes the wrapped content locator, if it is instance of {@link Closeable}. To be used in cases when
+     * you actually don't need the stream (as some error cropped up), and you never requested the stream instance using
+     * {@link #getContent()}.
+     * 
+     * @throws IOException if an I/O error occurs.
+     * @since 2.5
+     */
+    @Override
+    public void close()
+        throws IOException
+    {
+        if ( contentLocator instanceof Closeable )
+        {
+            ( (Closeable) contentLocator ).close();
+        }
     }
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
@@ -12,10 +12,9 @@
  */
 package org.sonatype.nexus.proxy.item;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-
-import com.google.common.io.Closeables;
 
 /**
  * A content locator that emits a prepared InputStream. Not reusable.
@@ -23,7 +22,7 @@ import com.google.common.io.Closeables;
  * @author cstamas
  */
 public class PreparedContentLocator
-    implements ContentLocator
+    implements ContentLocator, Closeable
 {
     private final InputStream content;
 
@@ -56,13 +55,14 @@ public class PreparedContentLocator
 
     /**
      * Cleans up, closes the underlying prepared content. To be used in cases when you actually don't need the stream
-     * (as some error cropped up), and you never requested the stream instance using {@link #getContent()}. This method
-     * will suppress any eventual {@link IOException}.
+     * (as some error cropped up), and you never requested the stream instance using {@link #getContent()}.
      * 
+     * @throws IOException if an I/O error occurs.
      * @since 2.5
      */
-    public void closePreparedContent()
+    public void close()
+        throws IOException
     {
-        Closeables.closeQuietly( content );
+        content.close();
     }
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
@@ -60,6 +60,7 @@ public class PreparedContentLocator
      * @throws IOException if an I/O error occurs.
      * @since 2.5
      */
+    @Override
     public void close()
         throws IOException
     {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/item/PreparedContentLocator.java
@@ -15,6 +15,8 @@ package org.sonatype.nexus.proxy.item;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.google.common.io.Closeables;
+
 /**
  * A content locator that emits a prepared InputStream. Not reusable.
  * 
@@ -50,5 +52,17 @@ public class PreparedContentLocator
     public boolean isReusable()
     {
         return false;
+    }
+
+    /**
+     * Cleans up, closes the underlying prepared content. To be used in cases when you actually don't need the stream
+     * (as some error cropped up), and you never requested the stream instance using {@link #getContent()}. This method
+     * will suppress any eventual {@link IOException}.
+     * 
+     * @since 2.5
+     */
+    public void closePreparedContent()
+    {
+        Closeables.closeQuietly( content );
     }
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
@@ -52,6 +52,7 @@ import org.sonatype.nexus.proxy.wastebasket.Wastebasket;
 import org.sonatype.nexus.util.ItemPathUtils;
 
 import com.google.common.base.Strings;
+import com.google.common.io.Closeables;
 
 /**
  * LocalRepositoryStorage that uses plain File System (relies on {@link File}) to implement it's functionality.
@@ -387,7 +388,7 @@ public class DefaultFSLocalRepositoryStorage
             if ( originalContentLocator != null
                 && ( originalContentLocator instanceof PreparedContentLocator ) )
             {
-                ( (PreparedContentLocator) originalContentLocator ).closePreparedContent();
+                Closeables.closeQuietly( ( (PreparedContentLocator) originalContentLocator ) );
             }
         }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.proxy.storage.local.fs;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -40,7 +41,6 @@ import org.sonatype.nexus.proxy.item.DefaultStorageCollectionItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageLinkItem;
 import org.sonatype.nexus.proxy.item.LinkPersister;
-import org.sonatype.nexus.proxy.item.PreparedContentLocator;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
@@ -385,10 +385,9 @@ public class DefaultFSLocalRepositoryStorage
             // (typically those coming from RRS, as the content is actually wrapped HTTP response body, hence not reusable)
             // get closed irrelevant of the actual outcome. If all went right, stream was already closed,
             // and we will be "punished" by one extra (redundant) call to Closeable#close().
-            if ( originalContentLocator != null
-                && ( originalContentLocator instanceof PreparedContentLocator ) )
+            if ( originalContentLocator instanceof Closeable )
             {
-                Closeables.closeQuietly( ( (PreparedContentLocator) originalContentLocator ) );
+                Closeables.closeQuietly( (Closeable) originalContentLocator );
             }
         }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/storage/local/fs/DefaultFSLocalRepositoryStorage.java
@@ -40,6 +40,7 @@ import org.sonatype.nexus.proxy.item.DefaultStorageCollectionItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
 import org.sonatype.nexus.proxy.item.DefaultStorageLinkItem;
 import org.sonatype.nexus.proxy.item.LinkPersister;
+import org.sonatype.nexus.proxy.item.PreparedContentLocator;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
@@ -328,42 +329,67 @@ public class DefaultFSLocalRepositoryStorage
     public void storeItem( Repository repository, StorageItem item )
         throws UnsupportedStorageOperationException, LocalStorageException
     {
-        // set some sanity stuff
-        item.setStoredLocally( System.currentTimeMillis() );
-        item.setRemoteChecked( item.getStoredLocally() );
-        item.setExpired( false );
-
-        File target = getFileFromBase( repository, item.getResourceStoreRequest() );
-
-        ContentLocator cl = null;
-
+        final File target;
+        final ContentLocator originalContentLocator;
         if ( item instanceof StorageFileItem )
         {
-            StorageFileItem fItem = (StorageFileItem) item;
-
-            prepareStorageFileItemForStore( fItem );
-
-            cl = fItem.getContentLocator();
+            originalContentLocator = ( (StorageFileItem) item ).getContentLocator();
         }
-        else if ( item instanceof StorageLinkItem )
+        else
         {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-
-            try
-            {
-                getLinkPersister().writeLinkContent( (StorageLinkItem) item, bos );
-            }
-            catch ( IOException e )
-            {
-                // should not happen, look at implementation
-                // we will handle here two byte array backed streams!
-                throw new LocalStorageException( "Problem ", e );
-            }
-
-            cl = new ByteArrayContentLocator( bos.toByteArray(), "text/xml" );
+            originalContentLocator = null;
         }
+        try 
+        {
+            // set some sanity stuff
+            item.setStoredLocally( System.currentTimeMillis() );
+            item.setRemoteChecked( item.getStoredLocally() );
+            item.setExpired( false );
 
-        getFSPeer().storeItem( repository, getBaseDir( repository, item.getResourceStoreRequest() ), item, target, cl );
+            ContentLocator cl = null;
+
+            if ( item instanceof StorageFileItem )
+            {
+                StorageFileItem fItem = (StorageFileItem) item;
+
+                prepareStorageFileItemForStore( fItem );
+
+                cl = fItem.getContentLocator();
+            }
+            else if ( item instanceof StorageLinkItem )
+            {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+                try
+                {
+                    getLinkPersister().writeLinkContent( (StorageLinkItem) item, bos );
+                }
+                catch ( IOException e )
+                {
+                    // should not happen, look at implementation
+                    // we will handle here two byte array backed streams!
+                    throw new LocalStorageException( "Problem ", e );
+                }
+
+                cl = new ByteArrayContentLocator( bos.toByteArray(), "text/xml" );
+            }
+
+            target = getFileFromBase( repository, item.getResourceStoreRequest() );
+
+            getFSPeer().storeItem( repository, getBaseDir( repository, item.getResourceStoreRequest() ), item, target, cl );
+        } 
+        finally
+        {
+            // NEXUS-5468: Ensure that in case of file item with prepared content
+            // (typically those coming from RRS, as the content is actually wrapped HTTP response body, hence not reusable)
+            // get closed irrelevant of the actual outcome. If all went right, stream was already closed,
+            // and we will be "punished" by one extra (redundant) call to Closeable#close().
+            if ( originalContentLocator != null
+                && ( originalContentLocator instanceof PreparedContentLocator ) )
+            {
+                ( (PreparedContentLocator) originalContentLocator ).closePreparedContent();
+            }
+        }
 
         if ( item instanceof StorageFileItem )
         {

--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/NEXUS5468ConnectionLeakOnStoreItemTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/storage/local/fs/NEXUS5468ConnectionLeakOnStoreItemTest.java
@@ -1,0 +1,111 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.proxy.storage.local.fs;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sonatype.nexus.mime.MimeSupport;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
+import org.sonatype.nexus.proxy.attributes.AttributesHandler;
+import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
+import org.sonatype.nexus.proxy.item.LinkPersister;
+import org.sonatype.nexus.proxy.item.PreparedContentLocator;
+import org.sonatype.nexus.proxy.repository.Repository;
+import org.sonatype.nexus.proxy.wastebasket.Wastebasket;
+import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+/**
+ * Testing NEXUS-5468 http connection leak triggered by LocalStorageException
+ * 
+ * @author cstamas
+ */
+public class NEXUS5468ConnectionLeakOnStoreItemTest
+    extends TestSupport
+{
+    @Mock
+    private Wastebasket wastebasket;
+
+    @Mock
+    private LinkPersister linkPersister;
+
+    @Mock
+    private MimeSupport mimeSupport;
+
+    @Mock
+    private FSPeer fsPeer;
+
+    @Test
+    public void closeIsCalledOnPreparedContentLocatorIfAllWentOkay()
+        throws Exception
+    {
+        final InputStream preparedStream = Mockito.mock( InputStream.class );
+        try
+        {
+            final DefaultFSLocalRepositoryStorage testSubject =
+                new DefaultFSLocalRepositoryStorage( wastebasket, linkPersister, mimeSupport, fsPeer );
+
+            final Repository repository = Mockito.mock( Repository.class );
+            Mockito.when( repository.getId() ).thenReturn( "test" );
+            Mockito.when( repository.getAttributesHandler() ).thenReturn( Mockito.mock( AttributesHandler.class ) );
+            // we return some URL, but does not matter which, this is only to avoid NPE
+            // so execution path is "normal success" of storeItem in this case
+            Mockito.when( repository.getLocalUrl() ).thenReturn( new File( "target" ).toURI().toURL().toString() );
+
+            final PreparedContentLocator pcl = new PreparedContentLocator( preparedStream, "text/plain" );
+
+            final DefaultStorageFileItem file =
+                new DefaultStorageFileItem( repository, new ResourceStoreRequest( "/some/file.txt" ), true, true, pcl );
+
+            testSubject.storeItem( repository, file );
+        }
+        finally
+        {
+            Mockito.verify( preparedStream, Mockito.times( 1 ) ).close();
+        }
+    }
+
+    @Test( expected = RuntimeException.class )
+    public void closeIsCalledOnPreparedContentLocatorIfUnexpectedExceptionIsMet()
+        throws Exception
+    {
+        final InputStream preparedStream = Mockito.mock( InputStream.class );
+        try
+        {
+            final DefaultFSLocalRepositoryStorage testSubject =
+                new DefaultFSLocalRepositoryStorage( wastebasket, linkPersister, mimeSupport, fsPeer );
+
+            final Repository repository = Mockito.mock( Repository.class );
+            Mockito.when( repository.getId() ).thenReturn( "test" );
+            Mockito.when( repository.getAttributesHandler() ).thenReturn( Mockito.mock( AttributesHandler.class ) );
+            // we intentionally throw some unexpected exception here
+            // so execution path here will be interrupted
+            Mockito.when( repository.getLocalUrl() ).thenThrow( new RuntimeException( "Something unexpected!" ) );
+
+            final PreparedContentLocator pcl = new PreparedContentLocator( preparedStream, "text/plain" );
+
+            final DefaultStorageFileItem file =
+                new DefaultStorageFileItem( repository, new ResourceStoreRequest( "/some/file.txt" ), true, true, pcl );
+
+            testSubject.storeItem( repository, file );
+        }
+        finally
+        {
+            Mockito.verify( preparedStream, Mockito.times( 1 ) ).close();
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for LRS to always clean up PreparedContentLocator instances
and a UT verifying this happens in both case, in "norma" but
also in "early unexpected" exception case.

Issue:
https://issues.sonatype.org/browse/NEXUS-5468

CI
https://bamboo.zion.sonatype.com/browse/NXO-OSSF2-1
