### PR TITLE
[REVIEW] Turn Velocity template caching on.

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
@@ -1,0 +1,83 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.velocity;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.sonatype.sisu.velocity.internal.VelocityConfigurator;
+
+/**
+ * Nexus specific {@link VelocityConfigurator} implementation, that configures {@link VelocityEngine} for Nexus, and
+ * supports "development" or "production" mode, depending on configuration (system property
+ * {@code nexus.velocity.production} that defaults to {@code true}). By default, it configures the "production" mode,
+ * which is basically turning template caching on without modification check (as Nexus uses JARred templates that are
+ * not changing at runtime).
+ * 
+ * @author cstamas
+ * @since 2.5
+ */
+@Singleton
+@Named
+public class NexusVelocityConfigurator
+    implements VelocityConfigurator
+{
+    private final boolean production;
+
+    @Inject
+    public NexusVelocityConfigurator( @Named( "${nexus.velocity.production:-true}" ) final boolean production )
+    {
+        super();
+        this.production = production;
+    }
+
+    @Override
+    public void configure( final VelocityEngine engine )
+    {
+        engine.setProperty( RuntimeConstants.RESOURCE_LOADER, "class" );
+        engine.setProperty( "class.resource.loader.class",
+            "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader" );
+
+        if ( production )
+        {
+            configureForProduction( engine );
+        }
+        else
+        {
+            configureForDevelopment( engine );
+        }
+    }
+
+    // ==
+
+    protected void configureForProduction( final VelocityEngine engine )
+    {
+        // caching ON
+        engine.setProperty( "class.resource.loader.cache", "true" );
+        // never check for template modification (they are JARred)
+        engine.setProperty( "class.resource.loader.modificationCheckInterval", "0" );
+        // strict mode OFF
+        engine.setProperty( "runtime.references.strict", "false" );
+    }
+
+    protected void configureForDevelopment( final VelocityEngine engine )
+    {
+        // caching OFF
+        engine.setProperty( "class.resource.loader.cache", "false" );
+        // strict mode ON for early error detection
+        engine.setProperty( "runtime.references.strict", "true" );
+    }
+}

--- a/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.nexus.velocity;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -35,49 +34,17 @@ import org.sonatype.sisu.velocity.internal.VelocityConfigurator;
 public class NexusVelocityConfigurator
     implements VelocityConfigurator
 {
-    private final boolean production;
-
-    @Inject
-    public NexusVelocityConfigurator( @Named( "${nexus.velocity.production:-true}" ) final boolean production )
-    {
-        super();
-        this.production = production;
-    }
-
     @Override
     public void configure( final VelocityEngine engine )
     {
         engine.setProperty( RuntimeConstants.RESOURCE_LOADER, "class" );
         engine.setProperty( "class.resource.loader.class",
             "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader" );
-
-        if ( production )
-        {
-            configureForProduction( engine );
-        }
-        else
-        {
-            configureForDevelopment( engine );
-        }
-    }
-
-    // ==
-
-    protected void configureForProduction( final VelocityEngine engine )
-    {
         // caching ON
         engine.setProperty( "class.resource.loader.cache", "true" );
         // never check for template modification (they are JARred)
         engine.setProperty( "class.resource.loader.modificationCheckInterval", "0" );
         // strict mode OFF
         engine.setProperty( "runtime.references.strict", "false" );
-    }
-
-    protected void configureForDevelopment( final VelocityEngine engine )
-    {
-        // caching OFF
-        engine.setProperty( "class.resource.loader.cache", "false" );
-        // strict mode ON for early error detection
-        engine.setProperty( "runtime.references.strict", "true" );
     }
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/velocity/NexusVelocityConfigurator.java
@@ -20,11 +20,9 @@ import org.apache.velocity.runtime.RuntimeConstants;
 import org.sonatype.sisu.velocity.internal.VelocityConfigurator;
 
 /**
- * Nexus specific {@link VelocityConfigurator} implementation, that configures {@link VelocityEngine} for Nexus, and
- * supports "development" or "production" mode, depending on configuration (system property
- * {@code nexus.velocity.production} that defaults to {@code true}). By default, it configures the "production" mode,
- * which is basically turning template caching on without modification check (as Nexus uses JARred templates that are
- * not changing at runtime).
+ * Nexus specific {@link VelocityConfigurator} implementation, that configures {@link VelocityEngine} for Nexus. It
+ * configures the "production" mode, which is basically turning template caching on without modification check (as Nexus
+ * uses JARred templates that are not changing at runtime).
  * 
  * @author cstamas
  * @since 2.5

--- a/nexus-core/src/test/java/org/sonatype/nexus/velocity/NexusVelocityConfiguratorTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/velocity/NexusVelocityConfiguratorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.velocity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+import org.sonatype.nexus.test.NexusTestSupport;
+import org.sonatype.sisu.velocity.Velocity;
+
+/**
+ * Test ensuring production config on Velocity is set. The dev setting is not checked
+ * 
+ * @author cstamas
+ */
+public class NexusVelocityConfiguratorTest
+    extends NexusTestSupport
+{
+    @Test
+    public void checkForProduction()
+        throws Exception
+    {
+        final Velocity velocity = lookup( Velocity.class );
+
+        assertThat( (String) velocity.getEngine().getProperty( "class.resource.loader.cache" ), equalTo( "true" ) );
+        assertThat( (String) velocity.getEngine().getProperty( "class.resource.loader.modificationCheckInterval" ),
+            equalTo( "0" ) );
+        assertThat( (String) velocity.getEngine().getProperty( "runtime.references.strict" ), equalTo( "false" ) );
+    }
+}


### PR DESCRIPTION
As turned out, Templates are always re-read from classpath
causing congestion.

Using SISU Velocity's VelocityConfigurator to configure
enging to Nexus needs (as it was using defaults) set in
VelocityImpl of sisu-velocity.

This NX specific Configurator overrides the defaults from here
https://github.com/sonatype/sisu-velocity/blob/master/src/main/java/org/sonatype/sisu/velocity/internal/VelocityImpl.java#L74

These defaults were used by NX so far.

Verified that caching works (as this is Velocity concern
not Nexus) by debugging. Method (line 294):

org.apache.velocity.runtime.resource.ResourceManagerImpl.getResource(String, int, String)

Verified that template is loaded up once, and subsequent calls
are retrieving it from "globalCache".
