### PR TITLE
REVIEW: Switch to security 3.1-SNAPSHOT

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/security/NexusViewSecurityResource.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/security/NexusViewSecurityResource.java
@@ -36,8 +36,11 @@ import org.sonatype.security.model.CRole;
 import org.sonatype.security.model.Configuration;
 import org.sonatype.security.realms.tools.AbstractDynamicSecurityResource;
 import org.sonatype.security.realms.tools.ConfigurationManager;
+import org.sonatype.security.realms.tools.ConfigurationManagerAction;
 import org.sonatype.security.realms.tools.DynamicSecurityResource;
 import org.sonatype.sisu.goodies.eventbus.EventBus;
+
+import com.google.common.base.Throwables;
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
 
@@ -162,7 +165,23 @@ public class NexusViewSecurityResource
     {
         setDirty( true );
 
-        configManager.cleanRemovedPrivilege( createPrivilegeId( event.getRepository().getId() ) );
+        try
+        {
+            configManager.runWrite(new ConfigurationManagerAction()
+            {
+                @Override
+                public void run()
+                    throws Exception
+                {
+                    configManager.cleanRemovedPrivilege( createPrivilegeId( event.getRepository().getId() ) );
+                }
+                
+            });
+        }
+        catch(Exception e)
+        {
+            throw Throwables.propagate(e);
+        }
     }
 
     public void initialize()

--- a/nexus-core/src/main/java/org/sonatype/nexus/security/SecurityCleanupEventInspector.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/security/SecurityCleanupEventInspector.java
@@ -32,6 +32,9 @@ import org.sonatype.security.authorization.NoSuchPrivilegeException;
 import org.sonatype.security.authorization.Privilege;
 import org.sonatype.security.authorization.xml.SecurityXmlAuthorizationManager;
 import org.sonatype.security.realms.tools.ConfigurationManager;
+import org.sonatype.security.realms.tools.ConfigurationManagerAction;
+
+import com.google.common.base.Throwables;
 
 @Component( role = EventInspector.class, hint = "SecurityCleanupEventInspector" )
 public class SecurityCleanupEventInspector
@@ -97,7 +100,7 @@ public class SecurityCleanupEventInspector
     {
         Set<Privilege> privileges = security.listPrivileges();
 
-        Set<String> removedIds = new HashSet<String>();
+        final Set<String> removedIds = new HashSet<String>();
 
         for ( Privilege privilege : privileges )
         {
@@ -111,10 +114,26 @@ public class SecurityCleanupEventInspector
             }
         }
 
-        for ( String privilegeId : removedIds )
+        try
         {
-            configManager.cleanRemovedPrivilege( privilegeId );
+            configManager.runWrite(new ConfigurationManagerAction()
+            {
+                @Override
+                public void run()
+                    throws Exception
+                {
+                    for ( String privilegeId : removedIds )
+                    {
+                        configManager.cleanRemovedPrivilege( privilegeId );
+                    }
+                    configManager.save();
+                }
+                
+            });
         }
-        configManager.save();
+        catch(Exception e)
+        {
+            throw Throwables.propagate(e);
+        }
     }
 }

--- a/nexus-test/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleRealmTest.java
+++ b/nexus-test/nexus-it-helper-plugin/src/test/java/org/sonatype/security/realms/simple/SimpleRealmTest.java
@@ -57,7 +57,7 @@ public class SimpleRealmTest
         // copy the tests nexus.xml and security.xml to the correct location
         copyTestConfigToPlace();
         // restart security
-        lookup( ConfigurationManager.class ).clearCache();
+        lookup( ConfigurationManager.class, "legacydefault" ).clearCache();
         lookup( SecuritySystem.class ).start();
     }
 

--- a/plugins/kenai/nexus-kenai-plugin/pom.xml
+++ b/plugins/kenai/nexus-kenai-plugin/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <pluginName>Nexus Kenai Realm Plugin</pluginName>
     <pluginDescription>Adds Kenai realm to Nexus.</pluginDescription>
-    <security.version>3.0.3-SNAPSHOT</security.version>
+    <security.version>3.1-SNAPSHOT</security.version>
     <jetty.version>6.1.12</jetty.version>
   </properties>
 
@@ -47,12 +47,6 @@
       <groupId>org.json</groupId>
       <artifactId>org.json</artifactId>
       <version>2.0-NEXUS-3758</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.security.realms</groupId>
-      <artifactId>security-xml-realm</artifactId>
-      <version>${security.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- These below are transitive deps but are in core already -->

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/privileges/PrivilegeTypePlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/security/rest/privileges/PrivilegeTypePlexusResource.java
@@ -58,7 +58,7 @@ public class PrivilegeTypePlexusResource
     public static final String RESOURCE_URI = "/privilege_types";
 
     @Inject
-    @Named( "resourceMerging" )
+    @Named( "default" )
     private ConfigurationManager configurationManager;
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <aether.version>1.13.1</aether.version>
     <jetty.version>8.1.8.v20121106</jetty.version>
     <maven.version>3.0.4</maven.version>
-    <plexus-security.version>3.0.3-SNAPSHOT</plexus-security.version>
+    <plexus-security.version>3.1-SNAPSHOT</plexus-security.version>
     <shiro.version>1.2.1</shiro.version>
     <jackson.version>1.9.10</jackson.version>
     <goodies.version>1.6.1</goodies.version>


### PR DESCRIPTION
Switch Nexus to use security 3.1-SNAPSHOT to pickup the recently introduced thread-safety improvements.

Other than updating the pom, the other changes were required to conform to the updated interface of ConfigurationManager, introduced in security 3.1-SNAPSHOT
