### PR TITLE
[REVIEW] NEXUS-5511 Refine reasoning

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -454,14 +454,12 @@ public abstract class AbstractMavenRepository
     }
 
     @Override
-    protected boolean shouldTryRemote( final ResourceStoreRequest request )
+    protected void shouldTryRemote( final ResourceStoreRequest request )
         throws IllegalOperationException, ItemNotFoundException
     {
-        final boolean shouldTryRemote = super.shouldTryRemote( request );
-        if ( !shouldTryRemote )
-        {
-            return false;
-        }
+        // do super first
+        super.shouldTryRemote( request );
+        // if here, super did not throw any exception, so let's continue
         // apply autorouting filter to "normal" requests only, not hidden (which is meta or plain hidden)
         final RepositoryItemUid uid = createUid( request.getRequestPath() );
         if ( !uid.getBooleanAttributeValue( IsHiddenAttribute.class ) )
@@ -473,12 +471,13 @@ public abstract class AbstractMavenRepository
                 if ( !proxyFilterAllowed )
                 {
                     getLogger().debug( "Automatic routing filter rejected remote request for path {} in {}.",
-                        request.getRequestPath(), RepositoryStringUtils.getHumanizedNameString( this ) );
-                    return false;
+                        request.getRequestPath(), this );
+                    throw new ItemNotFoundException( ItemNotFoundException.reasonFor( request, this,
+                        "Automatic routing filter rejected remote request for path %s in %s", request.getRequestPath(),
+                        this ) );
                 }
             }
         }
-        return true;
     }
 
     @Override

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -48,8 +48,8 @@ import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.item.uid.IsHiddenAttribute;
 import org.sonatype.nexus.proxy.maven.EvictUnusedMavenItemsWalkerProcessor.EvictUnusedMavenItemsWalkerFilter;
 import org.sonatype.nexus.proxy.maven.packaging.ArtifactPackagingMapper;
-import org.sonatype.nexus.proxy.maven.routing.ProxyRequestFilter;
 import org.sonatype.nexus.proxy.maven.routing.Manager;
+import org.sonatype.nexus.proxy.maven.routing.ProxyRequestFilter;
 import org.sonatype.nexus.proxy.repository.AbstractProxyRepository;
 import org.sonatype.nexus.proxy.repository.DefaultRepositoryKind;
 import org.sonatype.nexus.proxy.repository.HostedRepository;
@@ -470,10 +470,8 @@ public abstract class AbstractMavenRepository
                 final boolean proxyFilterAllowed = getProxyRequestFilter().allowed( this, request );
                 if ( !proxyFilterAllowed )
                 {
-                    getLogger().debug( "Automatic routing filter rejected remote request for path {} in {}.",
-                        request.getRequestPath(), this );
                     throw new ItemNotFoundException( ItemNotFoundException.reasonFor( request, this,
-                        "Automatic routing filter rejected remote request for path %s in %s", request.getRequestPath(),
+                        "Automatic routing filter rejected remote request for path %s from %s", request.getRequestPath(),
                         this ) );
                 }
             }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/AbstractMavenRepository.java
@@ -414,7 +414,7 @@ public abstract class AbstractMavenRepository
 
             throw new ItemNotFoundException( reasonFor( request, this,
                 "Retrieval of %s from %s is forbidden by repository policy %s.", request.getRequestPath(),
-                RepositoryStringUtils.getHumanizedNameString( this ), getRepositoryPolicy() ) );
+                this, getRepositoryPolicy() ) );
         }
 
         if ( getRepositoryKind().isFacetAvailable( ProxyRepository.class )

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractGroupRepository.java
@@ -260,7 +260,7 @@ public abstract class AbstractGroupRepository
             {
                 throw new GroupItemNotFoundException( reasonFor( request, this,
                     "The %s not found in local storage of group repository %s (no member processing happened).",
-                    request.getRequestPath(), RepositoryStringUtils.getHumanizedNameString( this ) ), memberThrowables );
+                    request.getRequestPath(), this ), memberThrowables );
             }
         }
 
