### PR TITLE
[2.6] NEXUS-5704: 500 Internal Server Error when "If-None-Match" in header

### DIFF
--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/ResourceStoreContentPlexusResourceTest.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/ResourceStoreContentPlexusResourceTest.java
@@ -12,24 +12,35 @@
  */
 package org.sonatype.nexus.rest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
 import com.noelios.restlet.http.HttpResponse;
 import com.noelios.restlet.http.HttpServerCall;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.restlet.Context;
+import org.restlet.data.ClientInfo;
 import org.restlet.data.Conditions;
 import org.restlet.data.Form;
 import org.restlet.data.Reference;
 import org.restlet.data.Request;
+import org.restlet.data.Status;
+import org.restlet.data.Tag;
 import org.restlet.resource.ResourceException;
 import org.restlet.resource.Variant;
 import org.restlet.util.Series;
@@ -42,6 +53,7 @@ import org.sonatype.nexus.proxy.ItemNotFoundException;
 import org.sonatype.nexus.proxy.NoSuchResourceStoreException;
 import org.sonatype.nexus.proxy.RequestContext;
 import org.sonatype.nexus.proxy.ResourceStore;
+import org.sonatype.nexus.proxy.ResourceStoreRequest;
 import org.sonatype.nexus.proxy.attributes.Attributes;
 import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageCollectionItem;
@@ -146,6 +158,19 @@ public class ResourceStoreContentPlexusResourceTest
             }
 
             @Override
