### PR TITLE
REVIEW [NEXUS-5599] Warn if browser is <IE8

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/resources/templates/index.vm
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/resources/templates/index.vm
@@ -79,6 +79,10 @@
                         }
                         alreadyDone = true;
 
+                        if (Ext.isIE6 || Ext.isIE7) {
+                            Ext.MessageBox.alert('Unsupported Browser', 'You are using a version of Internet Explorer that is not supported.<br/>See the <a href="http://links.sonatype.com/products/nexus/oss/docs/browsers">knowledge base article</a> for details.')
+                        }
+
                         Nexus.Log.debug('Initializing UI...');
                         Sonatype.init();
                         Sonatype.view.init();


### PR DESCRIPTION
Opens a modal dialog so that the user has to acknowledge that they are using an unsupported browser.

Link goes to https://support.sonatype.com/entries/22926682-Nexus-2-3-Internet-Explorer-Compatibility, this should probably be a redirect from links.sonatype.com
