### PR TITLE
NXCM-4928: Bump to JUnit 4.11

### DIFF
--- a/nexus-test/nexus-testsuite-support/src/test/java/org/sonatype/nexus/testsuite/support/hamcrest/NexusMatcherTest.java
+++ b/nexus-test/nexus-testsuite-support/src/test/java/org/sonatype/nexus/testsuite/support/hamcrest/NexusMatcherTest.java
@@ -15,7 +15,6 @@ package org.sonatype.nexus.testsuite.support.hamcrest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
 
 import java.io.File;
 
@@ -52,6 +51,7 @@ public class NexusMatcherTest
             containsString( "java.io.FileNotFoundException" ),
             containsString( "nexus.log" )
         ) );
+        thrown.handleAssertionErrors();
         assertThat(
             new File( "nexus.log" ),
             NexusMatchers.doesNotHaveCommonExceptions()
@@ -81,6 +81,7 @@ public class NexusMatcherTest
             containsString( "Log file does not contain any of the common unwanted exceptions" ),
             endsWith( "contained on line <1>: \"java.lang.ClassNotFoundException: some.package.Foo\"" )
         ) );
+        thrown.handleAssertionErrors();
         assertThat(
             resolveLogFile(),
             NexusMatchers.doesNotHaveCommonExceptions()

--- a/pom.xml
+++ b/pom.xml
@@ -1374,16 +1374,15 @@
                   <excludes>
                     <exclude>junit:junit:(,4.10]</exclude>
                   </excludes>
-                  <message>junit:junit includes old versions of hamcrest; use junit:junit-dep instead</message>
+                  <message>junit:junit before 4.11 includes old versions of hamcrest; use junit:junit 4.11+ instead</message>
                 </bannedDependencies>
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
                   <excludes>
                     <exclude>junit:junit-dep:(,4.10]</exclude>
                   </excludes>
-                  <message>junit:junit-dep 4.9 wrongly includes hamcrest api in jar, 4.10 or greater required due to TestRule changes over earlier
-                    versions
-                  </message>
+                  <message>junit:junit-dep ceased to exists since junit:junit:4.11; use junit:junit 4.11+ instead</message>
+                </message>
                 </bannedDependencies>
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>

--- a/pom.xml
+++ b/pom.xml
@@ -771,13 +771,13 @@
       <dependency>
         <groupId>org.sonatype.http-testing-harness</groupId>
         <artifactId>server-provider</artifactId>
-        <version>0.7</version>
+        <version>0.8-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.sonatype.http-testing-harness</groupId>
         <artifactId>junit-runner</artifactId>
-        <version>0.7</version>
+        <version>0.8-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -789,7 +789,7 @@
       <dependency>
         <groupId>org.sonatype.sisu.litmus</groupId>
         <artifactId>litmus-testsupport</artifactId>
-        <version>1.6</version>
+        <version>1.6.1-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -1372,14 +1372,14 @@
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
                   <excludes>
-                    <exclude>junit:junit</exclude>
+                    <exclude>junit:junit:(,4.10]</exclude>
                   </excludes>
                   <message>junit:junit includes old versions of hamcrest; use junit:junit-dep instead</message>
                 </bannedDependencies>
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
                   <excludes>
-                    <exclude>junit:junit-dep:(,4.9]</exclude>
+                    <exclude>junit:junit-dep:(,4.10]</exclude>
                   </excludes>
                   <message>junit:junit-dep 4.9 wrongly includes hamcrest api in jar, 4.10 or greater required due to TestRule changes over earlier
                     versions


### PR DESCRIPTION
Depends on following pulls:
https://github.com/sonatype/sisu-litmus/pull/16
https://github.com/sonatype/http-testing-harness/pull/2

Mostly:
- POM changes regarding litmus and HTH versions
- POM changes regarding enforcer rules banning junit:junit and junit:junit-dep
- slight (needed) changes in one UT class (new in JUnit 4.11: ExceptionRule does not handle AssertionError anymore unless explicitly told to do so)

CI:
until those pulls above are not merged and built by CI, this branch will not build properly.

Related issue:
https://issues.sonatype.org/browse/NXCM-4928