+            protected String getValidRemoteIPAddress( Request request )
+            {
+                // for test simplicity, to not have to mock layers of HTTPCall/Request
+                return "127.0.0.1";
+            }
+
+            protected Reference getContextRoot( Request request )
+            {
+                // unimportant, as we don't go anywhere else than resource itself
+                return reference;
+            }
+
+            @Override
             protected Nexus getNexus()
             {
                 return nexus;
@@ -165,7 +190,7 @@ public class ResourceStoreContentPlexusResourceTest
 
         when( collectionItem.getRepositoryItemUid() ).thenReturn( itemUid );
         when( fileItem.getRepositoryItemUid() ).thenReturn( itemUid );
-
+        when( fileItem.getResourceStoreRequest() ).thenReturn( new ResourceStoreRequest( "/some/path" ) );
         when( fileItem.getRepositoryItemAttributes() ).thenReturn( attributes );
         when( fileItem.getItemContext() ).thenReturn( new RequestContext() );
 
@@ -212,6 +237,113 @@ public class ResourceStoreContentPlexusResourceTest
         underTest.renderStorageLinkItem( context, request, response, variant, resourceStore, linkItem );
 
         verifyZeroInteractions( headers );
+    }
+
+    /**
+     * This test simulates the Request call in a way Restlet does when no if-modified-since condition is present. So we
+     * verify that created ResourceStoreRequest does not have condition set.
+     */
+    @Test
+    public void testNexus5704IfNoneMatchNoNPEWithNoETag()
+    {
+        final Conditions conditions = new Conditions();
+        when( request.getConditions() ).thenReturn( conditions );
+
+        // we need more mock responses as getResourceStoreRequest tries to gather
+        // as much info as it can (from client, reference, baseUrl etc
+        when( request.getClientInfo() ).thenReturn( new ClientInfo() );
+        when( request.getOriginalRef() ).thenReturn( reference );
+        final ResourceStoreRequest rsr = underTest.getResourceStoreRequest( request, "/some/path" );
+
+        assertThat( rsr.getIfNoneMatch(), nullValue() );
+    }
+
+    /**
+     * This test simulates the Request call in a way Restlet would do when ETag is badly formatted (is not quoted):
+     * parsing of HTTP request with ETag without quotes will detect the presence of condition (Conditions
+     * if-modified-since will be non empty list), but the only one member of the list is actually {@code null} (as saw
+     * when debugged NEXUS-5704). So we verify that created ResourceStoreRequest does not have condition set AND we
+     * don't have NPE either.
+     */
+    @Test
+    public void testNexus5704IfNoneMatchNoNPEWithBadlyParsedETag()
+    {
+        final Conditions conditions = new Conditions();
+        // ETag will be list with one element: null when ETag field is badly formatted
+        // (as seen from DEBUG)
+        conditions.setNoneMatch( Collections.singletonList( (Tag) null ) );
+        when( request.getConditions() ).thenReturn( conditions );
+
+        // we need more mock responses as getResourceStoreRequest tries to gather
+        // as much info as it can (from client, reference, baseUrl etc
+        when( request.getClientInfo() ).thenReturn( new ClientInfo() );
+        when( request.getOriginalRef() ).thenReturn( reference );
+        final ResourceStoreRequest rsr = underTest.getResourceStoreRequest( request, "/some/path" );
+
+        assertThat( rsr.getIfNoneMatch(), nullValue() );
+    }
+
+    /**
+     * This test simulates the Request in a way Restlet does: parsing of HTTP request with ETag with quotes will be OK.
+     * So we verify is it detected and added to created ResourceStoreRequest.
+     */
+    @Test
+    public void testNexus5704IfNoneMatchNoNPEWithParsedETag()
+    {
+        final Conditions conditions = new Conditions();
+        conditions.setNoneMatch( Collections.singletonList( new Tag( "{SHA1{fake-sha1-string}}", false ) ) );
+        when( request.getConditions() ).thenReturn( conditions );
+
+        // we need more mock responses as getResourceStoreRequest tries to gather
+        // as much info as it can (from client, reference, baseUrl etc
+        when( request.getClientInfo() ).thenReturn( new ClientInfo() );
+        when( request.getOriginalRef() ).thenReturn( reference );
+        final ResourceStoreRequest rsr = underTest.getResourceStoreRequest( request, "/some/path" );
+
+        assertThat( rsr.getIfNoneMatch(), equalTo( "{SHA1{fake-sha1-string}}" ) );
+    }
+
+    /**
+     * With matching condition (client known ETag and Nexus ETag matches) should result in {@link ResourceException}
+     * carrying status 304 Not Modified.
+     */
+    @Test
+    public void testNexus5704renderStorageFileItemWithMatchingCondition()
+        throws Exception
+    {
+        try
+        {
+            final ResourceStoreRequest rsr = fileItem.getResourceStoreRequest();
+            rsr.setIfNoneMatch( "{SHA1{1234567890}}" );
+            when( attributes.containsKey( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( true );
+            when( attributes.get( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( "1234567890" );
+
+            underTest.renderStorageFileItem( request, fileItem );
+            assertThat( "ResourceException was expected to be thrown", false );
+        }
+        catch ( ResourceException e )
+        {
+            assertThat( e.getStatus(), equalTo( Status.REDIRECTION_NOT_MODIFIED ) );
+        }
+    }
+
+    /**
+     * With non matching condition (client known ETag and Nexus ETag differs), the {@link StorageFileItemRepresentation}
+     * should be returned that wraps the passed in {@link StorageFileItem} instance.
+     */
+    @Test
+    public void testNexus5704renderStorageFileItemWithNonMatchingCondition()
+        throws Exception
+    {
+        final ResourceStoreRequest rsr = fileItem.getResourceStoreRequest();
+        rsr.setIfNoneMatch( "{SHA1{1234567890}}" ); // client "knows" hash 1234567890
+        when( attributes.containsKey( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( true );
+        when( attributes.get( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( "0987654321" ); // item hash is "0987654321"
+
+        final StorageFileItemRepresentation representation =
+            (StorageFileItemRepresentation) underTest.renderStorageFileItem( request, fileItem );
+
+        assertThat( representation.getStorageItem(), sameInstance( fileItem ) );
     }
 
 }

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/ResourceStoreContentPlexusResourceTest.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/test/java/org/sonatype/nexus/rest/ResourceStoreContentPlexusResourceTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -24,12 +25,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import com.google.common.collect.Maps;
-import com.noelios.restlet.http.HttpResponse;
-import com.noelios.restlet.http.HttpServerCall;
-
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -63,6 +58,10 @@ import org.sonatype.nexus.proxy.item.uid.IsRemotelyAccessibleAttribute;
 import org.sonatype.plexus.rest.resource.PathProtectionDescriptor;
 import org.sonatype.security.SecuritySystem;
 import org.sonatype.sisu.litmus.testsupport.TestSupport;
+
+import com.google.common.collect.Maps;
+import com.noelios.restlet.http.HttpResponse;
+import com.noelios.restlet.http.HttpServerCall;
 
 /**
  * Tests for {@link AbstractResourceStoreContentPlexusResource}
@@ -319,7 +318,7 @@ public class ResourceStoreContentPlexusResourceTest
             when( attributes.get( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( "1234567890" );
 
             underTest.renderStorageFileItem( request, fileItem );
-            assertThat( "ResourceException was expected to be thrown", false );
+            fail( "ResourceException is expected to be thrown" );
         }
         catch ( ResourceException e )
         {
@@ -338,7 +337,8 @@ public class ResourceStoreContentPlexusResourceTest
         final ResourceStoreRequest rsr = fileItem.getResourceStoreRequest();
         rsr.setIfNoneMatch( "{SHA1{1234567890}}" ); // client "knows" hash 1234567890
         when( attributes.containsKey( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( true );
-        when( attributes.get( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( "0987654321" ); // item hash is "0987654321"
+        when( attributes.get( StorageFileItem.DIGEST_SHA1_KEY ) ).thenReturn( "0987654321" ); // item hash is
+                                                                                              // "0987654321"
 
         final StorageFileItemRepresentation representation =
             (StorageFileItemRepresentation) underTest.renderStorageFileItem( request, fileItem );


### PR DESCRIPTION
Restlet 1.1 is very picky (and have a bug) how it handles ETags: it requires "by the book" how HTTP request formats ETags, they must be quoted. In other case, the header presence is detected (condition list is non-empty), but unexpected `null` value is returned for tag value (the condition list will have one element, which is `null`). This causes NPE in Nexus code.

"Vanilla" Nexus (even without this change) _works properly_ for HTTP conditional GETs using `if-modified-since` headers, as shown in the linked issue. Still, with unquoted ETag NPE does happens in Nexus codebase, and this pull fixes it.

This pull merely fixes that single point of NPE by adding nullcheck, and also simplifies the `renderStorageFileItem()` method, but DOES NOT fix the Restlet library in this manner. Nexus will still NPE if HTTP request carries badly formatted ETag. After this change, badly formatted ETags will continue to cause 500 Internal Server Error responses, but this time deeply in Restlet code (where also Tag inspection is tried, without nullchecks around it).

Relates to issue
https://issues.sonatype.org/browse/NEXUS-5704
