### PR TITLE
[2.6] NEXUS-5714: Status resource without perms

### DIFF
--- a/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3936/Nexus3936DisableSecurityStatusIT.java
+++ b/nexus-test/nexus-test-harness-its/src/test/java/org/sonatype/nexus/integrationtests/nexus3936/Nexus3936DisableSecurityStatusIT.java
@@ -35,7 +35,7 @@ public class Nexus3936DisableSecurityStatusIT
     {
 
         NexusStatusUtil statusUtil = getNexusStatusUtil();
-        StatusResource statusResource = statusUtil.getNexusStatus().getData();
+        StatusResource statusResource = statusUtil.getNexusStatus( true ).getData();
 
         List<ClientPermission> permisisons = statusResource.getClientPermissions().getPermissions();
 

--- a/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/NexusStatusUtil.java
+++ b/nexus-test/nexus-test-harness-launcher/src/main/java/org/sonatype/nexus/test/utils/NexusStatusUtil.java
@@ -108,17 +108,40 @@ public class NexusStatusUtil
     }
 
     /**
-     * Get Nexus Status, failing if the request response is not successfully returned.
-     *
+     * Get Nexus Status, failing if the request response is not successfully returned. Delegates call to
+     * {@link #getNexusStatus(boolean)} with {@code false} parameter.
+     * 
      * @return the status resource
      * @throws NexusIllegalStateException
      */
     public StatusResourceResponse getNexusStatus()
         throws NexusIllegalStateException
     {
+        return getNexusStatus( false );
+    }
+
+    /**
+     * Get Nexus Status, failing if the request response is not successfully returned.
+     * 
+     * @param withPermissions if {@code true}, it will ask for permissions too, as returned before Nexus 2.6
+     * @return the status resource
+     * @throws NexusIllegalStateException
+     * @since 2.6
+     */
+    public StatusResourceResponse getNexusStatus( final boolean withPermissions )
+        throws NexusIllegalStateException
+    {
         try
         {
-            String entityText = RequestFacade.doGetForText( "service/local/status" );
+            final String entityText;
+            if ( withPermissions )
+            {
+                entityText = RequestFacade.doGetForText( "service/local/status?perms=1" );
+            }
+            else
+            {
+                entityText = RequestFacade.doGetForText( "service/local/status" );
+            }
             StatusResourceResponse status =
                 (StatusResourceResponse) XStreamFactory.getXmlXStream().fromXML( entityText );
             return status;

--- a/plugins/nexus-ui-extjs3-plugin/src/main/resources/static/js/Nexus/config.js
+++ b/plugins/nexus-ui-extjs3-plugin/src/main/resources/static/js/Nexus/config.js
@@ -90,7 +90,7 @@ define('Nexus/config',['extjs', 'Nexus/messagebox', 'Sonatype/init', 'Nexus/conf
           configCurrent : servicePath + '/configs/current',
           logs : servicePath + '/logs',
           logConfig : servicePath + '/log/config',
-          status : servicePath + '/status',
+          status : servicePath + '/status?perms=1',
           schedules : servicePath + '/schedules',
           scheduleRun : servicePath + '/schedule_run',
           scheduleTypes : servicePath + '/schedule_types',


### PR DESCRIPTION
Introduced "perms" query parameter on status resource, that is
checked for presence only (hence, without, or with any value
works). If "perms" query parameter is present, the status
resource will emit permission related info, as it behaved
before this change.

Without this query parameter, status resource emits only what
it's original intent was.

Measured (before vs after) response time differences is 300ms vs 150 ms,
payload size differences is 7009 byte vs 1152 byte

Note: tested with OSS. The numbers would just grow with Pro, as
delivered permissions are extended by Pro plugins like staging and
others. In short: the more plugins that introduce new UI perms the
payload would get bigger (and since permission count would grow,
more CPU to "unravel" them from current user).

CI:
https://bamboo.zion.sonatype.com/browse/NXO-OSSF0-1

Related issue:
https://issues.sonatype.org/browse/NEXUS-5714
