### PR TITLE
[NEXUS-267] default to sortable columns

### DIFF
--- a/nexus-webapp/src/main/webapp/js/Sonatype/panels/GridViewer.js
+++ b/nexus-webapp/src/main/webapp/js/Sonatype/panels/GridViewer.js
@@ -197,7 +197,10 @@ NX.define('Sonatype.panels.GridViewer', {
       // sortInfo: { field: 'name', direction: "ASC"},
       loadMask : true,
       deferredRender : false,
-      columns : columns,
+      colModel : new Ext.grid.ColumnModel({
+        defaultSortable : true,
+        columns : columns
+      }),
       autoExpandColumn : this.autoExpandColumn,
       disableSelection : false,
 


### PR DESCRIPTION
This change will make grid columns sortable for those views in Nexus which extend the GridViewer (e.g. security/user, sec/privileges, plugin console, ...)
