### PR TITLE
[REVIEW] Caching MimeUtil2 responses

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
@@ -16,7 +16,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -26,12 +25,9 @@ import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.item.ContentLocator;
 
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.MapMaker;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 
 import eu.medsea.mimeutil.MimeType;

--- a/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
@@ -143,9 +143,7 @@ public class DefaultMimeSupport
         }
         catch ( ExecutionException e )
         {
-            Throwables.propagate( e );
-            // only to make compiler happy, execution will never get here
-            return null;
+            throw Throwables.propagate( e );
         }
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
@@ -25,6 +25,7 @@ import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.item.ContentLocator;
 
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -142,7 +143,9 @@ public class DefaultMimeSupport
         }
         catch ( ExecutionException e )
         {
-            throw new RuntimeException( e );
+            Throwables.propagate( e );
+            // only to make compiler happy, execution will never get here
+            return null;
         }
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/mime/DefaultMimeSupport.java
@@ -16,19 +16,31 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
-import com.google.common.base.Strings;
-import com.google.common.io.Closeables;
-import eu.medsea.mimeutil.MimeType;
-import eu.medsea.mimeutil.MimeUtil2;
-import eu.medsea.mimeutil.detector.MagicMimeMimeDetector;
 import org.codehaus.plexus.component.annotations.Component;
 import org.sonatype.nexus.logging.AbstractLoggingComponent;
 import org.sonatype.nexus.proxy.item.ContentLocator;
 
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
+import com.google.common.io.Closeables;
+
+import eu.medsea.mimeutil.MimeType;
+import eu.medsea.mimeutil.MimeUtil2;
+import eu.medsea.mimeutil.detector.MagicMimeMimeDetector;
+
 /**
- * Default implementation of {@link MimeSupport} component using MimeUtil2 library and the {@link NexusExtensionMimeDetector}.
+ * Default implementation of {@link MimeSupport} component using MimeUtil2 library and the
+ * {@link NexusExtensionMimeDetector}.
  * 
  * @since 2.0
  */
@@ -40,6 +52,18 @@ public class DefaultMimeSupport
     private final MimeUtil2 nonTouchingMimeUtil;
 
     private final MimeUtil2 touchingMimeUtil;
+
+    /**
+     * A "cache" to be used with {@link #nonTouchingMimeUtil}. As that instance of MimeUtil2 uses only one mime detector
+     * registered by us, the {@link NexusExtensionMimeDetector}. Hence, even if the
+     * {@link #guessMimeTypeFromPath(String)} and other methods talk about paths, we know they actually deal with file
+     * extensions only (deduces the MIME type from file extension). This map simply caches the responses from MimeUtil2,
+     * as it's operation is a bit heavy weight (congestion happens on synchronized {@link Properties} instance deeply
+     * buried in MimeUtil2 classes), and also, modifications to extension MIME type mapping is not possible without
+     * restarting JVM where MimeUtil2. The cache is keyed with extensions, values are MIME types (represented as
+     * strings).
+     */
+    private final LoadingCache<String, String> extensionToMimeTypeCache;
 
     /**
      * See {@link NexusMimeTypes} for customizations
@@ -57,6 +81,30 @@ public class DefaultMimeSupport
         // See src/main/resources/magic.mime for customizations
         touchingMimeUtil = new MimeUtil2();
         touchingMimeUtil.registerMimeDetector( MagicMimeMimeDetector.class.getName() );
+
+        // create the cache
+        extensionToMimeTypeCache =
+            CacheBuilder.newBuilder().maximumSize( 500 ).build( new CacheLoader<String, String>()
+            {
+                @Override
+                public String load( final String key )
+                    throws Exception
+                {
+                    // FIXME (by replacing MimeUtil with something else?)
+                    // MimeUtil2#getMostSpecificMimeType is broken in 2.1.2/2.1.3, it will (in contrast to it's javadoc)
+                    // *usually*
+                    // return the last
+                    // mime type regardless of specificity. Which one is last depends on the impl of
+                    // HashSet<String>.iterator()
+                    // (which seems to have a fairly stable ordering on JVM: different order breaks unit tests.)
+                    //
+                    // TODO: Hack alert: as with introduction of cache, loading cache will be invoked with extension got from 
+                    // the path only. As code reading showed, MimeUtil2 will do similarly, as only extension MimeDetector is registered
+                    // Still, we make a "fake" filename, just to not bork any existing logic or expectancies in MimeUtil2. Still
+                    // it is the extension that matters of this "dummy" file.
+                    return MimeUtil2.getMostSpecificMimeType( getNonTouchingMimeUtil2().getMimeTypes( "dummyfile." + key ) ).toString();
+                }
+            } );
     }
 
     protected MimeUtil2 getNonTouchingMimeUtil2()
@@ -88,11 +136,18 @@ public class DefaultMimeSupport
     @Override
     public String guessMimeTypeFromPath( final String path )
     {
-        // FIXME (by replacing MimeUtil with something else?)
-        // MimeUtil2#getMostSpecificMimeType is broken in 2.1.2/2.1.3, it will (in contrast to it's javadoc) *usually* return the last
-        // mime type regardless of specificity. Which one is last depends on the impl of HashSet<String>.iterator() (which seems
-        // to have a fairly stable ordering on JVM: different order breaks unit tests.)
-        return MimeUtil2.getMostSpecificMimeType( getNonTouchingMimeUtil2().getMimeTypes( path ) ).toString();
+        // even if we got path as param, the "non touching" mimeutil2 uses extensions only
+        // see constructor how it is configured
+        // Note: using same method to get extension as MimeUtil2's MimeDetectors would
+        final String pathExtension = MimeUtil2.getExtension( path );
+        try
+        {
+            return extensionToMimeTypeCache.get( pathExtension );
+        }
+        catch ( ExecutionException e )
+        {
+            throw new RuntimeException( e );
+        }
     }
 
     @Override
@@ -131,5 +186,4 @@ public class DefaultMimeSupport
         }
         return result;
     }
-
 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/mime/NexusExtensionMimeDetector.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/mime/NexusExtensionMimeDetector.java
@@ -14,12 +14,10 @@ package org.sonatype.nexus.mime;
 
 import java.util.Collection;
 import java.util.List;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+
 import eu.medsea.mimeutil.MimeException;
 import eu.medsea.mimeutil.MimeUtil2;
 import eu.medsea.mimeutil.detector.ExtensionMimeDetector;


### PR DESCRIPTION
Calling into MimeUtil2 hides a point where
congestion might happen, as all these calls
are hitting a single j.u.Properties instance.

This change adds a cache a top of MimeUtil2
(actually in Nexus component wrapping it),
and should reduce actual calls to MimeUtil2.

The calls to guess MIME types are happening often, at high rate.
It happens at every creation of StorageFileItem.
