### PR TITLE
[PROTOTYPE] Add jsdoc and use it as the plugin documentation

### DIFF
--- a/plugins/nexus-ui-extjs3-plugin/pom.xml
+++ b/plugins/nexus-ui-extjs3-plugin/pom.xml
@@ -136,6 +136,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>nl.secondfloor.mojo.jsduck</groupId>
+        <artifactId>jsduck-maven-plugin</artifactId>
+        <version>0.1.1-SNAPSHOT</version>
+        <configuration>
+          <javascriptDirectory>src/main/resources/static/js</javascriptDirectory>
+          <targetDirectory>${project.build.outputDirectory}/docs</targetDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>clean-jsduck</goal>
+              <goal>jsduck</goal>
+            </goals>
+          </execution>
+        </executions>
+
+      </plugin>
     </plugins>
   </build>
 

--- a/plugins/nexus-ui-extjs3-plugin/src/main/java/org/sonatype/nexus/plugins/ui/rest/UiDocumentationResourceBundle.java
+++ b/plugins/nexus-ui-extjs3-plugin/src/main/java/org/sonatype/nexus/plugins/ui/rest/UiDocumentationResourceBundle.java
@@ -1,0 +1,39 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2012 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.ui.rest;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.plugins.rest.AbstractDocumentationNexusResourceBundle;
+
+/**
+ *
+ */
+@Named
+@Singleton
+public class UiDocumentationResourceBundle
+    extends AbstractDocumentationNexusResourceBundle
+{
+    @Override
+    public String getDescription()
+    {
+        return "ExtJS3 UI";
+    }
+
+    @Override
+    public String getPluginId()
+    {
+        return "nexus-ui-extjs3-plugin";
+    }
+}


### PR DESCRIPTION
Adds configuration for https://github.com/pguedes/maven-jsduck plugin to generated jsdocs to the same path as enunciate would generate the documentation.

There seems to be no way to have two documentation links, so using enunciate and jsduck both needs some changes in core.

The maven-jsduck-plugin is not available from central, so you have to build it locally before trying this branch. The documentation of our js code is lacking at best, and is mostly not in a format recognized by jsduck.
