### PR TITLE
[REVIEW] Making Nexus570IndexArchetypeIT stable.

### DIFF
--- a/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/Jetty8NexusBooter.java
+++ b/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/booter/Jetty8NexusBooter.java
@@ -147,15 +147,8 @@ public class Jetty8NexusBooter
         // guice finalizer
         System.setProperty( "guice.executor.class", "NONE" );
         
-        // Note: in ITs we want to make Indexer perform blocking commits.
-        // Since MavenIndexer 4.0, it performs async commits by default, meaning that no "helper" from Nexus
-        // is able to tell and potentially block (see EventInspectorsUtil#waitForCalmPeriod() as example) execution
-        // up to the moment when readers are refreshed (indexing operation IS done, but readers will not "see" the
-        // change without reopening those).
-        // By having this switch, we are switching Maven Indexer back into "blocking" mode as it was before 4.0.
-        // The proper fix is to make all Indexer related ITs behave "properly" (with some heuristics?), and have some
-        // sort of "try-wait-try-failAfterSomeRetries" the search operation itself.
-        System.setProperty( "mavenIndexerBlockingCommits", Boolean.TRUE.toString() );
+        // Making MI integration in Nexus behave in-sync
+        System.setProperty( "org.sonatype.nexus.events.IndexerManagerEventInspector.async", Boolean.FALSE.toString() );
         
         // Note: autorouting initialization prevented
         // Presence breaks many ITs, especially those that either listen for proxy requests (will be more coz of prefix file


### PR DESCRIPTION
Changes:
- As legacy ITs already had (unsatisfied) expectation about
  "sync" nature of Indexer related operations, added a flag
  to IndexerManagerEventInspector that makes it "blocking" or
  "async" depending on a system property. To be used in ITs.
- removed obsolete "mavenIndexerBlockingCommits" property
  from Jetty8NexusBooter, as code handling this was removed along
  with other notable changes happened in MI 5.x. Simply put,
  this property had no effect since then.
- Using the newly added key in Jetty8NexusBooter, to make
  Index related event inspector become "blocking".