@@ -417,7 +417,7 @@ public abstract class AbstractGroupRepository
             {
                 throw new GroupItemNotFoundException( reasonFor( request, this,
                     "The %s not found in local storage of group repository %s (no member processing happened).",
-                    request.getRequestPath(), RepositoryStringUtils.getHumanizedNameString( this ) ), memberThrowables );
+                    request.getRequestPath(), this ), memberThrowables );
             }
         }
         finally
@@ -666,7 +666,7 @@ public abstract class AbstractGroupRepository
             {
                 throw new GroupItemNotFoundException( reasonFor( request, this,
                     "The %s not found in local storage of group repository %s (no member processing happened).",
-                    request.getRequestPath(), RepositoryStringUtils.getHumanizedNameString( this ) ), memberThrowables );
+                    request.getRequestPath(), this ), memberThrowables );
             }
         }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.proxy.repository;
 
+import static org.sonatype.nexus.proxy.ItemNotFoundException.reasonFor;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,8 +75,6 @@ import org.sonatype.nexus.util.ConstantNumberSequence;
 import org.sonatype.nexus.util.FibonacciNumberSequence;
 import org.sonatype.nexus.util.NumberSequence;
 import org.sonatype.nexus.util.SystemPropertiesHelper;
-
-import static org.sonatype.nexus.proxy.ItemNotFoundException.reasonFor;
 
 /**
  * Adds the proxying capability to a simple repository. The proxying will happen only if reposiory has remote storage!
@@ -1158,12 +1158,12 @@ public abstract class AbstractProxyRepository
         if ( request.isRequestLocalOnly() )
         {
             throw new ItemNotFoundException( ItemNotFoundException.reasonFor( request, this,
-                "Request is marked as local-only, remote access not allowed" ) );
+                "Request is marked as local-only, remote access not allowed from %s", this ) );
         }
         if ( getProxyMode() != null && !getProxyMode().shouldProxy() )
         {
             throw new ItemNotFoundException( ItemNotFoundException.reasonFor( request, this,
-                "Repository proxy-mode is %s, remote access not allowed", getProxyMode() ) );
+                "Repository proxy-mode is %s, remote access not allowed from %s", getProxyMode(), this ) );
         }
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1352,8 +1352,8 @@ public abstract class AbstractProxyRepository
                 }
 
                 throw new ItemNotFoundException( reasonFor( request, this,
-                    "Path %s not found in local nor in remote storage of %s repository.", request.getRequestPath(),
-                    RepositoryStringUtils.getHumanizedNameString( this ) ) );
+                    "Path %s not found in local nor in remote storage of %s", request.getRequestPath(),
+                    this ) );
             }
             else if ( localItem != null && remoteItem == null )
             {

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1738,8 +1738,8 @@ public abstract class AbstractProxyRepository
 
             // validation failed, I guess.
             throw new ItemNotFoundException( reasonFor( request, this,
-                "Path %s fetched from remote but failed validation in %s.", request.getRequestPath(),
-                RepositoryStringUtils.getHumanizedNameString( this ) ) );
+                "Path %s fetched from remote storage of %s but failed validation.", request.getRequestPath(),
+                this ) );
         }
         finally
         {
@@ -1835,7 +1835,7 @@ public abstract class AbstractProxyRepository
                             RemoteStatus.UNAVAILABLE,
                             new ItemNotFoundException( reasonFor( request, AbstractProxyRepository.this,
                                 "Proxy mode %s or repository %s forbids remote storage use.", getProxyMode(),
-                                RepositoryStringUtils.getHumanizedNameString( AbstractProxyRepository.this ) ) ) );
+                                AbstractProxyRepository.this ) ) );
                     }
                     else
                     {
@@ -1847,7 +1847,7 @@ public abstract class AbstractProxyRepository
                         {
                             autoBlockProxying( new ItemNotFoundException( reasonFor( request,
                                 AbstractProxyRepository.this, "Remote peer of repository %s detected as unavailable.",
-                                RepositoryStringUtils.getHumanizedNameString( AbstractProxyRepository.this ) ) ) );
+                                AbstractProxyRepository.this ) ) );
                         }
                     }
                 }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -1215,8 +1215,7 @@ public abstract class AbstractRepository
                     }
 
                     throw new ItemNotFoundException( reasonFor( request, this,
-                        "The path %s is in NFC of repository %s.", request.getRequestPath(),
-                        RepositoryStringUtils.getHumanizedNameString( this ) ) );
+                        "The path %s is in NFC of repository %s.", request.getRequestPath(), this ) );
                 }
             }
         }

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -675,7 +675,7 @@ public abstract class AbstractRepository
                     + " but repository is not Browseable." );
 
             throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable.",
-                RepositoryStringUtils.getHumanizedNameString( this ) ) );
+                this ) );
         }
 
         checkPostConditions( request, item );
@@ -772,7 +772,7 @@ public abstract class AbstractRepository
         }
         else
         {
-            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable!" ) );
+            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable!", this ) );
         }
 
         return items;
@@ -871,7 +871,8 @@ public abstract class AbstractRepository
                             RepositoryStringUtils.getHumanizedNameString( this ), uid.getPath(), key ) );
 
                     throw new ItemNotFoundException( reasonFor( request, this,
-                        "The generator for generated path %s not found!" ) );
+                        "The generator for generated path %s with key %s not found in %s", request.getRequestPath(),
+                        key, this ) );
                 }
             }
 
@@ -1142,7 +1143,7 @@ public abstract class AbstractRepository
         else
         {
             throw new ItemNotFoundException( reasonFor( request, this, "Path %s in repository %s is not a collection.",
-                request.getRequestPath(), RepositoryStringUtils.getHumanizedNameString( this ) ) );
+                request.getRequestPath(), this ) );
         }
     }
 

--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractRepository.java
@@ -674,7 +674,7 @@ public abstract class AbstractRepository
                 getId() + " retrieveItem() :: FOUND a collection on " + request.toString()
                     + " but repository is not Browseable." );
 
-            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable.",
+            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable",
                 this ) );
         }
 
@@ -772,7 +772,7 @@ public abstract class AbstractRepository
         }
         else
         {
-            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable!", this ) );
+            throw new ItemNotFoundException( reasonFor( request, this, "Repository %s is not browsable", this ) );
         }
 
         return items;
@@ -1142,7 +1142,7 @@ public abstract class AbstractRepository
         }
         else
         {
-            throw new ItemNotFoundException( reasonFor( request, this, "Path %s in repository %s is not a collection.",
+            throw new ItemNotFoundException( reasonFor( request, this, "Path %s in repository %s is not a collection",
                 request.getRequestPath(), this ) );
         }
     }
@@ -1216,7 +1216,7 @@ public abstract class AbstractRepository
                     }
 
                     throw new ItemNotFoundException( reasonFor( request, this,
-                        "The path %s is in NFC of repository %s.", request.getRequestPath(), this ) );
+                        "The path %s is still cached as not found for repository %s", request.getRequestPath(), this ) );
                 }
             }
         }


### PR DESCRIPTION
Original fix for NEXUS-5511, but left some loose endings.

Conditions like "request is local-only", "proxy mode is not ALLOW" and "rejected by auto-routing" were all put under same message stating "...remote storage access is prevented...". Clearly, this is no good.

This pull separates now these scenarios, but also improves the messages by aligning how repository is "rendered" (unifying the message).

See issue for "validation scenario" where new (but also old) reasoning messages are represented:
https://issues.sonatype.org/browse/NEXUS-5511
