### PR TITLE
[REVIEW] NXCM-5067 jsw quote fix

### DIFF
--- a/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -28,12 +28,12 @@ wrapper.java.library.path.1=bin/jsw/lib
 # Additional JVM parameters (tune if needed, but match the sequence of numbers!)
 wrapper.java.additional.1=-Djava.net.preferIPv4Stack=true
 wrapper.java.additional.2=-Dcom.sun.jndi.ldap.connect.pool.protocol="plain ssl"
-wrapper.java.additional.3.stripquotes=TRUE
-#wrapper.java.additional.4=-Xdebug
-#wrapper.java.additional.5=-Xnoagent
-#wrapper.java.additional.6=-Djava.compiler=NONE
-#wrapper.java.additional.7=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#wrapper.java.additional.8=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.2.stripquotes=TRUE
+#wrapper.java.additional.3=-Xdebug
+#wrapper.java.additional.4=-Xnoagent
+#wrapper.java.additional.5=-Djava.compiler=NONE
+#wrapper.java.additional.6=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#wrapper.java.additional.7=-XX:+HeapDumpOnOutOfMemoryError
 
 wrapper.app.parameter.1=./conf/jetty.xml
 

--- a/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
+++ b/nexus-oss-webapp/src/main/resources/content/bin/jsw/conf/wrapper.conf
@@ -28,11 +28,12 @@ wrapper.java.library.path.1=bin/jsw/lib
 # Additional JVM parameters (tune if needed, but match the sequence of numbers!)
 wrapper.java.additional.1=-Djava.net.preferIPv4Stack=true
 wrapper.java.additional.2=-Dcom.sun.jndi.ldap.connect.pool.protocol="plain ssl"
-#wrapper.java.additional.3=-Xdebug
-#wrapper.java.additional.4=-Xnoagent
-#wrapper.java.additional.5=-Djava.compiler=NONE
-#wrapper.java.additional.6=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#wrapper.java.additional.7=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.3.stripquotes=TRUE
+#wrapper.java.additional.4=-Xdebug
+#wrapper.java.additional.5=-Xnoagent
+#wrapper.java.additional.6=-Djava.compiler=NONE
+#wrapper.java.additional.7=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#wrapper.java.additional.8=-XX:+HeapDumpOnOutOfMemoryError
 
 wrapper.app.parameter.1=./conf/jetty.xml
 


### PR DESCRIPTION
Add a directive to the Java Service Wrapper to strip quotes for a JVM property on *nix.

https://issues.sonatype.org/browse/NXCM-5067
