### PR TITLE
TRIVIAL: Fix test to work on Windows

### DIFF
--- a/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshallerTest.java
+++ b/nexus-core/src/test/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshallerTest.java
@@ -122,7 +122,7 @@ public class TextFilePrefixSourceMarshallerTest
 
         for ( String header : TextFilePrefixSourceMarshaller.HEADERS )
         {
-            sb.append( header ).append( "\n" );
+            sb.append( header ).append( System.getProperty("line.separator") );
         }
         sb.append( content );
         return sb.toString();


### PR DESCRIPTION
Test was failing on Windows due to a line-ending mismatch. Changed the test to be line-ending agnostic
