### PR TITLE
[2.6] NEXUS-5711: Auto routing periodic update is chatty about unsupported repositories

### DIFF
--- a/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/ManagerImpl.java
+++ b/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/ManagerImpl.java
@@ -293,34 +293,37 @@ public class ManagerImpl
         getLogger().trace( "mayUpdateAllProxyPrefixFiles started" );
         for ( MavenRepository mavenRepository : repositoryRegistry.getRepositoriesWithFacet( MavenRepository.class ) )
         {
-            try
+            if ( isMavenRepositorySupported( mavenRepository ) )
             {
-                final FilePrefixSource prefixSource = getPrefixSourceFor( mavenRepository );
-                if ( !prefixSource.exists() )
+                try
                 {
-                    // automatic routing has not been initialized for this repository yet, for initialization.
-                    doUpdatePrefixFileAsync( true, mavenRepository );
-                }
-                else
-                {
-                    MavenProxyRepository mavenProxyRepository =
-                        mavenRepository.adaptToFacet( MavenProxyRepository.class );
-                    if ( mavenProxyRepository != null )
+                    final FilePrefixSource prefixSource = getPrefixSourceFor( mavenRepository );
+                    if ( !prefixSource.exists() )
                     {
-                        mayUpdateProxyPrefixFile( mavenProxyRepository );
+                        // automatic routing has not been initialized for this repository yet, for initialization.
+                        doUpdatePrefixFileAsync( true, mavenRepository );
+                    }
+                    else
+                    {
+                        MavenProxyRepository mavenProxyRepository =
+                            mavenRepository.adaptToFacet( MavenProxyRepository.class );
+                        if ( mavenProxyRepository != null )
+                        {
+                            mayUpdateProxyPrefixFile( mavenProxyRepository );
+                        }
                     }
                 }
-            }
-            catch ( IllegalStateException e )
-            {
-                // just neglect it and continue, this one might be auto blocked if proxy or put out of service
-                getLogger().trace( "Repository {} is not in state to be updated", mavenRepository );
-            }
-            catch ( Exception e )
-            {
-                // just neglect it and continue, but do log it
-                getLogger().warn( "Problem during prefix file update of repository {}",
-                                  RepositoryStringUtils.getHumanizedNameString( mavenRepository ), e );
+                catch ( IllegalStateException e )
+                {
+                    // just neglect it and continue, this one might be auto blocked if proxy or put out of service
+                    getLogger().trace( "Repository {} is not in state to be updated", mavenRepository );
+                }
+                catch ( Exception e )
+                {
+                    // just neglect it and continue, but do log it
+                    getLogger().warn( "Problem during prefix file update of repository {}",
+                        RepositoryStringUtils.getHumanizedNameString( mavenRepository ), e );
+                }
             }
         }
     }


### PR DESCRIPTION
A trivial change, surrounding the meat of for cycle into an IF condition.

Reason was that periodic updater (running every hour currently)
did not filter the involved "maven repositories" as it got them
from registry. The result contained shadows too, that are NOT
supported by automatic routing, and auto routing was logging that 
fact, spamming the log at hourly rate.

Fixes
https://issues.sonatype.org/browse/NEXUS-5711
