### PR TITLE
[REVIEW] NEXUS-5710: Status and Content CSS files were not loaded

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/AbstractResourceStoreContentPlexusResource.java
@@ -597,7 +597,13 @@ public abstract class AbstractResourceStoreContentPlexusResource
 
             dataModel.put( "nexusVersion", getNexus().getSystemStatus().getVersion() );
 
-            dataModel.put( "nexusRoot", getContextRoot( req ).toString() );
+            // getContentRoot(req) always returns Reference with "/" as last character
+            String nexusRoot = getContextRoot( req ).toString();
+            if ( nexusRoot.endsWith( "/" ) )
+            {
+                nexusRoot = nexusRoot.substring( 0, nexusRoot.length() - 1 );
+            }
+            dataModel.put( "nexusRoot", nexusRoot );
 
             final VelocityRepresentation representation =
                 new VelocityRepresentation( context, "/templates/repositoryContentHtml.vm",

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/NexusStatusService.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/rest/NexusStatusService.java
@@ -51,7 +51,13 @@ public class NexusStatusService
 
         dataModel.put( "request", request );
         dataModel.put( "nexusVersion", nexus.getSystemStatus().getVersion() );
-        dataModel.put( "nexusRoot", referenceFactory.getContextRoot( request ).toString() );
+        // getContentRoot(req) always returns Reference with "/" as last character
+        String nexusRoot = referenceFactory.getContextRoot( request ).toString();
+        if ( nexusRoot.endsWith( "/" ) )
+        {
+            nexusRoot = nexusRoot.substring( 0, nexusRoot.length() - 1 );
+        }
+        dataModel.put( "nexusRoot", nexusRoot );
 
         dataModel.put( "statusCode", status.getCode() );
         dataModel.put( "statusName", status.getName() );


### PR DESCRIPTION
The URL generated by template (content and status template)
were always wrong, it contained "//" between nexusRoot
and rest of the path info.

But the changes how the resource is served up now
made the "//" appear as error, Restlet refuses
to serve it up (was 404).

The two places of use of getContextRoot(req) where
templates are evaluated are fixed (third place related
to openSearch already had a fix for this), as all the
other users of above mentioned method EXPECT that
returned reference contains path info ending with "/",
unlike the cases related to Velocity templates.
