### PR TITLE
[RFC for 2.5.0-02 release]- include log configuration changes to show beginning of thread name

### DIFF
--- a/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
+++ b/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
@@ -65,7 +65,7 @@ public class DefaultNexusBundleConfiguration
     /**
      * Default logging pattern.
      */
-    private static final String DEFAULT_LOG_PATTERN = "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n";
+    private static final String DEFAULT_LOG_PATTERN = "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n";
 
     /**
      * File task builder.

--- a/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
+++ b/nexus-launcher/src/main/java/org/sonatype/nexus/bundle/launcher/support/DefaultNexusBundleConfiguration.java
@@ -65,7 +65,7 @@ public class DefaultNexusBundleConfiguration
     /**
      * Default logging pattern.
      */
-    private static final String DEFAULT_LOG_PATTERN = "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n";
+    private static final String DEFAULT_LOG_PATTERN = "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n";
 
     /**
      * File task builder.

--- a/nexus-logging-extras/src/main/resources/META-INF/log/logback.properties
+++ b/nexus-logging-extras/src/main/resources/META-INF/log/logback.properties
@@ -12,5 +12,5 @@
 #
 
 root.level=INFO
-appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] %X{userId} %c - %m%n
+appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] %X{userId} %c - %m%n
 appender.file=${nexus.log-config-dir}/../logs/nexus.log

--- a/nexus-logging-extras/src/main/resources/META-INF/log/logback.properties
+++ b/nexus-logging-extras/src/main/resources/META-INF/log/logback.properties
@@ -12,5 +12,5 @@
 #
 
 root.level=INFO
-appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] %X{userId} %c - %m%n
+appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] %X{userId} %c - %m%n
 appender.file=${nexus.log-config-dir}/../logs/nexus.log

--- a/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
+++ b/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
@@ -17,7 +17,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n</pattern>
     </encoder>
   </appender>
 

--- a/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
+++ b/nexus-oss-webapp/src/main/resources/content/conf/logback.xml
@@ -17,7 +17,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
     </encoder>
   </appender>
 

--- a/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
+++ b/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
@@ -20,7 +20,7 @@
     <File>${project.build.directory}/logs/${test-id}/nexus.log</File>
     <Append>true</Append>
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
       <maxIndex>12</maxIndex>
@@ -34,7 +34,7 @@
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.out</target>
     <encoder>
-      <pattern>NEXUS: %date{HH:mm:ss.SSS} %level [%thread%X{DC}] %logger - %msg%n</pattern>
+      <pattern>NEXUS: %date{HH:mm:ss.SSS} %level [  %thread%X{DC}] %logger - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
+++ b/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
@@ -20,7 +20,7 @@
     <File>${project.build.directory}/logs/${test-id}/nexus.log</File>
     <Append>true</Append>
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
       <maxIndex>12</maxIndex>

--- a/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
+++ b/nexus-test/nexus-test-environment-maven-plugin/src/main/resources/default-config/logback-nexus.xml
@@ -34,7 +34,7 @@
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.out</target>
     <encoder>
-      <pattern>NEXUS: %date{HH:mm:ss.SSS} %level [  %thread%X{DC}] %logger - %msg%n</pattern>
+      <pattern>NEXUS: %date{HH:mm:ss.SSS} %level [%thread%X{DC}] %logger - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/nexus-test/nexus-test-harness-its/resources/nexus1375/test-config/logback.properties
+++ b/nexus-test/nexus-test-harness-its/resources/nexus1375/test-config/logback.properties
@@ -1,3 +1,3 @@
 root.level=DEBUG
-appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n
+appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n
 appender.file=${plexus.nexus-work}/logs/nexus.log

--- a/nexus-test/nexus-test-harness-its/resources/nexus1375/test-config/logback.properties
+++ b/nexus-test/nexus-test-harness-its/resources/nexus1375/test-config/logback.properties
@@ -1,3 +1,3 @@
 root.level=DEBUG
-appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n
+appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n
 appender.file=${plexus.nexus-work}/logs/nexus.log

--- a/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1375/Nexus1375LogConfigIT.java
+++ b/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1375/Nexus1375LogConfigIT.java
@@ -52,7 +52,7 @@ public class Nexus1375LogConfigIT
 
         Assert.assertEquals( "DEBUG", resource.getRootLoggerLevel() );
 
-        Assert.assertEquals( "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n", resource.getFileAppenderPattern() );
+        Assert.assertEquals( "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n", resource.getFileAppenderPattern() );
 
         // exposing actual OS file location over REST is very bad idea...
         // File actualLoggerLocation = new File( resource.getFileAppenderLocation() ).getCanonicalFile();

--- a/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1375/Nexus1375LogConfigIT.java
+++ b/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus1375/Nexus1375LogConfigIT.java
@@ -52,7 +52,7 @@ public class Nexus1375LogConfigIT
 
         Assert.assertEquals( "DEBUG", resource.getRootLoggerLevel() );
 
-        Assert.assertEquals( "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n", resource.getFileAppenderPattern() );
+        Assert.assertEquals( "%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n", resource.getFileAppenderPattern() );
 
         // exposing actual OS file location over REST is very bad idea...
         // File actualLoggerLocation = new File( resource.getFileAppenderLocation() ).getCanonicalFile();

--- a/nexus-webapp/src/main/resources/logback.xml
+++ b/nexus-webapp/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n</pattern>
     </encoder>
   </appender>
   <root level="${nexus.log.level:-INFO}">

--- a/nexus-webapp/src/main/resources/logback.xml
+++ b/nexus-webapp/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
     </encoder>
   </appender>
   <root level="${nexus.log.level:-INFO}">

--- a/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/logback.xml
+++ b/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
     </encoder>
   </appender>
   <root level="${test.log.level:-INFO}">

--- a/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/logback.xml
+++ b/plugins/ldap/nexus-ldap-realm-plugin/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%-15.-15t] - %c - %m%n</pattern>
+      <pattern>%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] - %c - %m%n</pattern>
     </encoder>
   </appender>
   <root level="${test.log.level:-INFO}">


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-5712
 change logging pattern layout to include first 15 characters of thread name instead of last 15
